### PR TITLE
Google Docs first-class + layout decision tracked as owner-action blocker

### DIFF
--- a/docs/research/vscode-1.110-integrated-browser.md
+++ b/docs/research/vscode-1.110-integrated-browser.md
@@ -1,0 +1,133 @@
+# Research — VS Code 1.110 Integrated Browser
+
+> **Source:** External research report delivered 2026-04-22, reviewed in the `claude/browser-document-editing-OdneV` branch.
+> **Why it's here:** Duo's architecture is a direct response to the walls this report documents. VS Code 1.110 ships a capable agent-driven browser but locks Claude Code out; Duo is being designed so Claude Code is the first-class client of the browser. Preserving the report helps future Claude instances understand which patterns we are borrowing, which we are improving on, and why.
+> **Companion doc:** See `../../duo-brief.md` §17 ("Google Docs First-Class Support") for the implications mapped onto our roadmap.
+
+-----
+
+# VSCode 1.110's integrated browser: powerful for Copilot, walled off from Claude Code
+
+**The VSCode 1.110 integrated browser is a genuinely capable agent-driven browser — but Claude Code cannot use it.** The browser tools are hardwired into VS Code's internal chat/agent system with no exposed CDP port, no MCP wrapper, no extension API, and no CLI access. They are built-in workbench primitives, not extension-contributed tools, which means they exist below the extensibility layer where third-party agents operate. Claude Code users who need browser automation should use the Playwright MCP server or Claude Code's own Chrome integration instead.
+
+The integrated browser itself — introduced in VS Code 1.109 (January 2026) with agent tools added in 1.110 (stable March 4, 2026) — is a real Chromium browser running inside Electron, capable of loading any URL including Google Docs with full authentication. The agent tooling on top of it is genuinely impressive: screenshot capture, DOM reading via accessibility tree, console log monitoring, click/type/hover simulation, and arbitrary Playwright code execution. The gap is purely one of access control architecture.
+
+-----
+
+## The browser is real Chromium with full web capabilities
+
+The integrated browser is **not** an iframe or webview hack. It runs in Electron's embedded Chromium engine (Chromium 142.x as of 1.110) as a separate process with full isolation from VS Code's main process. Source code lives in `src/vs/workbench/contrib/chat/electron-browser/tools/` — the `electron-browser` layer of the workbench, meaning it's a core platform feature, not a bundled extension.
+
+This architecture means the browser can do everything a real browser does: load `http://`, `https://`, and `file://` URLs; handle JavaScript-heavy SPAs; run authentication flows for Google, GitHub, and other OAuth providers; maintain cookies and localStorage across sessions. The old Simple Browser (an iframe-in-a-webview) couldn't authenticate to Google or load sites with `X-Frame-Options` restrictions. The integrated browser overcomes all of these limitations.
+
+Session storage is controlled by `workbench.browser.dataStorage` with three modes: **`global`** (persists across workspaces), **`workspace`** (isolated per workspace), and **`ephemeral`** (incognito-like, no persistence). In untrusted workspaces, ephemeral mode is forced regardless of the setting. Multiple browser instances can run simultaneously in separate editor tabs.
+
+-----
+
+## Ten agent tools — and what each actually does
+
+When `workbench.browser.enableChatTools` is set to `true`, agents gain access to **10 built-in tools** grouped under "Built-in > Browser" in the chat tools picker:
+
+| Category          | Tools                                                                       | What they do                                                                        |
+|-------------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| Page navigation   | `openBrowserPage`, `navigatePage`                                           | Open URLs and navigate within pages                                                 |
+| Content reading   | `readPage`, `screenshotPage`                                                | Extract page content (accessibility tree → Markdown) and capture visual screenshots |
+| User interaction  | `clickElement`, `hoverElement`, `dragElement`, `typeInPage`, `handleDialog` | Simulate clicks, hovers, drag operations, keyboard input, and dialog responses      |
+| Custom automation | `runPlaywrightCode`                                                         | Execute arbitrary Playwright scripts in the browser context                         |
+
+The `readPage` tool almost certainly returns the page's **accessibility tree converted to Markdown**, based on PR #245571 ("Convert Accessibility Tree to Markdown") found in VS Code's commit history. This approach mirrors the Playwright MCP server's strategy of using structured accessibility snapshots rather than raw HTML, making output LLM-friendly without requiring vision models.
+
+The `runPlaywrightCode` tool is the most powerful entry point. It accepts arbitrary Playwright automation code, meaning agents can call `page.evaluate()` for JavaScript execution, `page.accessibility.snapshot()` for raw accessibility tree data, and any other Playwright API. Console errors and warnings are **automatically streamed** to the agent during all interactions — this isn't a poll-based system but a real-time feed.
+
+-----
+
+## Shared pages vs. agent-opened pages: the authentication model
+
+The browser tools implement a **dual-session architecture** that is central to understanding what agents can and cannot access:
+
+**Agent-opened pages** (via `openBrowserPage`) run in **private, in-memory sessions** with no shared cookies or storage. The agent gets a clean, isolated browser context. This means an agent cannot access your authenticated Google Docs session unless you explicitly grant it.
+
+**Shared pages** use a fundamentally different model. When you manually open a page in the integrated browser, log into Google, and then click the **"Share with Agent"** button in the browser toolbar, a confirmation dialog appears. Upon approval, a visual indicator marks the tab as shared, and the agent gains temporary access to that page **including your full session state** — cookies, localStorage, and login credentials. Clicking "Share with Agent" again immediately revokes access.
+
+This is a thoughtful security design: **the agent never inherits your authenticated sessions by default**. Google Docs access requires explicit, revocable, per-page user consent. Agents that need to test authentication flows against their own apps use the ephemeral agent-opened pages instead.
+
+-----
+
+## Evaluation against the ten criteria
+
+Here is a direct assessment of each capability the user asked about:
+
+**1. Embedding a real browser that loads arbitrary URLs including authenticated Google Docs:** Yes. Full Chromium browser, loads any URL. Google authentication works. Shared pages preserve login state.
+
+**2. CLI-based access from the VSCode terminal (e.g., Claude Code programmatically inspecting DOM, evaluating JS, taking screenshots):** No. The tools are internal workbench primitives with no CLI interface, no command-line API, and no way for a terminal process to invoke them. There is no `vscode` CLI flag, no Unix socket, no REST endpoint, and no IPC mechanism exposed to terminal processes.
+
+**3. Chrome DevTools Protocol (CDP) access:** No externally accessible CDP. The integrated browser uses CDP internally through Electron's `webContents.debugger` APIs, and VS Code maintains the `@vscode/cdp` library (now archived, likely absorbed into core). But **no CDP port or WebSocket endpoint is exposed** for external tools to connect to. The protocol layer is fully encapsulated.
+
+**4. Google authentication with persistent sessions:** Yes. Users can log into Google and maintain sessions. The `global` storage mode persists cookies across workspaces. Shared pages give agents access to these authenticated sessions.
+
+**5. Accessibility tree access:** Yes, through two paths. `readPage` returns the accessibility tree converted to Markdown format. For raw accessibility tree data, `runPlaywrightCode` provides access to Playwright's `page.accessibility.snapshot()` API.
+
+**6. Screenshot capture:** Yes. The `screenshotPage` tool captures page screenshots, likely using Electron's `webContents.capturePage()` or CDP's `Page.captureScreenshot`. The browser testing guide specifically describes capturing screenshots at different viewport sizes for responsive testing.
+
+**7. Console log reading:** Yes. Console errors and warnings are automatically streamed to the agent in real time as it interacts with pages. This uses CDP's `Runtime.consoleAPICalled` event or Electron's console event handlers internally.
+
+**8. JavaScript evaluation:** Yes, via `runPlaywrightCode`. Agents can call `page.evaluate()` to run arbitrary JavaScript in the page context. The simpler tools (`clickElement`, `typeInPage`) handle common interactions without requiring custom JS.
+
+**9. "Share with Agent" feature:** This is a manual, user-initiated sharing mechanism. Click the toolbar button → confirm in dialog → visual indicator appears on tab → agent gets temporary access including your session → click again to revoke. It is part of VS Code's built-in chat system and **not extensible** to agents outside that system.
+
+**10. Does it work with Claude Code specifically?** **No.** This is the critical finding, detailed in the next section.
+
+-----
+
+## Why Claude Code is locked out — and the three walls blocking it
+
+There are three distinct architectural barriers preventing Claude Code from accessing the integrated browser tools:
+
+**Wall 1: The tools are not exposed through any extension API.** The browser tools are registered as internal workbench contributions, not through the Language Model Tools API (`vscode.lm.registerTool` / `vscode.lm.tools`). Third-party extensions cannot discover, invoke, or interact with these tools programmatically. There is no `vscode.commands` entry point, no event to subscribe to, and no API surface whatsoever.
+
+**Wall 2: The tools are bound to VS Code's chat/agent system.** They appear exclusively in the chat tools picker under "Built-in > Browser" and are invoked through the agent mode conversation flow. GitHub issue #298949 reveals that `workbench.browser.enableChatTools` is **governed by GitHub Copilot organizational policies** — when a user's org disabled MCP servers in Copilot settings, this setting showed "Managed by organization." The issue was closed as "not planned," confirming the tight coupling to Copilot infrastructure.
+
+**Wall 3: Claude operates with its own tool definitions.** Whether running as the standalone Claude Code extension (Anthropic's VS Code extension with its own UI and terminal) or as a third-party agent within Copilot Chat (via `github.copilot.chat.claudeAgent.enabled`), Claude uses **Anthropic's Claude Agent SDK with its own set of tools and capabilities**. The official docs state this explicitly. Cloud Claude agent sessions "can't directly access VS Code built-in tools." Local Claude agent sessions use the Claude Agent harness rather than the Copilot agent harness. No documentation confirms local Claude sessions can access the built-in browser tools.
+
+-----
+
+## Practical alternatives for Claude Code browser automation
+
+Since the integrated browser tools are inaccessible, Claude Code users have three viable alternatives:
+
+- **Playwright MCP server** (`@microsoft/mcp-server-playwright` or `@playwright/mcp@latest`): The most mature option. Launches a separate Chromium instance, supports CDP endpoint connection to existing browsers, works with any MCP-compatible client including Claude Code. Configured via `.vscode/mcp.json` or Claude Code's MCP settings. Provides accessibility tree snapshots, screenshots, click/type actions, and JavaScript evaluation — functionally similar to the built-in tools but running externally.
+- **Claude Code's native Chrome integration**: Anthropic's own solution, released in 2026. Uses the "Claude in Chrome" browser extension (v1.0.36+) connected via native messaging to Claude Code (v2.0.73+). This is completely independent of VS Code's integrated browser — it controls your actual Chrome or Edge browser. Requires a paid Anthropic plan.
+- **Community extensions**: Projects like "Damocles" (claude-unbound) build their own browser integrations as in-process MCP servers, demonstrating that the community is routing around VS Code's walled garden rather than waiting for official extensibility.
+
+The Playwright MCP server is the closest equivalent to the built-in tools. The key tradeoff: the built-in tools offer tighter integration (real-time console streaming, visual tab indicators, Share with Agent UI) and zero setup, while the Playwright MCP requires configuration but works with any agent.
+
+-----
+
+## Conclusion
+
+VS Code 1.110's integrated browser is architecturally impressive — a real Chromium browser with a thoughtful dual-session security model, ten capable agent tools, and Playwright as an escape hatch for arbitrary automation. The `readPage` accessibility-tree-to-Markdown approach and real-time console streaming represent genuine advances over external browser automation.
+
+But the architecture is a **closed system**. No CDP port, no extension API, no MCP wrapper, no CLI access. The tools exist as internal workbench primitives below the extensibility layer, tightly coupled to Copilot's organizational policy framework. There are no GitHub issues requesting broader access, no documented plans to open the API, and the one related issue (#298949) was closed as "not planned."
+
+For Claude Code users, the practical answer is the **Playwright MCP server** for headless automation or **Claude Code's Chrome integration** for interactive browsing. These provide ~90% of the same capabilities with different tradeoffs. The missing 10% — real-time console streaming, the Share with Agent UX, and zero-config setup — remains a Copilot exclusive for now. Whether Microsoft opens this architecture to third-party agents will likely depend on competitive pressure from Cursor and Windsurf, both of which have shipped their own deep browser integrations.
+
+-----
+
+## Implications for Duo (added during integration)
+
+The architectural walls that block Claude Code from VS Code's browser do **not** exist in Duo, because Duo owns its own Electron main process and exposes CDP to the terminal via a Unix-socket CLI bridge by design. Direct mapping of the ten criteria onto Duo's planned architecture:
+
+| # | Capability                        | In Duo                                                                                 |
+|---|-----------------------------------|----------------------------------------------------------------------------------------|
+| 1 | Real Chromium with authenticated URLs | WebContentsView is real Chromium with persistent session (Stage 2)                 |
+| 2 | CLI access from terminal          | Core design — `orbit <cmd>` over Unix socket (Stage 3)                                 |
+| 3 | CDP access                        | Free via `webContents.debugger.sendCommand(...)` in the main process                   |
+| 4 | Google auth with persistent sessions | Electron `session` + partition persists cookies (Stage 2)                           |
+| 5 | Accessibility tree                | `Accessibility.getFullAXTree` via CDP — the read path for canvas-rendered apps         |
+| 6 | Screenshots                       | `Page.captureScreenshot` (CDP) or `webContents.capturePage()`                          |
+| 7 | Console logs                      | `Runtime.consoleAPICalled` CDP event or `webContents` `console-message`                |
+| 8 | JS evaluation                     | `Runtime.evaluate` / `webContents.executeJavaScript`                                   |
+| 9 | Share-with-agent gating           | Optional — Duo's threat model is single-user-owned; may adopt the UX for clarity       |
+| 10| Works with Claude Code            | Yes by construction                                                                    |
+
+**Key gotcha surfaced by this report for Duo planning:** Google Docs (Kix editor) renders to `<canvas>`, not DOM. Naive `document.querySelector('.kix-appview-canvas')` returns almost no text, so the original skill example in `duo-brief.md` §10 was wrong. The accessibility-tree path described here (what VS Code's `readPage` does) is the correct primitive. See `duo-brief.md` §17 for Duo's adopted strategy.

--- a/docs/ux/layout-options.html
+++ b/docs/ux/layout-options.html
@@ -1,0 +1,743 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Duo — Layout Options</title>
+<style>
+  :root {
+    --bg: #0b0f14;
+    --surface: #11161d;
+    --surface-2: #161c26;
+    --border: #1f2833;
+    --text: #e6edf3;
+    --text-dim: #b8c1cc;
+    --muted: #7d8894;
+    --accent: #6ee7b7;
+
+    /* Wireframe region palette — consistent across all cards */
+    --c-terminal: #1e2a3a;
+    --c-terminal-fg: #9ad5b0;
+    --c-working: #ede6d1;
+    --c-working-fg: #2a2a2a;
+    --c-files: #3e5670;
+    --c-tools: #5b4974;
+    --c-drawer-edge: rgba(255,255,255,0.16);
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    padding: 48px 24px 96px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  header {
+    max-width: 1280px;
+    margin: 0 auto 40px;
+  }
+  h1 {
+    margin: 0 0 10px;
+    font-size: 30px;
+    letter-spacing: -0.02em;
+    font-weight: 600;
+  }
+  .sub {
+    color: var(--text-dim);
+    margin: 0 0 20px;
+    max-width: 820px;
+    font-size: 15px;
+  }
+
+  .legend {
+    display: flex;
+    gap: 22px;
+    flex-wrap: wrap;
+    font-size: 13px;
+    color: var(--text-dim);
+    padding: 14px 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  .legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    display: inline-block;
+    border: 1px solid rgba(255,255,255,0.06);
+  }
+  .swatch.drawer {
+    background: transparent;
+    border: 1px dashed var(--c-drawer-edge);
+  }
+
+  main {
+    max-width: 1400px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(440px, 1fr));
+    gap: 24px;
+  }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+  }
+  .card .header-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 4px;
+  }
+  .card h2 {
+    margin: 0;
+    font-size: 19px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .card h2 .num {
+    color: var(--muted);
+    font-size: 13px;
+    font-weight: 500;
+    margin-right: 8px;
+  }
+  .tag {
+    font-size: 12px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    white-space: nowrap;
+  }
+  .tag.recommend {
+    color: var(--accent);
+  }
+  .desc {
+    color: var(--text-dim);
+    margin: 10px 0 18px;
+    font-size: 14px;
+  }
+
+  /* Wireframe */
+  .wireframe {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: #05080c;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+    display: grid;
+    gap: 2px;
+    padding: 2px;
+    margin-bottom: 18px;
+    position: relative;
+  }
+  .region {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    user-select: none;
+    overflow: hidden;
+  }
+  .region .label-main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    text-align: center;
+    padding: 4px;
+  }
+  .region .sublabel {
+    font-size: 8px;
+    font-weight: 500;
+    opacity: 0.7;
+    letter-spacing: 0.04em;
+    text-transform: none;
+  }
+
+  .r-term { background: var(--c-terminal); color: var(--c-terminal-fg); }
+  .r-work { background: var(--c-working); color: var(--c-working-fg); }
+  .r-files { background: var(--c-files); color: #fff; }
+  .r-tools { background: var(--c-tools); color: #fff; }
+
+  /* Drawer variants — faded + dashed to signal "hidden by default" */
+  .drawer {
+    opacity: 0.55;
+    outline: 1px dashed rgba(255,255,255,0.35);
+    outline-offset: -3px;
+  }
+  .drawer::after {
+    content: "drawer";
+    position: absolute;
+    top: 3px;
+    left: 4px;
+    font-size: 8px;
+    font-weight: 500;
+    letter-spacing: 0.03em;
+    text-transform: none;
+    color: rgba(255,255,255,0.65);
+  }
+
+  /* Tiny tab strip for panes that are tabbed */
+  .tabs {
+    position: absolute;
+    top: 3px;
+    left: 4px;
+    right: 4px;
+    height: 8px;
+    display: flex;
+    gap: 2px;
+    pointer-events: none;
+  }
+  .tabs i {
+    height: 100%;
+    background: rgba(0,0,0,0.25);
+    border-radius: 2px 2px 0 0;
+    flex: 0 0 18%;
+  }
+  .tabs i:first-child {
+    background: rgba(0,0,0,0.5);
+  }
+  .r-work .tabs i { background: rgba(0,0,0,0.18); }
+  .r-work .tabs i:first-child { background: rgba(0,0,0,0.38); }
+
+  /* Individual layout grids */
+  .wf-cockpit   { grid-template-columns: 48px 1fr 1fr 48px; }
+  .wf-classic   { grid-template: "f w t" 2fr
+                                 "f term t" 1fr
+                                 / 56px 1fr 56px; }
+  .wf-classic .gf { grid-area: f; }
+  .wf-classic .gw { grid-area: w; }
+  .wf-classic .gt { grid-area: t; }
+  .wf-classic .gterm { grid-area: term; }
+
+  .wf-mirror    { grid-template-columns: 48px 1.1fr 1fr; }
+  .wf-tri       { grid-template-columns: 1fr 1fr 1fr; }
+  .wf-diptych   { grid-template-columns: 32px 1fr 1fr 32px; }
+
+  .wf-stage     { grid-template-rows: 2fr 1fr; }
+  .wf-shell     { grid-template-rows: 2fr 1fr; } /* terminal on top */
+  .wf-focus     { grid-template-columns: 1fr; }
+  .wf-duplex    { grid-template: "a b" 1fr
+                                 "c d" 1fr
+                                 / 1fr 1fr; }
+  .wf-duplex .ga { grid-area: a; }
+  .wf-duplex .gb { grid-area: b; }
+  .wf-duplex .gc { grid-area: c; }
+  .wf-duplex .gd { grid-area: d; }
+
+  .wf-zen       { grid-template-columns: 1fr 1fr; }
+
+  /* For the Focus layout, we overlay small drawer stubs on edges */
+  .focus-overlays {
+    position: absolute;
+    inset: 2px;
+    pointer-events: none;
+  }
+  .focus-overlays .stub {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.9);
+    background: rgba(0,0,0,0.35);
+    border: 1px dashed rgba(255,255,255,0.45);
+    border-radius: 3px;
+    padding: 2px 6px;
+  }
+  .focus-overlays .stub.l  { top: 8px; bottom: 8px; left: 4px; writing-mode: vertical-rl; }
+  .focus-overlays .stub.r  { top: 8px; bottom: 8px; right: 4px; writing-mode: vertical-rl; }
+  .focus-overlays .stub.b  { left: 8px; right: 8px; bottom: 4px; }
+
+  /* Split columns for pros/cons */
+  .columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px;
+    font-size: 13.5px;
+    margin-top: auto;
+  }
+  .columns h3 {
+    margin: 0 0 8px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .columns ul {
+    margin: 0;
+    padding-left: 18px;
+    color: var(--text);
+  }
+  .columns li { margin-bottom: 5px; color: var(--text-dim); }
+  .columns li::marker { color: var(--muted); }
+
+  .best-for {
+    font-size: 12.5px;
+    color: var(--muted);
+    margin: 0 0 16px;
+    padding: 8px 10px;
+    background: var(--surface-2);
+    border-left: 2px solid var(--border);
+    border-radius: 0 4px 4px 0;
+  }
+  .best-for strong {
+    color: var(--text-dim);
+    font-weight: 600;
+  }
+
+  footer {
+    max-width: 1280px;
+    margin: 56px auto 0;
+    padding-top: 24px;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 13px;
+  }
+  footer p { margin: 0 0 8px; }
+  footer code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    background: var(--surface);
+    padding: 1px 6px;
+    border-radius: 3px;
+    color: var(--text-dim);
+    font-size: 12px;
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Duo — Layout Options</h1>
+  <p class="sub">
+    Ten candidate layouts for the main window. The variables are: where the terminal sits,
+    whether the working pane is tabbed or mode-toggled, and how the two side panels
+    (file browser + agent tools) are exposed. Review side by side, then we update the brief.
+  </p>
+  <div class="legend">
+    <span><i class="swatch" style="background:var(--c-terminal)"></i>Terminal (agent)</span>
+    <span><i class="swatch" style="background:var(--c-working)"></i>Working pane — browser / file viewer / markdown editor</span>
+    <span><i class="swatch" style="background:var(--c-files)"></i>File browser</span>
+    <span><i class="swatch" style="background:var(--c-tools)"></i>Agent tools / skills</span>
+    <span><i class="swatch drawer"></i>Drawer (hidden by default)</span>
+  </div>
+</header>
+
+<main>
+
+  <!-- 01 Cockpit -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">01</span>Cockpit</h2>
+      <span class="tag">Your proposed layout</span>
+    </div>
+    <p class="desc">Two persistent sidebars flank a primary split: working pane left (tabbed, polymorphic), terminal right. The agent is the dominant action surface; the working pane is what it operates on.</p>
+    <div class="wireframe wf-cockpit">
+      <div class="region r-files"><div class="label-main">Files</div></div>
+      <div class="region r-work">
+        <div class="tabs"><i></i><i></i><i></i></div>
+        <div class="label-main">Working<span class="sublabel">browser · md · file</span></div>
+      </div>
+      <div class="region r-term">
+        <div class="tabs"><i></i><i></i></div>
+        <div class="label-main">Terminal</div>
+      </div>
+      <div class="region r-tools"><div class="label-main">Tools</div></div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> users who want both inputs and agent tools one click away, always visible.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Clear agent-primary framing</li>
+          <li>Separates inputs (files) from actions (tools)</li>
+          <li>Familiar IDE-adjacent chrome</li>
+          <li>Every surface persistently visible</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Four columns is tight on 13" displays</li>
+          <li>Working pane ends up ~35% of width</li>
+          <li>Two sidebars add visual noise</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 02 Classic IDE -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">02</span>Classic IDE</h2>
+      <span class="tag">VS Code-style</span>
+    </div>
+    <p class="desc">File browser left, working pane center-top (tabbed), terminal as a bottom strip, agent tools right. Closest to what PMs already know from VS Code or Cursor.</p>
+    <div class="wireframe wf-classic">
+      <div class="region r-files gf"><div class="label-main">Files</div></div>
+      <div class="region r-work gw">
+        <div class="tabs"><i></i><i></i><i></i></div>
+        <div class="label-main">Working</div>
+      </div>
+      <div class="region r-tools gt"><div class="label-main">Tools</div></div>
+      <div class="region r-term gterm"><div class="label-main">Terminal</div></div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> teams coming from VS Code who want zero relearning cost.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Lowest learning curve</li>
+          <li>Working pane dominates visually</li>
+          <li>File browser placement is conventional</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Bottom-strip terminal fights the "agent-primary" thesis</li>
+          <li>Horizontal terminal is narrow for Claude Code output</li>
+          <li>Less differentiated from existing tools</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 03 Mirror -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">03</span>Mirror</h2>
+      <span class="tag">Inverse VS Code</span>
+    </div>
+    <p class="desc">File browser + working pane on the left, terminal on the right. No persistent right sidebar — agent tools live in a command palette (Cmd-K) or overlay.</p>
+    <div class="wireframe wf-mirror">
+      <div class="region r-files"><div class="label-main">Files</div></div>
+      <div class="region r-work">
+        <div class="tabs"><i></i><i></i><i></i></div>
+        <div class="label-main">Working</div>
+      </div>
+      <div class="region r-term">
+        <div class="tabs"><i></i><i></i></div>
+        <div class="label-main">Terminal</div>
+      </div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> users who want the working pane wide and the agent adjacent, without a second sidebar.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Wider working pane than Cockpit</li>
+          <li>Less chrome — three zones, not four</li>
+          <li>Agent-on-right still reads as primary action</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Agent tools/skills harder to discover</li>
+          <li>Power-user palette required for skill switching</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 04 Tri-column -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">04</span>Tri-column</h2>
+      <span class="tag">Equal thirds</span>
+    </div>
+    <p class="desc">Three columns of equal weight: file browser, working pane, terminal. Agent tools are a drawer that slides over the terminal when invoked.</p>
+    <div class="wireframe wf-tri">
+      <div class="region r-files"><div class="label-main">Files</div></div>
+      <div class="region r-work">
+        <div class="tabs"><i></i><i></i></div>
+        <div class="label-main">Working</div>
+      </div>
+      <div class="region r-term">
+        <div class="tabs"><i></i><i></i></div>
+        <div class="label-main">Terminal</div>
+      </div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> wide displays (27"+) where three equal columns each have real breathing room.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Balanced visual weight</li>
+          <li>File browser is a peer, not an afterthought</li>
+          <li>No second sidebar cluttering edges</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Working pane feels narrow on 13" screens</li>
+          <li>Three equal columns makes the hierarchy ambiguous</li>
+          <li>Google Docs UI gets cramped at this width</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 05 Diptych -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">05</span>Diptych</h2>
+      <span class="tag">Balanced 50/50</span>
+    </div>
+    <p class="desc">Strict 50/50 split: working pane left (tabbed), terminal right (tabbed). Sidebars are thin icon rails that hover-expand into full panels.</p>
+    <div class="wireframe wf-diptych">
+      <div class="region r-files"><div class="label-main" style="font-size:9px">F</div></div>
+      <div class="region r-work">
+        <div class="tabs"><i></i><i></i><i></i></div>
+        <div class="label-main">Working</div>
+      </div>
+      <div class="region r-term">
+        <div class="tabs"><i></i><i></i></div>
+        <div class="label-main">Terminal</div>
+      </div>
+      <div class="region r-tools"><div class="label-main" style="font-size:9px">T</div></div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> users who want persistent access to sidebars without giving up screen space.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Working pane and terminal both get ~48% width</li>
+          <li>Sidebars are always reachable (icon rail)</li>
+          <li>Hover-expand keeps panels out of the way</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>No dominant surface — hierarchy is flat</li>
+          <li>Hover-expand adds latency and accidental triggers</li>
+          <li>Icon rails need good iconography to be legible</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 06 Stage -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">06</span>Stage</h2>
+      <span class="tag">Content hero</span>
+    </div>
+    <p class="desc">The working pane takes the top two-thirds of the window; the terminal is a full-width strip beneath. Sidebars are drawers triggered by hotkeys.</p>
+    <div class="wireframe wf-stage">
+      <div class="region r-work">
+        <div class="tabs"><i></i><i></i><i></i></div>
+        <div class="label-main">Working<span class="sublabel">dominant</span></div>
+      </div>
+      <div class="region r-term">
+        <div class="tabs"><i></i><i></i></div>
+        <div class="label-main">Terminal</div>
+      </div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> doc-centric sessions — reviewing a PRD in Docs while the agent produces changes below.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Working pane feels like the main event</li>
+          <li>Terminal as strip is natural for short agent replies</li>
+          <li>Clean, uncluttered default view</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Inverts the "agent-primary" thesis</li>
+          <li>Long Claude output scrolls a lot in a bottom strip</li>
+          <li>Drawer sidebars require discovery</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 07 Shell-first -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">07</span>Shell-first</h2>
+      <span class="tag">Terminal hero</span>
+    </div>
+    <p class="desc">Inverse of Stage: terminal is the dominant top region, working pane is a collapsible preview beneath. Sidebars are drawers.</p>
+    <div class="wireframe wf-shell">
+      <div class="region r-term">
+        <div class="tabs"><i></i><i></i><i></i></div>
+        <div class="label-main">Terminal<span class="sublabel">dominant</span></div>
+      </div>
+      <div class="region r-work">
+        <div class="tabs"><i></i><i></i></div>
+        <div class="label-main">Working</div>
+      </div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> agent-watching sessions — long-running Claude tasks where the transcript is the primary artifact.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Maximalist agent-primary framing</li>
+          <li>Full terminal width for wide Claude output</li>
+          <li>Working pane preview still glanceable</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Reading/editing a Google Doc feels cramped</li>
+          <li>Working pane gets demoted to "preview"</li>
+          <li>Not a natural PM-friendly layout</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 08 Focus -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">08</span>Focus</h2>
+      <span class="tag">One surface at a time</span>
+    </div>
+    <p class="desc">One dominant surface (user picks working pane or terminal); everything else is a drawer triggered by hotkey or hover. Distraction-free.</p>
+    <div class="wireframe wf-focus" style="position:relative">
+      <div class="region r-work">
+        <div class="tabs"><i></i><i></i><i></i></div>
+        <div class="label-main">Working<span class="sublabel">fullscreen</span></div>
+      </div>
+      <div class="focus-overlays">
+        <div class="stub l">Files</div>
+        <div class="stub r">Tools</div>
+        <div class="stub b">Terminal ↑</div>
+      </div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> solo deep-work sessions — one thing at a time, keyboard-driven.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Maximum real estate for the active surface</li>
+          <li>Minimal chrome — zen feel</li>
+          <li>Great for demos and screen shares</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Can't watch agent while reading docs</li>
+          <li>Heavy keyboard dependency</li>
+          <li>Hostile to newcomers — no visible affordances</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 09 Duplex -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">09</span>Duplex</h2>
+      <span class="tag">Parallel workflows</span>
+    </div>
+    <p class="desc">Two stacked pairs, each a (working pane + terminal) duo. A PM can run two fully-visible parallel sessions — e.g., PRD review above, research session below.</p>
+    <div class="wireframe wf-duplex">
+      <div class="region r-work ga"><div class="label-main">Working A</div></div>
+      <div class="region r-term gb"><div class="label-main">Terminal A</div></div>
+      <div class="region r-work gc"><div class="label-main">Working B</div></div>
+      <div class="region r-term gd"><div class="label-main">Terminal B</div></div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> users who routinely run two independent Claude sessions they want to compare at a glance.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Both sessions visible and active simultaneously</li>
+          <li>No tab-switching to check on the other</li>
+          <li>Unique — no existing tool does this well</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Very dense; each quadrant is ~half normal size</li>
+          <li>Google Docs barely fits at this scale</li>
+          <li>Complex to implement (double the panes and routing)</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 10 Zen -->
+  <section class="card">
+    <div class="header-row">
+      <h2><span class="num">10</span>Zen</h2>
+      <span class="tag">Palette-driven</span>
+    </div>
+    <p class="desc">Two-pane main window — working left, terminal right — and that's it. File browser and agent tools are palette overlays (Cmd-P, Cmd-K) rather than persistent panels.</p>
+    <div class="wireframe wf-zen">
+      <div class="region r-work">
+        <div class="tabs"><i></i><i></i><i></i></div>
+        <div class="label-main">Working</div>
+      </div>
+      <div class="region r-term">
+        <div class="tabs"><i></i><i></i></div>
+        <div class="label-main">Terminal</div>
+      </div>
+    </div>
+    <p class="best-for"><strong>Best for:</strong> keyboard-native users who dislike permanent sidebars and prefer invoking panels on demand.</p>
+    <div class="columns">
+      <div>
+        <h3>Pros</h3>
+        <ul>
+          <li>Maximum screen area for content</li>
+          <li>Cleanest, most intentional aesthetic</li>
+          <li>Palette scales well as features grow</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Cons</h3>
+        <ul>
+          <li>Worst discoverability — new users are lost</li>
+          <li>File browser as palette loses spatial navigation</li>
+          <li>Skills viewer in a palette is awkward to browse</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  <p><strong style="color:var(--text-dim)">How to read the wireframes.</strong> Tab strips (the little rectangles along the top of a region) indicate that surface is tabbed. Dashed outlines indicate drawers — panels hidden by default, invoked by hotkey or hover. All layouts assume the working pane is polymorphic (browser / markdown editor / file viewer) with per-tab mode.</p>
+  <p><strong style="color:var(--text-dim)">Picking.</strong> Once you choose — or identify a hybrid — we update <code>duo-brief.md</code> §4, §7 (layout model), §8 (architecture diagram), §11 (Stage 1 exit criteria) and the repo structure in §12.</p>
+</footer>
+
+</body>
+</html>

--- a/duo-brief.md
+++ b/duo-brief.md
@@ -82,18 +82,19 @@ These have been discussed and settled. Do not reopen without cause.
 
 ## 7. Decisions Pending / Assumptions Made
 
-The following were not directly answered by the owner; reasonable assumptions were made and should be confirmed before or during Stage 1.
+The following were not directly answered by the owner; reasonable assumptions were made and should be confirmed before or during Stage 1. Rows marked **OPEN — OWNER ACTION** are hard blockers on their target stage and cannot be resolved by Claude without input from Geoff.
 
-|Topic              |Assumption                                                                     |Confirm before                                                |
-|-------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------|
-|Name               |`orbit` is a working placeholder                                               |Stage 5 (skill authoring, since the skill name is user-facing)|
-|Distribution scope |Geoff personal → Trailblazers cohort → broader PM community (staged)           |Stage 6 (signing/notarization setup)                          |
-|Layout model       |Resizable split: terminals on left, browser on right, sidebar for skills       |Stage 1                                                       |
-|Skills data sources|CWD scan (SKILL.md, .claude/, CLAUDE.md) + brainstem.cc API                    |Stage 4                                                       |
-|Starting point     |Greenfield                                                                     |—                                                             |
-|Agent topology     |Each terminal tab = independent Claude Code session; all tabs share one browser|Stage 1                                                       |
-|UI aesthetic       |Dark, dense, professional-tool feel (reference: Warp × Linear)                 |Stage 6                                                       |
-|Browser tabs       |Multiple tabs within the single browser pane                                   |Stage 2                                                       |
+|Topic              |Status / Assumption                                                                                                                                          |Confirm before                                                |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+|Name               |`orbit` is a working placeholder                                                                                                                             |Stage 5 (skill authoring, since the skill name is user-facing)|
+|Distribution scope |Geoff personal → Trailblazers cohort → broader PM community (staged)                                                                                         |Stage 6 (signing/notarization setup)                          |
+|Layout model       |**OPEN — OWNER ACTION.** Ten candidates (Cockpit, Classic IDE, Mirror, Tri-column, Diptych, Stage, Shell-first, Focus, Duplex, Zen) laid out in `docs/ux/layout-options.html`. Owner must pick one (or a hybrid) — this choice rewrites §4, §8, §11 Stage 1, and §12. **Blocks Stage 1 scaffolding.** |Stage 1 start                                                 |
+|Working pane model |**OPEN — OWNER ACTION (dependent on layout choice).** The working pane is polymorphic (browser / file viewer / markdown editor). Decide: (a) single instance with mode toggle vs. tabbed like VS Code, (b) per-terminal-tab state vs. shared across terminals, (c) whether the markdown editor is a local-files surface only or also a Docs edit surface.|Stage 1 start                                                 |
+|Skills data sources|CWD scan (SKILL.md, .claude/, CLAUDE.md) + brainstem.cc API                                                                                                  |Stage 4                                                       |
+|Starting point     |Greenfield                                                                                                                                                   |—                                                             |
+|Agent topology     |Each terminal tab = independent Claude Code session; all tabs share one browser                                                                              |Stage 1                                                       |
+|UI aesthetic       |Dark, dense, professional-tool feel (reference: Warp × Linear)                                                                                               |Stage 6                                                       |
+|Browser tabs       |Multiple tabs within the single browser pane                                                                                                                 |Stage 2                                                       |
 
 -----
 
@@ -212,14 +213,23 @@ The skill is the spec. If it’s painful to write, the CLI surface is wrong.
 
 ## 11. Roadmap — Build Stages
 
+> **Open decisions blocking the roadmap** — track these in §7, action belongs to the owner:
+>
+> 1. **Layout model (blocks Stage 1).** Pick one of the ten candidates in `docs/ux/layout-options.html` (or a hybrid). This determines the window chrome, the sidebars, and where the terminal lives. Stage 1 cannot scaffold the window layout without it.
+> 2. **Working pane model (blocks Stage 1).** Working pane is polymorphic (browser / file viewer / markdown editor). Decide tabbed vs. mode-toggle, per-tab state vs. shared, and whether the markdown editor is a local-files surface or also an edit path for Google Docs. Interacts with the layout decision.
+>
+> Everything below assumes both decisions are made. Until they are, Stage 1 is only safe to advance on scaffolding that is layout-agnostic (Electron app shell, build tooling, one PTY, one browser view — wired up without committing to a window layout).
+
 ### Stage 1 — Core shell (Week 1)
 
 - Electron app scaffold with electron-vite + React + Tailwind
-- Resizable split layout (terminal left, browser right placeholder)
+- **Window layout per the §7 "Layout model" decision** (see `docs/ux/layout-options.html`). Resizable split; exact geometry determined by the chosen layout option.
+- **Working pane shell** per the §7 "Working pane model" decision (tabbed vs. mode-toggle; per-tab vs. shared state). Browser / file viewer / markdown editor modes stubbed even if only one is wired up in Stage 1.
 - xterm.js + node-pty: one working terminal
 - Tab bar for multiple terminal sessions
-- Keyboard shortcuts: new tab, close tab, cycle tabs, focus toggle
+- Keyboard shortcuts: new tab, close tab, cycle tabs, focus toggle; plus any hotkeys the chosen layout needs (e.g. drawer toggles for Focus/Stage/Shell-first).
 - **Exit criteria:** Geoff can open the app, get multiple terminal tabs, run Claude Code in them.
+- **Blocked on:** §7 "Layout model" and "Working pane model" rows. Do not scaffold the window until both are resolved.
 
 ### Stage 2 — Browser pane (Week 1–2)
 
@@ -385,6 +395,7 @@ If you are a Claude instance picking this up, here’s what you need to know:
 1. **If blocked on an open question in §7, state the assumption and proceed.** Do not stall waiting for clarification on layout, aesthetics, or naming — these can be resolved in-flight.
 1. **Suggested first task:** scaffold the repo per §12, get electron-vite + React + Tailwind running, render a single xterm.js terminal backed by node-pty. One file, one window, one working terminal. Everything else builds from there.
 1. **Before touching Stage 2/3/5, read §17 and `docs/research/vscode-1.110-integrated-browser.md`.** Google Docs read/edit is the flagship success test for this project, and the naive DOM approach does not work — canvas rendering requires the accessibility tree for reads and synthesized input (or the Docs REST API) for writes. The acceptance criteria in §11 Stages 2, 3, and 5 are the go/no-go gates.
+1. **Do not commit the window layout before the owner picks one.** The ten candidates are in `docs/ux/layout-options.html`; the decision is tracked as OPEN — OWNER ACTION in §7 and blocks Stage 1 scaffolding of the window chrome (see the call-out at the top of §11). Scaffolding that is layout-agnostic (Electron shell, build tooling, PTY, browser view wiring) can proceed in parallel.
 
 -----
 

--- a/duo-brief.md
+++ b/duo-brief.md
@@ -40,8 +40,9 @@ It is also a **personal daily driver** for Geoff. The design choices reflect bot
 - Real Chromium (so Google SSO, Google Docs, modern web apps all work)
 - Snappy, responsive UI — terminal must feel as fast as iTerm/Warp
 - Multiple terminal tabs, one shared browser
-- Agent can read DOM, click, fill, inject JS, navigate, screenshot
-- Skills context panel scoped to active terminal’s CWD
+- Agent can read DOM **and the accessibility tree**, click, fill, **type**, inject JS, navigate, screenshot, **read console logs**
+- **Google Docs is a first-class target: the agent can both read and edit the doc currently open in the browser pane.** See §17 and the Stage 2/3/5 acceptance criteria in §11.
+- Skills context panel scoped to active terminal's CWD
 - Ship an accompanying skill that teaches Claude Code how to use the app
 
 ### Non-Goals (explicitly out of scope for MVP)
@@ -141,22 +142,33 @@ The CLI is the agent’s API surface. It must be stable, predictable, and output
 
 ### Command reference (draft)
 
-|Command                                         |Description                             |Output                  |
-|------------------------------------------------|----------------------------------------|------------------------|
-|`orbit navigate <url>`                          |Navigate the browser to URL             |JSON: `{ok, url, title}`|
-|`orbit url`                                     |Current URL                             |plain text              |
-|`orbit title`                                   |Current page title                      |plain text              |
-|`orbit dom`                                     |Full page HTML (outerHTML)              |HTML to stdout          |
-|`orbit text`                                    |Visible text content (innerText of body)|plain text              |
-|`orbit text --selector <css>`                   |innerText of matching element           |plain text              |
-|`orbit click <selector>`                        |Click element by CSS selector           |JSON: `{ok, error?}`    |
-|`orbit fill <selector> <value>`                 |Fill input                              |JSON: `{ok, error?}`    |
-|`orbit eval <js>`                               |Execute JS, return result               |JSON-serialized result  |
-|`orbit screenshot [--out path] [--selector css]`|PNG screenshot                          |Path to file            |
-|`orbit tabs`                                    |List open browser tabs                  |JSON array              |
-|`orbit tab <n>`                                 |Switch to browser tab N                 |JSON: `{ok}`            |
-|`orbit wait <selector> [--timeout ms]`          |Wait for element                        |JSON: `{ok, error?}`    |
-|`orbit --version`                               |Version string (must match skill)       |plain text              |
+|Command                                                |Description                                                                            |Output                      |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------|----------------------------|
+|`orbit navigate <url>`                                 |Navigate the browser to URL                                                            |JSON: `{ok, url, title}`    |
+|`orbit url`                                            |Current URL                                                                            |plain text                  |
+|`orbit title`                                          |Current page title                                                                     |plain text                  |
+|`orbit dom`                                            |Full page HTML (outerHTML)                                                             |HTML to stdout              |
+|`orbit text`                                           |Visible text content (innerText of body)                                               |plain text                  |
+|`orbit text --selector <css>`                          |innerText of matching element                                                          |plain text                  |
+|`orbit ax [--selector <css>] [--format md\|json]`      |Accessibility-tree snapshot. **Required** for canvas-rendered apps (Google Docs, etc.) |Markdown (default) or JSON  |
+|`orbit click <selector>`                               |Click element by CSS selector                                                          |JSON: `{ok, error?}`        |
+|`orbit fill <selector> <value>`                        |Fill input (DOM-level `value =` + input events)                                        |JSON: `{ok, error?}`        |
+|`orbit type <text>`                                    |Synthesize keystrokes into the focused element via CDP `Input.insertText`              |JSON: `{ok, error?}`        |
+|`orbit key <keyname> [--modifiers cmd,shift,...]`      |Dispatch a single key event (e.g. `Enter`, `ArrowDown`, `Backspace`)                   |JSON: `{ok, error?}`        |
+|`orbit focus <selector>`                               |Move focus to the matching element (for subsequent `type`/`key`)                       |JSON: `{ok, error?}`        |
+|`orbit eval <js>`                                      |Execute JS, return result                                                              |JSON-serialized result      |
+|`orbit screenshot [--out path] [--selector css]`       |PNG screenshot                                                                         |Path to file                |
+|`orbit console [--since <ts>] [--follow] [--level ...]`|Dump buffered console messages; with `--follow`, stream live                           |NDJSON (one event per line) |
+|`orbit tabs`                                           |List open browser tabs                                                                 |JSON array                  |
+|`orbit tab <n>`                                        |Switch to browser tab N                                                                |JSON: `{ok}`                |
+|`orbit wait <selector> [--timeout ms]`                 |Wait for element                                                                       |JSON: `{ok, error?}`        |
+|`orbit --version`                                      |Version string (must match skill)                                                      |plain text                  |
+
+### Notes on the read/write primitives
+
+- **`orbit ax` is first-class, not a fallback.** Modern web apps increasingly render to `<canvas>` (Google Docs/Sheets/Slides, Figma, newer Notion editors, spreadsheets, whiteboards). For these, `orbit text` and `orbit dom` return structural chrome without document content. The accessibility tree — which apps expose for screen readers — is the only reliable text path. Implemented via CDP `Accessibility.getFullAXTree` and `Accessibility.getPartialAXTree` (scoped by selector). Default Markdown output mirrors VS Code 1.110's `readPage` approach; JSON mode returns the raw tree for programmatic use. See `docs/research/vscode-1.110-integrated-browser.md`.
+- **`orbit type` + `orbit key` are the edit path for canvas apps.** Canvas editors route input through a hidden `contenteditable` or input element; setting `value` does nothing. We synthesize input via CDP `Input.insertText` (text) and `Input.dispatchKeyEvent` (named keys) against the focused element.
+- **`orbit console` surfaces what the agent would otherwise miss.** Main process subscribes to CDP `Runtime.consoleAPICalled` + `Log.entryAdded` and maintains a ring buffer per browser tab. Claude Code reaches for this after `orbit eval` or page interactions to diagnose failures.
 
 ### Protocol (CLI ↔ socket)
 
@@ -184,10 +196,12 @@ The skill lives at `~/.claude/skills/orbit/SKILL.md` after install. It teaches C
 1. **When to reach for `orbit`** vs. alternatives (WebFetch, file reads)
 1. **The command surface** — ref to §9
 1. **Common patterns:**
-- “Read a Google Doc” → `orbit navigate <url>` → wait for load → `orbit text --selector .kix-appview-canvas`
-- “Fill and submit a form” → `orbit fill`, `orbit click`
-- “Verify a visual state” → `orbit screenshot` → report back to user
-- “Iterate on a generated HTML artifact” → write file → `orbit navigate file://...` → `orbit screenshot`
+- **Read a Google Doc** → `orbit navigate <url>` → `orbit wait '[role="document"]'` → `orbit ax --selector '[role="document"]'`. Do **not** use `orbit text --selector .kix-appview-canvas` — Docs renders to a canvas and the DOM selector yields almost no content. The accessibility tree is the read path. (See §17.)
+- **Edit a Google Doc** → focus the editing surface (`orbit focus '[role="document"]'` or `orbit click '[role="document"]'`) → `orbit type "<text>"` and/or `orbit key Enter/Backspace/ArrowDown/...`. For structural edits (tables, headings), prefer the Google Docs REST API path documented in §17.
+- **Fill and submit a form** → `orbit fill`, `orbit click`
+- **Verify a visual state** → `orbit screenshot` → report back to user
+- **Diagnose a failing page interaction** → `orbit console --since <ts>` to inspect errors/warnings emitted since the last action
+- **Iterate on a generated HTML artifact** → write file → `orbit navigate file://...` → `orbit screenshot`
 1. **Error recovery** — when a selector fails, retry with `orbit dom` to inspect, or use `orbit eval` for custom queries
 1. **When NOT to use it** — static fetches (use WebFetch), reading local files (use Read), reading terminal state (not its job)
 1. **Pinned version** — skill tests `orbit --version` matches its compatible range
@@ -214,14 +228,27 @@ The skill is the spec. If it’s painful to write, the CLI surface is wrong.
 - Google SSO session persistence (partition → `~/Library/Application Support/orbit/browser-session`)
 - Multiple browser tabs within the browser pane
 - **Exit criteria:** Geoff can log into Google once, reopen the app, still be logged in. Google Docs renders correctly.
+- **Google Docs acceptance criteria (required to exit Stage 2):**
+  - A.2.1 — Open a Google Doc URL after a cold app launch with a logged-in session; the doc renders fully (no SSO bounce, no `X-Frame-Options` error, no accounts chooser loop).
+  - A.2.2 — Typing into the doc directly in the browser pane using the host keyboard produces characters at the cursor and they persist after reload. (Proves the WebContentsView passes keyboard focus through.)
+  - A.2.3 — Closing and reopening the app preserves the session — the same Doc reopens without re-authentication.
+  - A.2.4 — The user-agent the Electron browser presents to Google does not trip challenge flows (no repeated "unusual activity" interstitials over a 10-minute session).
 
 ### Stage 3 — `orbit` bridge (Week 2)
 
 - Unix socket server in main process
-- CDP wiring: navigate, dom, text, click, fill, eval, screenshot (core set first)
+- CDP wiring: navigate, dom, text, **ax**, click, fill, **type**, **key**, **focus**, eval, screenshot, **console** (core set first; see §9)
 - `orbit` CLI binary (compiled or Node.js shebang), installed via postinstall or bundled in DMG with a symlink step
 - Install script: `/usr/local/bin/orbit` symlink
-- **Exit criteria:** From any terminal tab in the app, `orbit text` returns the contents of whatever’s in the browser.
+- Console capture: main process subscribes to `Runtime.consoleAPICalled` and `Log.entryAdded` per tab and maintains a per-tab ring buffer (default 500 entries)
+- **Exit criteria:** From any terminal tab in the app, `orbit text` returns the contents of whatever's in the browser.
+- **Google Docs acceptance criteria (required to exit Stage 3):**
+  - A.3.1 — **Read round-trip.** With a Google Doc loaded in the browser pane, `orbit ax --selector '[role="document"]'` returns the full document text in the same order as it appears on screen, including headings and list structure, within 2s for a 20-page doc.
+  - A.3.2 — **Write round-trip.** From a terminal, the sequence `orbit focus '[role="document"]'` → `orbit key End` → `orbit type "Duo smoke test ⟨uuid⟩"` causes the string to appear at the end of the document and to persist after reload.
+  - A.3.3 — **Read-after-write.** Re-running `orbit ax` after A.3.2 returns text that contains the same `⟨uuid⟩`. (Proves read and write operate on the same live document state.)
+  - A.3.4 — **Multi-tab isolation.** With two Claude Code terminal tabs, both can issue `orbit ax` / `orbit type` against the shared browser without cross-talk (no lost events, no interleaved text at the wrong cursor position when issued sequentially).
+  - A.3.5 — **Console visibility.** `orbit eval 'console.warn("hello")'` followed by `orbit console --since <ts>` returns a row containing `"hello"` with level `warn`.
+  - A.3.6 — **No DOM fallback regression.** `orbit text --selector '.kix-appview-canvas'` returns an empty or near-empty string on Google Docs — documenting *why* `orbit ax` exists. The skill example is explicit about this.
 
 ### Stage 4 — Skills context panel (Week 2–3)
 
@@ -234,10 +261,15 @@ The skill is the spec. If it’s painful to write, the CLI surface is wrong.
 ### Stage 5 — `orbit` skill (Week 3)
 
 - Author `SKILL.md` per §10
-- Worked examples folder alongside the skill
+- Worked examples folder alongside the skill: `read-google-doc.md`, `edit-google-doc.md`, `fill-form.md`, `iterate-artifact.md`, `diagnose-console.md`
 - Installer drops skill into `~/.claude/skills/orbit/`
 - Version pinning between CLI and skill
 - **Exit criteria:** A fresh Claude Code session in the app autonomously discovers and uses `orbit` to read a Google Doc.
+- **Google Docs acceptance criteria (required to exit Stage 5 — this is the flagship success test):**
+  - A.5.1 — **Unprimed read.** With no prior context, a fresh Claude Code session given the prompt "summarize the doc open in my browser" discovers the `orbit` skill, reads via `orbit ax`, and returns an accurate summary. No human guidance, no reminder about canvas rendering.
+  - A.5.2 — **Unprimed edit.** A fresh session given "add a bullet to the risks section of the doc open in my browser saying '⟨X⟩'" completes the edit autonomously using `orbit focus` + `orbit key` + `orbit type`, and the bullet is visible to the user. The agent verifies with a follow-up `orbit ax`.
+  - A.5.3 — **Error recovery.** If the agent's first approach fails (e.g. wrong selector, focus lost), the skill's guidance leads it to retry successfully within 3 attempts — no dead end where the agent concludes "it can't be done."
+  - A.5.4 — **Honest non-goals.** The skill is explicit that complex structural edits (inserting a table, reformatting a heading block) should prefer the Docs REST API path (§17.5) rather than synthesized keystrokes, and documents when the API path is available.
 
 ### Stage 6 — Polish & distribution (ongoing)
 
@@ -321,17 +353,22 @@ orbit/
 |Skill drifts from CLI surface                                                  |Medium  |Version-pin the skill against `orbit --version`; add a smoke test that runs each example in CI.                       |
 |Apple notarization friction                                                    |Low     |One-time setup cost; standard process.                                                                                |
 |Performance: large DOM dumps (e.g. a long Google Doc) blow past terminal buffer|Medium  |`orbit text` + `--selector` narrowing; add `orbit text --max-chars N`; consider a `--save-to <file>` option.          |
+|Canvas-rendered apps (Google Docs/Sheets/Slides, Figma) invisible to DOM reads |High    |First-class `orbit ax` accessibility-tree path (§9, §17); skill explicitly steers agents off `orbit text` for these.  |
+|Google Docs DOM changes break synthesized-input edits                          |Medium  |Target ARIA roles (`[role="document"]`) not class names; skill's error-recovery loop retries with refocus (§17.6); REST API escape hatch for structural edits (§17.4).|
+|Docs REST API consent UX interrupts agent flow                                 |Low     |One-time consent; cached in Electron session; skill documents the prompt so the agent surfaces it to the user.        |
 
 -----
 
 ## 15. Glossary
 
 - **CDP** — Chrome DevTools Protocol. The wire protocol used to inspect and control Chromium. Electron exposes this via `webContents.debugger`.
-- **WebContentsView** — Electron’s modern API for embedding a Chromium view inside a BrowserWindow. Replaces the deprecated BrowserView.
+- **WebContentsView** — Electron's modern API for embedding a Chromium view inside a BrowserWindow. Replaces the deprecated BrowserView.
 - **node-pty** — Node.js bindings for spawning pseudo-terminal processes. Used to run real shells with full terminal semantics.
 - **xterm.js** — Browser-side terminal emulator. Renders PTY output into a canvas/DOM terminal.
-- **Brainstem** — Geoff’s personal knowledge management system at brainstem.cc, exposed as an MCP server. Relevant for the skills panel’s “context” source.
-- **Trailblazers** — Geoff’s pilot cohort of Capital One PMs getting early Claude Code access.
+- **Accessibility tree (AXTree)** — The structured representation of a page that browsers expose to screen readers, reachable via CDP `Accessibility.getFullAXTree`. For canvas-rendered apps like Google Docs, this tree — not the DOM — is where the actual document content lives. See §17 and `docs/research/vscode-1.110-integrated-browser.md`.
+- **Kix** — Google Docs' editor engine. Renders the document body to a `<canvas>` element with a hidden contenteditable for input. The reason `orbit ax` exists.
+- **Brainstem** — Geoff's personal knowledge management system at brainstem.cc, exposed as an MCP server. Relevant for the skills panel's "context" source.
+- **Trailblazers** — Geoff's pilot cohort of Capital One PMs getting early Claude Code access.
 
 -----
 
@@ -347,3 +384,88 @@ If you are a Claude instance picking this up, here’s what you need to know:
 1. **The skill-along-with-the-app is not an afterthought.** It is Stage 5 and a first-class deliverable. The app without the skill is 60% of the value. The skill without the app is 0%. Ship both or ship neither.
 1. **If blocked on an open question in §7, state the assumption and proceed.** Do not stall waiting for clarification on layout, aesthetics, or naming — these can be resolved in-flight.
 1. **Suggested first task:** scaffold the repo per §12, get electron-vite + React + Tailwind running, render a single xterm.js terminal backed by node-pty. One file, one window, one working terminal. Everything else builds from there.
+1. **Before touching Stage 2/3/5, read §17 and `docs/research/vscode-1.110-integrated-browser.md`.** Google Docs read/edit is the flagship success test for this project, and the naive DOM approach does not work — canvas rendering requires the accessibility tree for reads and synthesized input (or the Docs REST API) for writes. The acceptance criteria in §11 Stages 2, 3, and 5 are the go/no-go gates.
+
+-----
+
+## 17. Google Docs First-Class Support
+
+> Google Docs is the flagship target for Duo's agent↔browser bridge (see §2 and §3.1). This section consolidates the design decisions that make read-and-edit work end-to-end. It exists because the obvious approach (DOM scraping) does not work on Google Docs, and the failure mode is silent — a selector returns an empty string, the agent assumes the doc is empty, and the user sees hallucinated summaries. Do not ship without the acceptance criteria in §11 Stages 2/3/5 passing.
+
+### 17.1 The core problem
+
+Google Docs (the "Kix" editor, since ~2021) renders the document body to an HTML `<canvas>` element, not to a live DOM tree. Consequences:
+
+- `document.body.innerText` contains the Docs chrome (menus, toolbars) but almost none of the document text.
+- `document.querySelector('.kix-appview-canvas')` returns the canvas element, but `.innerText` on it is empty because canvas has no text children.
+- Keyboard input is not captured by visible elements — Docs uses a hidden `contenteditable` element (roughly `.docs-texteventtarget-iframe` descendants) for IME and input handling.
+
+This is the same pattern used by Google Sheets, Google Slides, Figma, and increasingly Notion's newer surfaces. Solving it for Docs unlocks the class.
+
+### 17.2 Read strategy — accessibility tree
+
+Google Docs exposes the full document to screen readers via ARIA. The browser's accessibility tree therefore contains the actual document content with structure (headings, lists, tables). We reach it via CDP:
+
+- `Accessibility.getFullAXTree` — full tree for the current page
+- `Accessibility.getPartialAXTree { backendNodeId }` — subtree rooted at a selector (we resolve the selector via `DOM.querySelector` first)
+
+The `orbit ax` command (see §9) wraps this and by default renders to Markdown using a small converter in the main process. For a Google Doc, the canonical invocation is:
+
+```bash
+orbit navigate https://docs.google.com/document/d/<id>/edit
+orbit wait '[role="document"]'
+orbit ax --selector '[role="document"]'
+```
+
+Output should be stable (paragraph order matches screen order) and fast (< 2s for a 20-page document; see A.3.1).
+
+### 17.3 Edit strategy — synthesized input
+
+For casual edits (appending text, replacing a selection, applying Cmd-B to the current selection), synthesizing keystrokes is sufficient:
+
+1. Focus the document: `orbit focus '[role="document"]'` (uses CDP `DOM.focus` on the resolved node; falls back to a click if focus fails).
+2. Position the cursor: `orbit key End`, `orbit key Home`, or use `orbit key ArrowDown --modifiers shift` to select.
+3. Insert text: `orbit type "..."` issues `Input.insertText`, which mimics IME input and is what Docs' hidden event target expects.
+4. Named keys for structure: `orbit key Enter` (new paragraph), `orbit key Tab` (list indent), `orbit key Backspace`, and modifier chords like `orbit key b --modifiers cmd` (bold).
+
+Synthesized-input edits are the default because they work without any extra OAuth scope beyond what the user's Google login already provides.
+
+### 17.4 Edit strategy — when to escalate to the Docs REST API
+
+Synthesized keystrokes are fragile for structural edits: inserting a table, rewriting a whole heading block, moving content across sections. For those, prefer the Google Docs REST API:
+
+- Endpoint: `https://docs.googleapis.com/v1/documents/{id}:batchUpdate`
+- Auth: bootstrap an OAuth access token from the signed-in Electron session (the user already consented at login). Scope: `https://www.googleapis.com/auth/documents`. First call triggers a consent dialog in the browser pane.
+- Exposed to agents as `orbit docs apply <json-patch>` (future command; not in Stage 3 core). Implementation lives in the main process so the access token never leaves the app.
+
+Skill guidance (§10, A.5.4): prefer synthesized input for simple text edits, escalate to the API for structural changes. The skill's `edit-google-doc.md` example documents both paths.
+
+### 17.5 Security posture
+
+Duo's threat model is a single trusted user on a trusted machine, so unlike VS Code 1.110 (see `docs/research/vscode-1.110-integrated-browser.md`) we do not require per-page "Share with Agent" consent. However:
+
+- The Unix socket is mode `0600` and lives under `~/Library/Application Support/duo/` (user-owned).
+- The Docs REST API path requires one-time explicit consent in the browser pane before the first write. The consent is cached in the Electron session, not in the socket bridge.
+- A future "paranoid mode" (Stage 6+) could adopt VS Code's per-tab share-with-agent gating. Not in MVP scope.
+
+### 17.6 Failure modes and telemetry
+
+Before Stage 5 declares done, the following failure modes must have explicit handling in the skill:
+
+| Failure                                                           | Detection                                        | Skill guidance                                                                     |
+|-------------------------------------------------------------------|--------------------------------------------------|------------------------------------------------------------------------------------|
+| Agent uses `orbit text` on a Google Doc and gets ~nothing         | Empty/near-empty output on a known-large doc     | Skill teaches: retry with `orbit ax`. `text` on `.kix-appview-canvas` is a trap.   |
+| Focus is lost between `orbit focus` and `orbit type`              | Text appears in the wrong element or not at all  | Skill: re-issue `orbit focus` immediately before `orbit type`; check `orbit url`.  |
+| Doc opens behind account chooser / SSO bounce                     | `orbit ax` returns a Google account-picker tree  | User remediation: log in once in the browser pane. Skill surfaces this clearly.    |
+| Docs API consent not yet granted                                  | `orbit docs apply` returns `{error: "consent"}`  | Skill: tell user to click through the consent prompt that appeared in the pane.    |
+| Long doc + naive full-tree fetch exceeds terminal buffer          | `orbit ax` output > N MB                         | Skill: use `--selector` to narrow; use `--format json` and pipe to `jq`.           |
+
+### 17.7 Acceptance criteria summary
+
+The Google Docs experience ships only when **all** of the following pass:
+
+- §11 Stage 2: A.2.1 – A.2.4 (browser + SSO foundation)
+- §11 Stage 3: A.3.1 – A.3.6 (CLI read, write, round-trip, multi-tab, console, no-regression)
+- §11 Stage 5: A.5.1 – A.5.4 (unprimed read, unprimed edit, error recovery, honest non-goals)
+
+If any criterion is failing at the end of its stage, the stage does not exit. This is the forcing function that keeps the flagship use case real instead of aspirational.


### PR DESCRIPTION
## Summary

Three threads landed on this branch:

1. **Google Docs read/edit as a first-class, measurable goal.** New §17 "Google Docs First-Class Support" documents the canvas-rendering failure mode, the accessibility-tree read path, the synthesized-input edit path, the Docs REST API escape hatch, security posture, and failure-mode telemetry. §9 CLI spec gains `orbit ax`, `orbit type`, `orbit key`, `orbit focus`, and `orbit console`. §10 skill example fixed (`.kix-appview-canvas` does not yield doc text). Acceptance criteria (A.2.1–A.2.4, A.3.1–A.3.6, A.5.1–A.5.4) added to Stages 2, 3, and 5 as explicit exit gates. §14 risks and §15 glossary updated.

2. **VS Code 1.110 browser research preserved.** Full report saved at `docs/research/vscode-1.110-integrated-browser.md` with a Duo-specific implications section mapping the ten VS Code capability criteria onto our architecture.

3. **Layout decision tracked as OPEN — OWNER ACTION.** Ten candidate layouts (Cockpit, Classic IDE, Mirror, Tri-column, Diptych, Stage, Shell-first, Focus, Duplex, Zen) in `docs/ux/layout-options.html` — a self-contained HTML page with wireframes and pros/cons. §7 upgraded with two new OPEN rows (layout model + working pane model). §11 roadmap gains a call-out at the top listing the two blockers and notes that Stage 1 scaffolding must wait on the owner's choice; layout-agnostic scaffolding can proceed in parallel. §16 handoff updated accordingly.

## Owner action required before Stage 1 can scaffold the window chrome

- [ ] Open `docs/ux/layout-options.html` and pick a layout (or hybrid).
- [ ] Answer the three working-pane-model questions in §7: tabbed vs. mode-toggle; per-terminal-tab state vs. shared; markdown editor as local-files surface only vs. also an edit path for Docs.

Once those two decisions are made, §4, §8, §11 Stage 1, and §12 will be rewritten to match.

## Test plan

- [ ] Open `docs/ux/layout-options.html` locally and pick a layout.
- [ ] Review §17 — confirm the synthesized-input vs. REST-API split for Docs editing matches intent.
- [ ] Confirm Stage 2/3/5 acceptance criteria are realistic before Stage 2 kickoff.

https://claude.ai/code/session_015ULohudFmCSLhZJeYVjcXi