### PR TITLE
docs: open ADR for skill scoping (global vs Duo-session-only)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,6 +113,7 @@ to the agent running in the active terminal tab.
 
 - [ ] Version pinning: skill asserts `duo --version` is in compatible range
 - [ ] Postinstall verified: skill copied to `~/.claude/skills/duo/` on first launch
+- [ ] **Resolve open ADR: skill scoping — global install vs. Duo-session-only** (see `docs/DECISIONS.md` → "Open ADRs"). Changes the first-launch install step if we pick per-session scoping.
 
 ---
 
@@ -240,3 +241,4 @@ deeper, shallower, or sideways without affecting any existing tab.
 | Apple Developer ID cert | Stage 6 |
 | Distribution timeline (personal → Trailblazers) | Stage 6 |
 | Socket auth approach for Trailblazers | Stage 6 |
+| Skill scoping: global `~/.claude/skills/duo/` vs. Duo-session-only (see `docs/DECISIONS.md` → Open ADRs) | Stage 5 |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -150,3 +150,74 @@ when a tab becomes visible to handle deferred layout.
 **Status:** Confirmed  
 **Decision:** The app is named "Duo". The CLI is `duo`. The skill installs to
 `~/.claude/skills/duo/`. No further confirmation needed.
+
+---
+
+## Open ADRs (pending decision)
+
+### Skill scoping — global install vs. Duo-session-only
+
+**Status:** 🟡 Open / Undecided  
+**Raised:** 2026-04-23  
+**Needed before:** Stage 5 ships (skill install step)
+
+**Question:** Should the `duo` skill be installed globally to
+`~/.claude/skills/duo/` (current plan per brief §6), or scoped so it only
+appears inside Claude Code sessions that Duo itself spawned?
+
+**Why it matters:**
+- The skill teaches Claude how to call `duo <command>` to drive Duo's
+  embedded browser. It's meaningless outside Duo.
+- We want to add stronger anti-improvisation guidance ("don't reach for
+  `osascript` / Playwright / system-Chrome CDP when `duo` is available") —
+  that guidance is irrelevant, and potentially confusing, in non-Duo
+  sessions (Terminal.app, VS Code terminals, CI, etc.).
+- A global install pollutes every Claude session on the machine with
+  Duo-specific context.
+
+**Options under consideration:**
+
+1. **Keep global install at `~/.claude/skills/duo/`** (current plan)
+   - Pro: Zero extra plumbing; `duo --version` failing is the implicit
+     "not in Duo" signal.
+   - Con: Pollutes all sessions; can't safely add Duo-specific guardrails
+     without them leaking elsewhere.
+
+2. **Per-session via shell init + `claude --plugin-dir` wrapper**
+   - `PtyManager.create` spawns zsh with a Duo-owned `ZDOTDIR` pointing
+     at a generated `.zshrc` that (a) sources the user's real `~/.zshrc`
+     and (b) defines a `claude()` function forwarding `--plugin-dir
+     <duo-bundled-skill-dir>` into every invocation. Bash gets equivalent
+     treatment via `--rcfile` / `BASH_ENV`.
+   - Pro: Cleanly scoped to Duo PTYs; invisible outside Duo;
+     CWD-independent; doesn't touch `~/.claude/`.
+   - Con: Skill becomes a plugin (namespaced as `/duo:<name>`); one more
+     layer of shell init that can break; users who invoke `/usr/local/bin/claude`
+     directly bypass the wrapper.
+
+3. **Per-session via `claude --add-dir <duo-bundled-skill-parent>`**
+   - Same shell-init wrapper, but uses `--add-dir` so Claude
+     auto-discovers `.claude/skills/duo/` inside the bundled path without
+     plugin namespacing.
+   - Pro: Same scoping win as option 2, without the `/duo:` prefix on
+     every skill name.
+   - Con: `--add-dir` also grants filesystem access to the bundled path
+     (fine — it's ours). Same shell-init fragility as option 2.
+
+4. **Project-level `.claude/skills/duo/` only**
+   - Symlink the skill into the PTY's launch CWD.
+   - Pro: No shell-init hop.
+   - Con: Evaporates when the user `cd`s away from launch CWD;
+     unreliable as the *only* mechanism.
+
+**Interference with user's existing skills:**
+- Options 2 / 3 / 4 are purely additive — `~/.claude/skills/` keeps
+  loading normally.
+- Plugin namespacing (option 2) means no name collisions.
+- The `ZDOTDIR` hop *must* source the user's real `.zshrc` or it will
+  nuke their aliases / PATH / prompt.
+
+**Related change if we pick 2/3/4:** Drop the global install step from
+Stage 5's first-launch flow — skill no longer lives under `~/.claude/`.
+
+**Decision owner:** Geoff.


### PR DESCRIPTION
## Summary

Records an open/undecided ADR for how the `duo` skill should be installed so
that a Claude Code session can reliably distinguish "I'm running inside Duo"
from "I'm a regular terminal session," without Duo-specific guidance leaking
into every Claude session on the machine.

- `docs/DECISIONS.md`: new "Open ADRs" section with the skill-scoping question, four options (keep global install / shell-init + `--plugin-dir` / shell-init + `--add-dir` / project-level only), their tradeoffs, and a note on how each interacts with the user's existing `~/.claude/skills/`.
- `ROADMAP.md`: new Stage 5 checkbox to resolve the ADR before the skill install step ships, plus an entry in the Open Questions table.

No code changes — this is a decision-tracking PR only.

## Test plan

- [ ] Geoff reviews the ADR and picks an option (or defers with notes)
- [ ] Once resolved: move the entry out of "Open ADRs" into the main decisions log and update Stage 5 accordingly

https://claude.ai/code/session_01DvW8JCgUvKjWUjr5qSVZXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvW8JCgUvKjWUjr5qSVZXF)_