### PR TITLE
docs: reframe Duo as a PM-native agent workspace (VISION.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ Brief: `duo-brief.md` (read this first — it's comprehensive and locked)
 | File | Purpose |
 |---|---|
 | `README.md` | Elevator pitch, quick start, CLI reference, architecture diagram |
-| `duo-brief.md` | Full vision brief — read before making architectural decisions |
+| `docs/VISION.md` | Product north star — persona, principles, flagship bet. Read before making product/UX decisions. |
+| `duo-brief.md` | Original engineering brief (Stages 1–5). Architecture + Google Docs path are authoritative; product framing is superseded by `docs/VISION.md`. |
 | `ROADMAP.md` | Stage-by-stage status with completion indicators + unscheduled backlog |
 | `docs/DECISIONS.md` | Locked architectural decisions with rationale (+ open ADR on skill scoping) |
 | `docs/FIRST-RUN.md` | Thorough setup + smoke-test procedure |

--- a/README.md
+++ b/README.md
@@ -1,29 +1,55 @@
 # Duo
 
-A macOS-native desktop app that pairs multiple Claude Code terminal sessions
-with an embedded Chromium browser, connected by a local CLI bridge so Claude
-Code can read and drive the browser — including authenticated Google Docs —
-as naturally as it runs shell commands.
+A macOS workspace for working **alongside an agent**. Duo pairs a terminal
+tuned for long human↔agent conversation with an embedded Chromium browser,
+a local CLI bridge, and (soon) a file browser and markdown editor — all in
+one signed app. Today the supported agent is
+[Claude Code](https://www.anthropic.com/claude-code); the architecture is
+BYO-harness.
 
 ![status: Stages 1–3 shipped, Stage 5 skill verified end-to-end](https://img.shields.io/badge/status-stages_1--3_shipped-brightgreen)
 
+> **Product north star lives in [docs/VISION.md](docs/VISION.md)** —
+> persona, principles, and the flagship "readable terminal + docs-style
+> markdown editor" bet. Read that for the *why*. This README is the *how*.
+
 ---
 
-## Why this exists
+## Who this is for
 
-Product managers using Claude Code hit a recurring wall: they want the agent
+Primarily, **product managers and other non-SWE knowledge workers** who
+want to work with an agent the way they already work in Google Docs or
+Notion — beautifully, safely, and without learning the terminal or the
+file system first. Duo smooths the rough edges of running an agent like
+Claude Code so the people least equipped to adopt it are actually able to.
+
+Duo is **not an agent.** It is a harness for someone else's agent.
+The terminal is still there — the agent lives in it — but everything
+around the terminal is designed for someone who does not.
+
+See [docs/VISION.md](docs/VISION.md) for the full persona and the
+aspirational capability set.
+
+---
+
+## What it is today
+
+At this point in the roadmap, Duo is a terminal + browser + agent-bridge
+in one native macOS app. The PM-facing surfaces (readable prose terminal,
+docs-style markdown editor, file browser, visual skill/connector management)
+are the next bets — see [ROADMAP.md](ROADMAP.md) and
+[docs/VISION.md](docs/VISION.md).
+
+A recurring pain point for the primary persona is that they want the agent
 to work with what's **on their screen** — a PRD in Google Docs, a live
 dashboard, a generated HTML prototype — and every bridge is awkward. Copy /
 paste, external MCP servers, browser-automation tools that break on Google
 SSO. Duo collapses the terminal, the browser, and the agent-bridge into one
-signed macOS app that installs by dragging to `/Applications`.
+signed macOS app that installs by dragging to `/Applications`. Authenticated
+Google Docs read/edit is the flagship success test for this foundation
+layer.
 
-Duo is also a personal daily driver: shippable quality for a broader PM
-cohort, prototype speed in the MVP.
-
----
-
-## What it does today
+What's shipped today:
 
 - **Terminal tabs** (xterm.js + node-pty) side-by-side with a real
   **Chromium browser pane** (Electron `WebContentsView`), in one window.
@@ -38,6 +64,9 @@ cohort, prototype speed in the MVP.
 - **First-class support for canvas-rendered apps** (Google Docs, Sheets,
   Slides, Figma) via the accessibility tree — not DOM scraping, which
   silently returns empty on these surfaces.
+
+Duo is also a personal daily driver for the owner: shippable quality for a
+broader cohort, prototype speed in the MVP.
 
 ---
 
@@ -234,8 +263,8 @@ Full stage-by-stage tracking lives in [ROADMAP.md](ROADMAP.md). Headlines:
 
 ## Further reading
 
-- **[duo-brief.md](duo-brief.md)** — the full vision brief. Read this for
-  the "why" and for features not yet implemented.
+- **[docs/VISION.md](docs/VISION.md)** — product north star: persona, jobs
+  to be done, principles, flagship bet. Start here for *why* Duo exists.
 - **[ROADMAP.md](ROADMAP.md)** — current status, per stage, plus the
   unscheduled backlog.
 - **[docs/DECISIONS.md](docs/DECISIONS.md)** — locked architectural
@@ -246,6 +275,10 @@ Full stage-by-stage tracking lives in [ROADMAP.md](ROADMAP.md). Headlines:
   and xterm notes that shaped the build.
 - **[skill/SKILL.md](skill/SKILL.md)** — the Claude Code skill installed
   alongside the app. Readable as-is for humans, too.
+- **[duo-brief.md](duo-brief.md)** — the original engineering brief for
+  Stages 1–5. Product framing is superseded by `docs/VISION.md`; the
+  technical detail (especially the Google Docs read/write path in §17)
+  remains the authoritative reference.
 
 ---
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,254 @@
+# Duo — Vision
+
+> The product north star. For engineering state see [ROADMAP.md](../ROADMAP.md),
+> for locked architectural choices see [DECISIONS.md](DECISIONS.md), for the
+> original engineering brief (historical) see [duo-brief.md](../duo-brief.md).
+
+---
+
+## What Duo is
+
+Duo is a macOS workspace for working **alongside an agent**. It bundles the
+pieces you need — a terminal, an embedded browser, a file browser, a prose
+editor, and a skill/connector surface — into one signed app, and it treats the
+presence of an agent as a first-class design assumption rather than an
+afterthought.
+
+Duo is **not** an agent. It is a harness for someone else's agent. Today that
+means [Claude Code](https://www.anthropic.com/claude-code); the architecture
+leaves room for others over time. When this document says "the agent" it means
+"whatever agent the user has brought."
+
+The goal is simple: make working with an agent feel as natural and as beautiful
+as working in the cloud-docs editors people already know — without closing the
+door on the terminal underneath, which is still where the agent actually lives.
+
+---
+
+## Who this is for
+
+### Primary — the product manager without a SWE background
+
+Knows the agent is useful. Does not write code. Lives in Google Docs, Figma,
+Notion, Jira, Slack. Is comfortable in a browser tab; is *not* comfortable in a
+terminal, does not think in file paths, does not edit markdown by typing `##`.
+Has probably installed Claude Code once, been impressed, been overwhelmed, and
+gone back to ChatGPT in a browser tab.
+
+The jobs-to-be-done we care about for this persona:
+
+- Draft, revise, and review PRDs, briefs, and strategy docs with an agent in
+  the loop — without copy-pasting between windows.
+- Pull local assets (a screenshot, a research transcript, a CSV) into the
+  conversation without knowing or typing where they live on disk.
+- Discover what the agent *can* do in this context — which skills, which
+  connectors, which shortcuts — without reading the docs.
+- Use the browser as a shared surface: the agent navigates, renders, and the
+  PM clicks through.
+- Trust that pressing the wrong key won't break anything or leak anything.
+
+### Secondary — other non-SWE knowledge workers
+
+Designers, UX researchers, program managers, marketers, and executives all
+share the same shape of problem. Duo should not over-fit to PM-specific
+jargon, but when a tradeoff splits the two, the PM use case wins. Where a
+feature helps one of these secondary personas noticeably more than the
+primary (e.g. a researcher's transcript-synthesis workflow), it lives in the
+starter skill pack rather than in core UI.
+
+### Explicitly not the primary audience
+
+Engineers using Claude Code for production software work are already well-served
+by a terminal + IDE + browser. Duo should not be hostile to them — the escape
+hatches stay — but it is not designed around their workflow and will not
+compromise PM-facing ergonomics to suit them.
+
+---
+
+## The problem
+
+The people most excited about agentic AI in a large company are rarely
+engineers. They are PMs, designers, researchers, and operators who see the
+promise and want in. When they try, they run into the same wall:
+
+- The terminal looks and feels like 1980s infrastructure. They are afraid of
+  it and, reasonably, they should be — one wrong command can delete their
+  work.
+- Markdown is the agent's native format. Cloud-docs people have spent a
+  decade unlearning markup.
+- Skills, subagents, MCP connectors, and `~/.claude/` live on the file system.
+  The file system is invisible to someone whose entire working life is in
+  a browser.
+- The agent produces beautiful reasoning and the harness renders it as green
+  text on a black background at 80 columns.
+
+The result is that the people whose work would benefit most from an agent are
+also the people least equipped to access one. Duo is the answer to "what if
+the surface looked like the tools these people already love?"
+
+---
+
+## North star
+
+> **Working with an agent should feel like working in a beautiful cloud
+> document — not like SSH-ing into a server.**
+
+A PM should be able to open Duo, start talking to the agent, drop in a file,
+approve a suggestion, tweak a paragraph in the editor, watch the agent render
+an interactive draft in the browser pane, and never once encounter a raw file
+path, a `cd`, a backslash-escape, or a YAML block — unless they want to.
+
+The terminal is still there, because the agent lives in it. But the terminal
+in Duo reads long, prose-heavy human-agent conversations the way a good book
+reads, not the way a log file reads.
+
+---
+
+## The flagship bet — the reading and writing pair
+
+Two surfaces, designed as one:
+
+### 1. A prose-first terminal
+
+Keeps full Claude Code TUI compatibility (the inner program must render
+correctly — that is non-negotiable), but the chrome, typography, and behavior
+around it are tuned for long, wrapped, human-readable conversation rather
+than for tail-f-ing a build log.
+
+Expect: proportional-ish fonts where safe, generous line-height, a reader-width
+soft limit with graceful overflow, markdown-aware highlighting for the
+agent's output, and no surprise truncation of a long answer. Claude Code's
+TUI keeps its columnar rendering where it needs to; the surrounding frame
+does not.
+
+### 2. A markdown editor that feels like your favorite docs editor
+
+Duo's editing surface for local markdown files renders and edits like Google
+Docs or Notion — live formatting, no visible asterisks or pound signs, clean
+heading typography, commentable, undoable, drag-and-drop for images, paste
+from the web that just works. Saves as plain markdown so the agent reads
+and writes the same file.
+
+This is the editor where the PM sees what the agent drafted, makes edits, and
+hands revisions back. It is also where the PM starts their own draft and
+asks the agent to iterate.
+
+### Why this pair is the flagship
+
+The reading surface (terminal) and the writing surface (editor) together turn
+the human-agent loop into something that feels like collaborative editing
+rather than a command-line session. Every other feature in this document is
+supporting cast — but without this pair, the supporting cast cannot save the
+experience.
+
+---
+
+## Supporting capabilities
+
+Ordered by how directly each one serves the primary persona. Some are shipped
+(Stages 1–5); some are aspirational. See [ROADMAP.md](../ROADMAP.md) for
+status.
+
+### Agent ↔ browser pair
+
+The agent and the user share a browser pane. The agent can navigate, read,
+and drive it (shipped: `duo navigate`, `duo ax`, `duo click`, `duo type`,
+etc.). Aspirationally, the agent can also **render its own interactive
+surfaces** into that pane — approval lists, diff views, tables, checklists,
+walk-throughs — that the user clicks through directly rather than replying
+in chat. The pane is a shared workspace, not just an agent-controlled tab.
+
+### Visual file browser / context drawer
+
+A sidebar that shows the files around the current working directory (and a
+pinned "home" scope), lets the user drag any file into the conversation to
+add it to context, and understands what the agent can do with each type
+(preview a PDF, summarize a CSV, diff two drafts). PMs should never have to
+know or type a file path.
+
+### Skill discovery, install, and editing
+
+Skills live in multiple places today — `~/.claude/skills/`, project
+`.claude/`, repo-bundled `skill/` directories. Duo presents one unified view:
+here are the skills available to this session, here is what they do, here
+is how to toggle one on or off, here is how to create a new one from a
+template. No opening of dotfiles, no sync scripts.
+
+### Connector / MCP setup wizard
+
+Installing an MCP connector (Slack, Jira, Notion, Google, GitHub) today means
+editing JSON. Duo wraps the common ones in a guided setup: click, OAuth,
+done. The JSON still exists; the PM never sees it.
+
+### Starter skill pack for PM-shaped work
+
+The first-run experience ships with a curated pack of skills tuned to PM
+scenarios — PRD drafting, competitive scan, interview synthesis, roadmap
+updates, stakeholder-summary generation. Not everyone keeps them all; they
+establish the "this tool knows what I do" feeling on day one.
+
+### The terminal escape hatch
+
+Everything above has a terminal-native equivalent. Nothing Duo does locks
+a power user out of the underlying shell, the raw markdown, or the dotfiles.
+When the PM grows into a power user, or hands the session to an engineer,
+the terminal is still the terminal. This is the BYO-harness promise: the
+smoothing is additive, never a cage.
+
+---
+
+## Principles
+
+1. **Agent-native by default.** Every surface assumes there is an agent in
+   the loop and designs for that fact. A file browser isn't a Finder clone;
+   it's a context drawer. An editor isn't Sublime; it's a collaboration
+   surface.
+
+2. **Bring your own harness.** Duo is not an agent. Today the only supported
+   harness is Claude Code. The architecture (skill + CLI + socket) is
+   harness-shaped, not agent-shaped, so future agents that speak the same
+   shell-command idiom can plug in without re-platforming.
+
+3. **Smooth over, don't replace.** When Claude Code exposes a sharp edge —
+   an unreadable log dump, a dotfile to edit, a permission prompt in the
+   wrong register — Duo smooths it. It does not hide or reimplement Claude
+   Code itself. The escape hatches stay open.
+
+4. **Don't break the TUI.** Claude Code's TUI is a living interface that
+   the primary agent vendor ships updates to. Duo's prose terminal must
+   render Claude Code exactly as Claude Code expects. Every typography
+   and layout choice is subordinate to that.
+
+5. **Beautiful by default.** The cloud-docs worker's baseline aesthetic is
+   very high. Duo matches it without trying to be minimalist-performative.
+   Dark-mode-first, proportional typography where it helps, restrained
+   color.
+
+6. **Ask before deciding.** A PM has opinions and deserves to be consulted
+   on meaningful choices. Silent defaults are fine for mechanics (paths,
+   ports); substantive UX (layout, behavior) is asked.
+
+7. **Shippable quality, prototype speed.** The MVP doesn't need every
+   capability in this document; it does need to *feel* like a finished
+   product for the capabilities it does ship. A half-polished surface
+   confirms the PM's suspicion that agent tooling isn't for them.
+
+---
+
+## What this vision supersedes
+
+- [`duo-brief.md`](../duo-brief.md) captured the engineering brief for Stages
+  1–5 (terminal + browser + bridge + skill). It remains the authoritative
+  reference for the technical architecture and the Google Docs first-class
+  read/write path. The product framing in that brief — "a tool for PMs using
+  Claude Code at Capital One" — is narrower than this vision and is
+  superseded here. The engineering content is not.
+
+- The README has been reframed to lead with the workspace framing (and
+  persona) rather than with the terminal-plus-browser technical pitch.
+  Install/quickstart/CLI reference remain.
+
+- [`ROADMAP.md`](../ROADMAP.md) and [`DECISIONS.md`](DECISIONS.md) continue
+  to be the source of truth for what is built and why. Aspirational items
+  named in this document are tracked there (or belong in the backlog if not
+  yet) — this document does not commit to dates.

--- a/duo-brief.md
+++ b/duo-brief.md
@@ -1,9 +1,18 @@
-# Duo — Project Brief
+# Duo — Project Brief (engineering, Stages 1–5)
 
 > **Name:** Duo (CLI: `duo`, socket: `~/Library/Application Support/duo/duo.sock`, skill: `~/.claude/skills/duo/`)
 > **Owner:** Geoff
 > **Status:** Stages 1–3 implemented; Stage 5 skill + subagent authored and verified end-to-end.
 > **Last updated:** 2026-04-22
+
+> **Product framing has moved to [docs/VISION.md](docs/VISION.md).** That
+> doc is the current north star — persona, principles, and the flagship
+> "readable terminal + docs-style markdown editor" bet. This brief is
+> retained as the engineering reference for Stages 1–5: the CLI spec (§9),
+> the architecture (§8), the Google Docs first-class read/write path (§17),
+> and the acceptance criteria (§11) are still authoritative. Where the
+> brief's product framing ("a tool for PMs using Claude Code at Capital
+> One") differs from the vision doc, the vision doc wins.
 
 > This is the full vision brief. For current build state see [ROADMAP.md](ROADMAP.md). For architecture decisions see [docs/DECISIONS.md](docs/DECISIONS.md). For first-time setup see [docs/FIRST-RUN.md](docs/FIRST-RUN.md). Brainstem.cc / MCP integration mentioned in §3, §8 is a future aspiration — the shipping Skills panel (Stage 4) is CWD-scan only.
 


### PR DESCRIPTION
## Summary

- New `docs/VISION.md` is the product north star: PM-native agent workspace, BYO-harness, primary + secondary personas, flagship bet = **readable prose terminal + docs-style markdown editor**.
- README reframed to lead with the workspace framing and a "who this is for" section; points at VISION.md for the *why*, keeps install / CLI / architecture intact.
- `duo-brief.md` gets a top-of-file note: product framing is superseded by VISION.md; architecture, CLI spec, and the Google Docs §17 path remain authoritative.
- `CLAUDE.md` Key files table now points Claude instances at VISION.md for product/UX decisions.

No code changes — docs only.

## Test plan

- [ ] Read `docs/VISION.md` end-to-end; persona, principles, and flagship bet match Geoff's intent
- [ ] README opens with the workspace/persona framing; install steps still work unchanged
- [ ] `duo-brief.md` still answers engineering questions (CLI spec §9, architecture §8, Google Docs §17)
- [ ] `CLAUDE.md` pointer reads right for a future Claude session doing product work

https://claude.ai/code/session_01KpEpfdy7YzcNVDkicKGz3W

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpEpfdy7YzcNVDkicKGz3W)_