### PR TITLE
docs: ADR + roadmap for sandbox-tolerant duo transport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,35 @@ Brief: `duo-brief.md` (read this first — it's comprehensive and locked)
 
 ---
 
+## Claude Code sandbox — must read before touching transport, install, or CLI file I/O
+
+Claude Code runs each Bash tool call inside a macOS Seatbelt sandbox that
+(a) blocks writes outside the working directory, (b) gates
+Unix-domain-socket outbound connections behind an explicit
+`allowUnixSockets: true`, and (c) permits localhost TCP. Duo's entire
+agent-side bridge today is a single Unix socket at
+`~/Library/Application Support/duo/duo.sock` — which means **every `duo`
+command silently fails inside a sandboxed Claude Code session**.
+The user sees a hung or `ECONNREFUSED` Bash call with no hint that the
+sandbox is the cause.
+
+Before changing any code in `cli/duo.ts`, `electron/socket-server.ts`,
+the install path, or the skill's troubleshooting guidance, read
+`docs/DECISIONS.md` → Open ADRs → **Sandbox-tolerant transport and
+install paths for the `duo` CLI**. That ADR inventories what breaks,
+explains the `dudgeon/chrome-cdp-skill` precedent (localhost TCP +
+auth-token file), and names the planned direction: TCP fallback
+alongside the Unix socket, `duo doctor` diagnostic,
+`~/.claude/bin/duo` as the preferred install target, skill-docs
+troubleshooting section, and a bundled settings fragment. Roadmap
+items cross-reference the ADR from Stages 5, 13, and 14.
+
+The work is planful and roadmap-aligned — not a patch. If you find a
+new sandbox failure mode not listed in the ADR, add it there rather
+than routing around it ad hoc.
+
+---
+
 ## Pre-built CLI binary (`cli/duo`)
 
 `cli/duo` is a compiled esbuild bundle intentionally tracked in git so Geoff

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -170,6 +170,7 @@ to the agent running in the active terminal tab.
 - [ ] Version pinning: skill asserts `duo --version` is in a compatible range
 - [ ] First-launch installer (copies `skill/` + `agents/` into `~/.claude/`) — currently manual. Stage 6.
 - [ ] **Open ADR: skill scoping** — global `~/.claude/skills/duo/` vs. Duo-session-only (`docs/DECISIONS.md` → Open ADRs). Changes the first-launch install step if we pick per-session.
+- [ ] **Skill docs: Claude Code sandbox troubleshooting section** — add a block to `skill/SKILL.md` (and the mirror guidance in `agents/duo-browser.md`) that names the sandbox failure mode (every `duo` command silently fails because Unix sockets are blocked by default), tells the agent to run `duo doctor` on the first failure, and documents the minimum `.claude/settings.json` allowlist for teams that prefer the Unix-socket fast path. See `docs/DECISIONS.md` → Open ADRs → *Sandbox-tolerant transport and install paths for the `duo` CLI*. Cheap; can land before Stages 9–11.
 
 ---
 
@@ -189,6 +190,25 @@ to the agent running in the active terminal tab.
 - [ ] `electron-updater` — auto-update from GitHub Releases or private S3
 - [ ] Session restore on relaunch (terminal CWDs, browser URL, split position)
 - [ ] Security: launch-time auth token on the Unix socket (before Trailblazers)
+- [ ] **Sandbox-safe install path for `duo install`.** Today the
+      install logic tries `/usr/local/bin/duo` then falls back to
+      `~/.local/bin/duo` — both write outside the Claude Code
+      sandbox's permitted cwd. Prefer `~/.claude/bin/duo` (inside
+      the sandbox-writable `~/.claude/` tree), fall back to
+      `~/.local/bin/duo`, and only touch `/usr/local/bin/duo` on
+      explicit opt-in. Print the required `export PATH=…` fragment
+      after install. See `docs/DECISIONS.md` → Open ADRs →
+      *Sandbox-tolerant transport and install paths for the `duo`
+      CLI*.
+- [ ] **Bundled Claude Code settings fragment.** Ship a
+      copy-pasteable `.claude/settings.json` allowlist in the
+      skill (socket path read-allowed + `allowUnixSockets: true`)
+      for teams that want to keep Duo on the Unix-socket fast path
+      rather than the TCP fallback. Optional for users because the
+      fallback heals sandboxed runs transparently; valuable as
+      documentation for sandbox-conscious reviewers. See
+      `docs/DECISIONS.md` → Open ADRs → *Sandbox-tolerant
+      transport and install paths for the `duo` CLI*.
 - [ ] Theming pass: refine Warp × Linear aesthetic
 - [ ] Notifications for agent-driven browser navigation
 - [ ] README + install guide for Trailblazers cohort
@@ -670,6 +690,27 @@ is up. Pulls from the unscheduled backlog the user raised earlier.
 - [ ] **`duo wait --timeout` / CLI socket timeout race.** Make the
       CLI's socket timeout `max(explicit + buffer, default)` so
       `duo wait --timeout 15000` stops hitting the 10s socket cap.
+- [ ] **TCP fallback alongside the Unix socket.** Claude Code's
+      macOS sandbox blocks Unix-domain-socket outbound connections
+      by default but permits localhost TCP, so today every `duo`
+      command silently fails inside a sandboxed Claude Code
+      session. Add a second `server.listen(0, '127.0.0.1')` in
+      `electron/socket-server.ts`, publish the port + a per-install
+      auth token to `~/Library/Application Support/duo/duo.port`,
+      and teach `cli/duo.ts` to fall back to TCP on
+      `EPERM`/`ECONNREFUSED`/timeout. Mirrors the
+      `dudgeon/chrome-cdp-skill` fix for the same class of problem.
+      See `docs/DECISIONS.md` → Open ADRs → *Sandbox-tolerant
+      transport and install paths for the `duo` CLI*.
+- [ ] **`duo doctor` diagnostic.** New CLI verb that reports
+      socket-reachable / TCP-fallback-reachable / install path
+      writable / `~/.claude/skills/duo/` synced / version match.
+      Prints a clear "Claude Code sandbox detected — falling back
+      to TCP" line when appropriate. Paired with a skill
+      instruction to run `duo doctor` on the first failed command
+      so the sandbox failure mode is named, not inferred. See
+      `docs/DECISIONS.md` → Open ADRs → *Sandbox-tolerant
+      transport and install paths for the `duo` CLI*.
 
 ---
 
@@ -706,3 +747,4 @@ been promoted into Stages 9, 11, and 13._
 | Distribution timeline (personal → Trailblazers) | Stage 6 |
 | Socket auth approach for Trailblazers | Stage 6 |
 | Skill scoping: global `~/.claude/skills/duo/` vs. Duo-session-only (see `docs/DECISIONS.md` → Open ADRs) | Stage 5 |
+| Sandbox-tolerant transport: TCP fallback + `duo doctor` + install-path fix (see `docs/DECISIONS.md` → Open ADRs: *Sandbox-tolerant transport and install paths for the `duo` CLI*) | Stages 5 (docs), 13 (transport), 14 (install + settings) |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -221,3 +221,146 @@ appears inside Claude Code sessions that Duo itself spawned?
 Stage 5's first-launch flow — skill no longer lives under `~/.claude/`.
 
 **Decision owner:** Geoff.
+
+---
+
+### Sandbox-tolerant transport and install paths for the `duo` CLI
+
+**Status:** 🟡 Open / Proposed
+**Raised:** 2026-04-23
+**Needed before:** Stage 14 (distribution). Skill-docs portion is cheap
+and can land before the flagship pair; transport + install changes land
+with polish.
+
+**Problem statement.** Claude Code runs each Bash tool invocation inside
+a macOS Seatbelt-based sandbox. Enterprise deployments (e.g. Capital
+One) have this enabled by default. The sandbox:
+
+- **Blocks filesystem writes outside the current working directory.**
+  Reads outside cwd are generally allowed.
+- **Gates Unix-domain-socket outbound connections behind explicit
+  `allowUnixSockets: true`.** The default disallows them; the Claude
+  Code docs warn that `allowUnixSockets` "can inadvertently grant
+  access to powerful system services" (e.g. the Docker socket), so
+  enterprise admins tend to leave it off.
+- **Permits localhost TCP by default.** The network filter is
+  domain/proxy-based, not a blanket loopback block. `127.0.0.1` and
+  `::1` are reachable.
+- **Is inherited by all child processes** spawned from a sandboxed
+  Bash call. Detaching / unref'ing doesn't escape it.
+
+Duo's entire agent-side bridge runs on a single Unix domain socket at
+`~/Library/Application Support/duo/duo.sock`. Every `duo` CLI command
+opens a fresh `net.createConnection(SOCKET_PATH)`. In a sandboxed
+Claude Code session this means **every** `duo` call fails — and it
+fails silently enough that Claude sees one failed Bash call, keeps
+following the skill's instructions, and the user is left debugging
+without any signal pointing at the sandbox as the culprit.
+
+This is the same shape of problem that hit `pasky/chrome-cdp-skill`:
+page-level CDP operations broke under Claude Code's sandbox while
+list/window operations (which happen to be plain HTTP GETs against
+`localhost:9222/json/list`) still worked. The
+`dudgeon/chrome-cdp-skill` fork's fix is a per-tab detached daemon
+listening on `127.0.0.1:<random-port>` with an NDJSON + auth-token
+protocol — localhost TCP passes the sandbox's network filter. See
+that repo's `skills/chrome-cdp/scripts/cdp.mjs` lines 555–679 for the
+reference implementation (TCP listener, token file, CLI reconnect).
+
+**Impact inventory** (2026-04-23 audit of current tree):
+
+| Operation | File:line | Sandbox verdict |
+|---|---|---|
+| Every `duo` command (navigate, url, title, dom, text, ax, click, fill, focus, type, key, eval, screenshot, console, tabs, tab, close, wait, open) | `cli/duo.ts:29` — `net.createConnection(SOCKET_PATH)` | ❌ **All fail** — Unix socket blocked without explicit opt-in |
+| `fs.existsSync(SOCKET_PATH)` pre-connect check | `cli/duo.ts:24` | ✅ Reads outside cwd allowed |
+| `duo install` symlink creation | `cli/duo.ts:266–272` — `/usr/local/bin/duo`, falls back to `~/.local/bin/duo` | ❌ Both paths write outside cwd |
+| `duo screenshot --out <path>` | `cli/duo.ts:195` | ⚠️ Only if `<path>` resolves outside cwd |
+| `duo open <relative/path>` resolution | `cli/duo.ts:237–257` | ✅ Pure reads; only the socket hop matters |
+| First-launch installer → `~/.claude/skills/duo/` | `scripts/postinstall.ts` | ✅ `~/.claude/` is writable per docs |
+| Skill discovery scanning `~/.claude/skills/` | `electron/skills-scanner.ts` | ✅ Runs in unsandboxed Electron main process |
+
+The Electron side (socket creation, chmod, bind, listen in
+`electron/socket-server.ts`) is unaffected: the user's Electron app
+runs outside the Claude Code sandbox. The failure surface is entirely
+on the CLI side — what `claude` shells out to from inside a Duo
+terminal.
+
+A note on the existing "Decisions made during build → Socket path:
+`~/Library/Application Support/duo/` not `/tmp`" entry above: that
+choice is still correct (persistence across reboots, macOS convention)
+but the "sandbox-safe" framing overstated the case. The path is
+*read-reachable* from inside the Claude Code sandbox, but the **Unix
+socket connection itself is not** on default policy. This ADR
+clarifies and supersedes that framing.
+
+**Proposed direction.**
+
+1. **TCP fallback alongside the Unix socket.** In
+   `electron/socket-server.ts`, additionally
+   `server.listen(0, '127.0.0.1')` (ephemeral port; Electron owns
+   both listeners). Write the chosen port and a per-install auth
+   token to `~/Library/Application Support/duo/duo.port` — a small
+   JSON file the sandboxed CLI can *read* (reads outside cwd are
+   allowed). In `cli/duo.ts`, try the Unix socket first; on `EPERM`
+   / `ECONNREFUSED` / connect timeout, read the port file and
+   reconnect over TCP, sending the token as the first NDJSON line
+   of the handshake. Keeps the fast path, heals sandboxed runs
+   transparently. ~100 LoC change; mirrors the chrome-cdp-skill
+   pattern.
+
+2. **`duo doctor` diagnostic.** A new CLI verb that reports, in
+   order: Electron app reachable via Unix socket? via TCP
+   fallback? install path writable? `~/.claude/skills/duo/` present
+   and current? `duo --version` vs. Electron app version? Prints a
+   clear "Claude Code sandbox detected (Unix socket blocked) —
+   falling back to TCP" line when the fallback kicks in. The skill
+   instructs the agent to run `duo doctor` on the first failed
+   command so the sandbox failure mode is named, not inferred.
+
+3. **Sandbox-safe install path.** Change `duo install` to prefer
+   `~/.claude/bin/duo` (the `~/.claude/` tree is writable under
+   Claude Code's sandbox), fall back to `~/.local/bin/duo`, and
+   only touch `/usr/local/bin/duo` on explicit opt-in. Emit a
+   one-line `export PATH=…` fragment for the user's rc after a
+   successful install.
+
+4. **Ship a recommended Claude Code settings fragment.** In
+   `skill/SKILL.md`, add a "Troubleshooting → Claude Code sandbox"
+   section with a copy-pasteable `.claude/settings.json` allowlist
+   (socket path read-allowed + `allowUnixSockets: true`) for teams
+   who prefer the Unix-socket fast path. The CLI's TCP fallback
+   means nobody *needs* this, but it documents the minimum
+   allowlist for sandbox-conscious reviewers.
+
+5. **Last-resort escape hatch.** `dangerouslyDisableSandbox` is
+   surfaced as a Bash tool parameter in some Claude Code builds but
+   disabled outright in managed enterprise settings
+   (`allowUnsandboxedCommands: false`). We mention it in the skill's
+   troubleshooting section as a manual option, do not rely on it.
+
+**Rejected alternatives.**
+
+- **File-based IPC (request/response files in cwd).** Would work
+  under the sandbox's cwd-scoped writes, but the Electron app does
+  not know which PTY CWDs to watch, and each Duo tab has an
+  independent launch CWD. Adds state explosion for no win over TCP.
+- **Named pipes / FIFOs.** Same sandbox class as Unix sockets; no
+  advantage.
+- **Daemon-per-tab like chrome-cdp-skill.** Duo already owns one
+  long-lived Electron process; per-tab daemons solve a problem
+  (Chrome "Allow debugging" modal) that doesn't exist here.
+- **Ship the CLI as a native-compiled binary with a different
+  sandbox surface.** Doesn't change Seatbelt's behavior — the
+  sandbox wraps the process, not the binary.
+
+**Cross-references into the roadmap:**
+- **Stage 5 (skill + subagent authoring, ✅ shipped)** picks up a
+  new doc item: "Troubleshooting → Claude Code sandbox" section in
+  `skill/SKILL.md` + `agents/duo-browser.md`. Cheap, can land
+  immediately.
+- **Stage 13 (interaction polish, ⬜)** picks up the TCP fallback
+  and `duo doctor` work items.
+- **Stage 14 (polish & distribution, ⬜)** picks up the install-path
+  cleanup and the bundled settings fragment.
+
+**Decision owner:** Geoff.


### PR DESCRIPTION
## Summary

Claude Code's macOS Seatbelt sandbox blocks Unix-domain-socket outbound connections by default (gated behind explicit `allowUnixSockets: true`) but permits localhost TCP. Duo's only agent-side bridge is a Unix socket at `~/Library/Application Support/duo/duo.sock` — so every `duo` command silently fails inside a sandboxed Claude Code session.

This PR is planful, roadmap-aligned documentation only. No code changes. It lays the groundwork for the transport + install fixes that will land in Stages 13 and 14.

## What's in here

- **`docs/DECISIONS.md`** — new Open ADR *Sandbox-tolerant transport and install paths for the `duo` CLI*. Full impact inventory (every `duo` command blocked; `duo install` and `duo screenshot --out` write-blocked outside cwd), the `dudgeon/chrome-cdp-skill` precedent (localhost TCP + auth-token file, with file:line references into `cdp.mjs`), five proposed next steps, and rejected alternatives (file-based IPC, FIFOs, per-tab daemons, native binary).
- **`ROADMAP.md`** — cross-referenced items placed where the work logically lives:
  - Stage 5 — skill-docs troubleshooting section (cheap; can land before the flagship pair)
  - Stage 13 — TCP fallback + `duo doctor` (transport work lives with CLI affordances)
  - Stage 14 — install-path cleanup + bundled settings fragment (lives with distribution polish)
  - Open Questions table — one row pointing at the ADR with the stages it touches
- **`CLAUDE.md`** — new "Claude Code sandbox" section pointing future agents at the ADR before they touch transport / install / CLI file-I/O code.

## Direction (for review, not decided)

1. TCP fallback alongside the Unix socket; ephemeral port + token published to `duo.port`; CLI falls back on `EPERM`/`ECONNREFUSED`/timeout.
2. `duo doctor` diagnostic that names the sandbox failure mode instead of leaving it inferred.
3. Prefer `~/.claude/bin/duo` as the install target (writable under the sandbox); fall back to `~/.local/bin/duo`; `/usr/local/bin/duo` on explicit opt-in only.
4. Bundle a `.claude/settings.json` allowlist fragment in the skill for teams that prefer the Unix-socket fast path.
5. Mention `dangerouslyDisableSandbox` as a last-resort manual escape (not relied on — many enterprise installs disable it).

Decision owner: Geoff.

## Test plan

Docs-only PR. Sanity-check items:

- [ ] ADR reads cleanly and is honest about what is *proposed* vs. *decided*
- [ ] Impact inventory file:line references resolve in the current tree
- [ ] Roadmap items cross-reference the ADR in both directions
- [ ] `CLAUDE.md` section is prescriptive enough that a future agent doesn't silently route around the sandbox

https://claude.ai/code/session_01BeqSngoUR2bXzPVNfm9bzv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeqSngoUR2bXzPVNfm9bzv)_