### PR TITLE
docs(skill): name the Claude Code sandbox failure mode for agents

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -207,7 +207,7 @@ to the agent running in the active terminal tab.
 - [ ] Version pinning: skill asserts `duo --version` is in a compatible range
 - [ ] First-launch installer (copies `skill/` + `agents/` into `~/.claude/`) — currently manual. Stage 6.
 - [ ] **Open ADR: skill scoping** — global `~/.claude/skills/duo/` vs. Duo-session-only (`docs/DECISIONS.md` → Open ADRs). Changes the first-launch install step if we pick per-session.
-- [ ] **Skill docs: Claude Code sandbox troubleshooting section** — add a block to `skill/SKILL.md` (and the mirror guidance in `agents/duo-browser.md`) that names the sandbox failure mode (every `duo` command silently fails because Unix sockets are blocked by default), tells the agent to run `duo doctor` on the first failure, and documents the minimum `.claude/settings.json` allowlist for teams that prefer the Unix-socket fast path. See `docs/DECISIONS.md` → Open ADRs → *Sandbox-tolerant transport and install paths for the `duo` CLI*. Cheap; can land before Stages 9–11.
+- [x] **Skill docs: Claude Code sandbox troubleshooting section** — `skill/SKILL.md` now carries a "Troubleshooting: Claude Code sandbox" block (failure signatures, `duo doctor` as first move, the recommended `allowUnixSockets: true` + socket-read allowlist, `dangerouslyDisableSandbox` called out as last resort). `agents/duo-browser.md` mirrors the short version in its "Diagnosing failures" section. See `docs/DECISIONS.md` → Open ADRs → *Sandbox-tolerant transport and install paths for the `duo` CLI*.
 
 ---
 

--- a/agents/duo-browser.md
+++ b/agents/duo-browser.md
@@ -223,6 +223,37 @@ If a selector silently fails, confirm it actually exists first:
 duo eval "!!document.querySelector('YOUR_SELECTOR')"
 ```
 
+### When every `duo` call fails — suspect the Claude Code sandbox
+
+Claude Code runs each Bash tool call inside a macOS Seatbelt sandbox
+whose default policy blocks Unix-domain-socket outbound connections.
+Duo's CLI talks to the Electron app over a Unix socket at
+`~/Library/Application Support/duo/duo.sock`, so under the default
+policy every `duo` command fails the same way — even though the Duo
+app is running. Tell-tale shapes:
+
+- `Socket error: connect EPERM …`
+- `Socket error: connect ECONNREFUSED …`
+- Hang ending in `Timeout waiting for response to "<cmd>"`
+
+**First move:** run `duo doctor` and surface the result. When the
+sandbox is the cause it prints
+`Claude Code sandbox detected (Unix socket blocked) — falling back
+to TCP`; once that line is in the output, proceed normally.
+
+**If `duo doctor` isn't recognized,** stop — do not retry. Return
+one sentence to the parent: the Claude Code sandbox is blocking the
+Unix socket; the user can either add
+`{ "permissions": { "allowUnixSockets": true, "allow":
+["Read(~/Library/Application Support/duo/**)"] } }` to
+`.claude/settings.json` and restart the session, or wait for the
+TCP fallback shipped in Stage 13. The skill's
+"Troubleshooting: Claude Code sandbox" section has the full
+diagnostic and rationale if they ask.
+
+Do not grind through retries — under the sandbox the failure is a
+policy denial, not a transient error.
+
 ## Returning results to the parent
 
 - **Read tasks** → return the extracted content or a summary of it.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -37,8 +37,13 @@ or when you're doing a single simple call.
 duo --version
 ```
 
-If this fails with "Cannot connect", the Duo app is not running. Ask the user
-to launch it before retrying.
+If this fails with `Cannot connect: Duo app is not running`, the app is
+closed — ask the user to launch it and retry. If it fails with any
+other shape — `Socket error: connect EPERM`, `ECONNREFUSED`, a hang
+that ends in `Timeout waiting for response`, or every subsequent `duo`
+call failing the same way — jump to
+[Troubleshooting: Claude Code sandbox](#troubleshooting-claude-code-sandbox)
+below. Do not retry blindly.
 
 ## Command reference
 
@@ -345,6 +350,76 @@ When a selector fails:
    switch to `duo ax`.
 5. Retry transient navigation/timing errors up to three times before
    declaring the operation impossible.
+
+## Troubleshooting: Claude Code sandbox
+
+Claude Code runs each Bash tool call inside a macOS Seatbelt sandbox.
+The default policy **blocks Unix-domain-socket outbound connections**
+— and Duo's CLI talks to the Electron app over a Unix socket at
+`~/Library/Application Support/duo/duo.sock`. Result: inside a
+sandboxed Claude Code session, every `duo` command can fail the same
+way, even though the Duo app is running and the socket file exists.
+
+**Failure shapes that point at the sandbox** (not at the app):
+
+- `Socket error: connect EPERM …` (the usual signature)
+- `Socket error: connect ECONNREFUSED …`
+- A hang that ends in `Timeout waiting for response to "<cmd>"`
+- `duo --version` works but everything else fails — *doesn't happen*
+  here; if `--version` works, so does the rest
+
+**First move on any sandbox-shaped failure:**
+
+```bash
+duo doctor
+```
+
+`duo doctor` reports socket reachability, the TCP-fallback status,
+install-path health, and whether `~/.claude/skills/duo/` is in sync.
+When the sandbox is the cause it prints a line like
+`Claude Code sandbox detected (Unix socket blocked) — falling back to
+TCP`; once that's in the output you can proceed normally.
+
+If `duo doctor` is not recognized on this machine, the fallback isn't
+shipped yet — stop, tell the user "every `duo` call is failing; I
+think the Claude Code sandbox is blocking the Unix socket", and offer
+the two fixes below. Do not retry in a loop.
+
+### Fix 1 (recommended): allow the Unix socket in project settings
+
+Add this to the project's `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allowUnixSockets": true,
+    "allow": [
+      "Read(~/Library/Application Support/duo/**)"
+    ]
+  }
+}
+```
+
+The user then restarts their Claude Code session for the new policy
+to take effect. Caveat: the Claude Code docs warn that
+`allowUnixSockets` "can inadvertently grant access to powerful system
+services" (e.g. the Docker socket). Teams with a stricter posture
+should wait for the Stage 13 TCP fallback rather than widen the
+socket allowlist.
+
+### Fix 2 (last resort): per-call sandbox escape
+
+Some Claude Code builds expose a `dangerouslyDisableSandbox`
+parameter on the Bash tool. Managed enterprise installs disable it
+(`allowUnsandboxedCommands: false`), so do **not** rely on it — only
+mention it to the user if Fix 1 is blocked by policy.
+
+### Why not "just keep trying"
+
+Under the sandbox the failure is a policy denial, not a flaky
+connection. Retrying burns tokens, confuses the user, and masks the
+real cause. The rule: **on the first unrecognized `duo` error, run
+`duo doctor` and surface the result — don't guess.**
 
 ## The canvas-text trap (why `ax` exists)
 


### PR DESCRIPTION
## Summary

Picks up the Stage 5 follow-up marked "cheap; can land before Stages 9–11" in `ROADMAP.md`: teach agents to recognize and surface the Claude Code sandbox failure mode instead of grinding through retries when every `duo` call fails under the default Seatbelt policy.

- `skill/SKILL.md` gains a **Troubleshooting: Claude Code sandbox** section: failure signatures (`EPERM` / `ECONNREFUSED` / timeout), `duo doctor` as the first move, a copy-pasteable `.claude/settings.json` allowlist (`allowUnixSockets: true` + read of the socket path), and `dangerouslyDisableSandbox` called out as the last-resort escape hatch rather than a recommendation.
- The existing **Sanity check** block now points to the new section for any non–"app not running" error shape.
- `agents/duo-browser.md` mirrors the short version inside its **Diagnosing failures** section — same failure signatures, same `duo doctor` first move, condensed fix guidance for stopping cleanly and returning one sentence to the parent.
- ROADMAP.md ticks the Stage 5 "Skill docs: Claude Code sandbox troubleshooting section" box and records what landed.

Cross-references the open ADR: [Sandbox-tolerant transport and install paths for the `duo` CLI](../blob/main/docs/DECISIONS.md). The transport + install work still belongs to Stages 13/14; this PR is just the skill/subagent half.

## Test plan

- [ ] Re-read the rendered **Troubleshooting: Claude Code sandbox** section in `skill/SKILL.md` for tone + accuracy.
- [ ] Re-read the mirrored block in `agents/duo-browser.md` — verify it's terse enough for a subagent that should return outcomes, not transcripts.
- [ ] `npm run sync:claude` (already run locally) — confirm `~/.claude/skills/duo/SKILL.md` and `~/.claude/agents/duo-browser.md` carry the new sections.
- [ ] Spot-check that `duo --version`'s "Cannot connect: Duo app is not running" path is still captured by the Sanity check (only the *other* failure shapes get redirected to the new section).

https://claude.ai/code/session_017WkEoQmopXLJCyq5qP9M5g

---
_Generated by [Claude Code](https://claude.ai/code/session_017WkEoQmopXLJCyq5qP9M5g)_