### PR TITLE
docs: Chrome extension exploration roadmap + cross-references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,14 @@ Owner: Geoff (Capital One, AI in Product program).
 - **`docs/design/atelier/`** — visual source-of-truth. Read its
   README before any UI-touching work.
 - **`docs/VISION.md`** — product north star.
+- **`docs/research/duo-as-chrome-extension/build-roadmap.md`** —
+  Chrome-extension exploration roadmap (Stages A–H), lives on
+  branch `duo-chrome-extension-exploration`. **Non-gating** — does
+  not block any main-roadmap stage. **Stage A** is a no-regrets
+  refactor (services to `core/`, EventSink, `host-api.ts` split)
+  that's a merge candidate back to `main` once smoke-walked. The
+  `phase0/` prototype directory is exploration-only; not in the
+  Electron build pipeline.
 
 ## Architecture in one paragraph
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,16 @@
 > [CLI-COVERAGE.md](docs/CLI-COVERAGE.md) (CLI verb inventory) ·
 > [docs/design/atelier/](docs/design/atelier/) (visual design bundle) ·
 > [docs/prd/](docs/prd/) (per-stage PRDs).
+>
+> **Chrome-extension exploration is a separate, non-gating roadmap.**
+> Lives on branch `duo-chrome-extension-exploration`; tracked in
+> [docs/research/duo-as-chrome-extension/build-roadmap.md](docs/research/duo-as-chrome-extension/build-roadmap.md)
+> as Stages A–H. None of those stages gate any stage on this main
+> roadmap. **Stage A** (services extracted from `electron/` to
+> `core/`, EventSink adapter, `shared/host-api.ts` split) is a
+> no-regrets refactor that benefits both targets and is a merge
+> candidate back to `main` once smoke-walked. The `phase0/` prototype
+> directory is exploration-only — not in the Electron build pipeline.
 
 ---
 

--- a/docs/research/duo-as-chrome-extension/README.md
+++ b/docs/research/duo-as-chrome-extension/README.md
@@ -1,0 +1,606 @@
+# Duo-as-Chrome-extension exploration — research project
+
+**Status:** Proposed 2026-04-29. **Pre-walk feasibility analysis** — no
+prototype built yet. This document scopes a walking skeleton and
+makes a preliminary call on whether to actually walk it.
+
+**Sibling research:** [`../duo-in-browser/README.md`](../duo-in-browser/README.md)
+explored a related-but-distinct shape (Duo as a local web app served
+from a Node daemon, viewed in a normal browser tab). That one was
+walked and shelved. The Chrome-extension variant differs along three
+axes (rendering surface, transport, ability to drive other tabs)
+significant enough to warrant its own analysis.
+
+---
+
+## TL;DR
+
+The shape under test: **Duo ships as a Chrome extension + a local
+helper daemon, with no Electron app at all.** The extension's side
+panel hosts the file navigator and terminal; canvas surfaces (markdown
++ HTML) live in regular browser tabs the extension opens; agents drive
+the user's *real* Chrome tabs via `chrome.debugger`, eliminating the
+embedded-browser problem entirely.
+
+**Three blocking-class facts** before any code is written:
+
+1. **Side panel minimum width is 360px**, fixed by Chrome, not
+   adjustable by the extension. Users can drag wider but it doesn't
+   persist across sessions ([chromium issue 40926440](https://issues.chromium.org/issues/40926440)).
+   A 360px column hosting both a file tree (~280–320px feels right)
+   AND a terminal (xterm at 360px is roughly 50 columns of monospace —
+   tight for any real code) is structurally cramped. Stacking
+   vertically inside that 360px works but gives each surface ~half
+   the screen height.
+2. **A local helper daemon is unavoidable.** Chrome extensions cannot
+   spawn PTYs, watch arbitrary filesystem paths, or own long-lived
+   processes. The terminal pane needs `node-pty` running outside the
+   browser. Communication path: extension service worker
+   ↔ Native Messaging stdio ↔ Node helper. This is well-supported
+   ([chrome.runtime.connectNative](https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging))
+   and bidirectional in MV3.
+3. **The MV3 service worker idle / native-host death problem is a
+   real, documented papercut.** Anthropic's *own* Claude Code browser
+   extension hit exactly this:
+   [anthropics/claude-code#16350](https://github.com/anthropics/claude-code/issues/16350)
+   — "the MV3 service worker appears to go idle, which closes the
+   native messaging port and terminates the native host." The 30-second
+   idle timeout is mitigable with keep-alive traffic (extension API
+   calls and active WebSocket / Native Messaging port traffic both
+   reset the timer per
+   [the lifecycle docs](https://developer.chrome.com/docs/extensions/develop/concepts/service-workers/lifecycle)),
+   but the mitigation is constant ambient effort, and a single 5-minute
+   blocking handler still gets killed regardless.
+
+**Preliminary call:** **Worth a walking skeleton, with a tight scope.**
+The architecture has at least three forks where a 30-minute experiment
+collapses an unknown into a fact (SW lifetime under realistic idle,
+side-panel ergonomics at 360px, distribution friction of the
+extension + helper pair). Pre-committing to the full re-platform on
+desk research alone would be irresponsible; refusing to walk it
+because it *might* not work would skip past leverage that's already
+visible (no embedded-browser headache, native session capture in the
+user's real Chrome, no notarization gauntlet for the renderer surface).
+
+The "embedded browser" question the user raised — *can the right pane
+hold a browser tab without inception?* — has a clean answer. **No
+inception needed.** The extension drives the user's existing Chrome
+tabs via `chrome.debugger`; there's no embedded right-pane browser to
+recreate. The right pane goes away in this shape. See § Surface map.
+
+---
+
+## Why explore this in the first place
+
+Three forces compound:
+
+1. **The Electron build carries weight that an extension wouldn't.**
+   Notarization, code signing, auto-update, DMG distribution, app
+   bundle ID gymnastics — every release of the Duo Electron app has to
+   go through this gauntlet ([Stage 21 cert procurement](../../dev/cert-procurement.md)
+   exists for a reason). A Chrome extension distributes through the
+   Web Store with a single signed package and has zero macOS
+   notarization surface. This is the strongest "obvious win" on offer.
+2. **The user's authenticated browser session is right there.**
+   Walk 4 of [`../duo-in-browser/README.md`](../duo-in-browser/README.md)
+   already proved that an agent driving the user's real Chrome via
+   CDP-over-TCP captures the user's full SaaS session surface. A
+   Chrome extension makes this even cleaner — no separate Chrome
+   instance, no `--remote-debugging-port` flag, no separate user-data-dir.
+   `chrome.debugger.attach({tabId})` and you're driving the tab the
+   user is currently logged into.
+3. **The renderer code is mostly portable.** `duo-in-browser` proved
+   the `window.electron` shim approach (D1 in that exploration's
+   design doc) lets every component under
+   [`renderer/components/`](../../../renderer/components/) host
+   verbatim if the shim forwards calls to a daemon. The same trick
+   transposes to an extension: the shim forwards over
+   `chrome.runtime.connect` ports to the service worker, which
+   forwards over Native Messaging to the helper. Same renderer code,
+   different transport.
+
+These do not yet demonstrate that the extension shape is *better*
+than the Electron shape — only that it might be cheaper to maintain
+and might unlock the user's session surface natively. Walking
+skeleton needs to test whether the cost of MV3 service-worker
+ergonomics outweighs those wins.
+
+---
+
+## Surface map
+
+The user's question — "side panel hosts navigator + terminal, right
+pane hosts canvas + browser, can we sub-tab the canvases, do we get
+browser-tab inception?" — translates surface-by-surface as follows.
+
+```
+┌──────────────────────── Chrome window (the user's actual Chrome) ─────────────────────┐
+│                                                                                        │
+│  ┌─ regular tabs ──────────────┐  ┌─ canvas tab #1 ─┐  ┌─ canvas tab #2 ─┐  ┌─ … ─┐  │
+│  │ gmail, jira, docs, etc.     │  │ foo.md          │  │ deck.html       │  │     │  │
+│  │ ← extension drives these    │  │ MarkdownEditor  │  │ HtmlCanvas      │  │     │  │
+│  │   via chrome.debugger        │  │ (full surface)  │  │ (full surface)  │  │     │  │
+│  └──────────────────────────────┘  └─────────────────┘  └─────────────────┘  └─────┘  │
+│                                                                                        │
+│  ┌──────────── side panel (360px min, attached to right edge) ──────────────────────┐ │
+│  │ [📁]                                                                              │ │
+│  │ [⚙ ]   ← 32px icon rail (always visible)                                         │ │
+│  │ [ ]                                                                               │ │
+│  │ [ ]    [ TerminalPane                                                            ]│ │
+│  │ [ ]    [   xterm at ~44 columns wide (full width minus rail)                     ]│ │
+│  │ [ ]    [   click 📁 or press ⌘+B → drawer slides in over terminal                ]│ │
+│  │ [ ]    [                                                                         ]│ │
+│  │                                                                                   │ │
+│  │   ┌─ NavDrawer (overlays terminal when open) ─┐                                  │ │
+│  │   │  FileTree                                  │                                 │ │
+│  │   │   project files, click → opens in new tab  │                                 │ │
+│  │   │   click outside / Esc / file click → close │                                 │ │
+│  │   └────────────────────────────────────────────┘                                 │ │
+│  └───────────────────────────────────────────────────────────────────────────────────┘ │
+│                                                                                        │
+└────────────────────────────────────────────────────────────────────────────────────────┘
+                                          ▲
+                          chrome.runtime.connect (port)
+                                          │
+                                  ┌───────┴────────┐
+                                  │ service worker │  ← extension SW (ephemeral, 30s idle)
+                                  └───────┬────────┘
+                                          │
+                                Native Messaging (stdio JSON)
+                                          │
+                                  ┌───────┴────────┐
+                                  │  Node helper   │  ← long-lived only while SW alive
+                                  │  · node-pty    │
+                                  │  · chokidar    │
+                                  │  · fs r/w      │
+                                  └────────────────┘
+```
+
+### Side panel: terminal first, navigator on demand
+
+- **Width: 360px minimum, Chrome-imposed.** Confirmed:
+  [chrome.sidePanel docs](https://developer.chrome.com/docs/extensions/reference/api/sidePanel)
+  and the [chromium tracker](https://issues.chromium.org/issues/40926440).
+  The extension cannot set a custom min/max. Users drag, doesn't
+  persist.
+- **The default state is terminal-only.** A 32px icon rail on the
+  leading edge stays put; the rest of the panel (~328px ≈ ~44
+  columns of monospace) is the terminal. That's still tight for
+  `git diff`, but enough for the agent's command surface and for
+  reading short outputs.
+- **The navigator is a hover drawer**, not a stacked top half.
+  Click the folder icon on the rail (or press ⌘+B) → a 280px
+  filetree drawer slides in `position: absolute` over the terminal,
+  200ms ease, with a backdrop blur so the terminal stays partially
+  visible. Click outside / Esc / file click → drawer collapses.
+  This buys back the terminal's full real estate at default and
+  accepts a one-click cost when the user wants to navigate.
+- The drawer pattern is tracked as **D3** in
+  [`./mvp-plan.md`](./mvp-plan.md).
+  [`renderer/components/FileTree.tsx`](../../../renderer/components/FileTree.tsx)
+  hosts inside the drawer with no behavioral changes.
+- **Stretching wider stays available** — the user can still drag the
+  panel out for a session (lost on restart). Document the gesture;
+  the hover drawer makes it less load-bearing than it would be
+  otherwise.
+- **One terminal at a time** in MVP. Multi-PTY tab strip is deferred
+  (see `mvp-plan.md` D7).
+
+### Canvas surfaces: tabs, not sub-tabs
+
+- **Each canvas opens in its own Chrome tab.** `duo edit foo.md` →
+  `chrome.tabs.create({url: chrome.runtime.getURL('canvas.html?path=foo.md')})`.
+  Each tab hosts a full-bleed copy of either
+  [`renderer/components/editor/MarkdownEditor.tsx`](../../../renderer/components/editor/)
+  or [`renderer/components/HtmlCanvas/`](../../../renderer/components/HtmlCanvas/),
+  same renderer code as today, talking to the SW over a port.
+- **The user gets native tab affordances for free** — Chrome's tab
+  strip, ⌘+1/2/3 navigation, drag-to-reorder, drag-out-to-new-window,
+  right-click pin. No need to build any of this.
+- **Sub-tabs inside a single canvas tab are not necessary.** The user
+  asked about it; the answer is the canvas-per-tab model gives the
+  same affordance with less complexity.
+- **State coordination:** the tree view and the open canvas tabs all
+  hit the helper daemon for file I/O. The daemon is the single source
+  of truth. Tabs subscribe to file-change events through the SW.
+
+### Browser surface: no inception, no embedded browser
+
+- **The right pane goes away.** The user's regular Chrome tabs
+  *are* the browser surface. The agent drives them through
+  Chrome's existing tab APIs and, where needed, the in-process CDP
+  gateway exposed to extensions.
+- **No `WebContentsView` to replicate.** Today's
+  [`electron/browser-manager.ts`](../../../electron/browser-manager.ts)
+  + [`electron/cdp-bridge.ts`](../../../electron/cdp-bridge.ts) become
+  unnecessary in this shape.
+
+#### Control mechanism: still CDP at the protocol layer, not at the transport layer
+
+A clarification worth saying out loud: even with no embedded browser
+of our own, agents *still* drive Chrome tabs via the Chrome DevTools
+Protocol — but the *transport* changes materially.
+
+- **Protocol layer — still CDP.** `Page.navigate`,
+  `Page.captureScreenshot`, `Runtime.evaluate`,
+  `Accessibility.getFullAXTree`, `Input.dispatchKeyEvent` — same
+  command surface
+  [`electron/cdp-bridge.ts`](../../../electron/cdp-bridge.ts) drives
+  today. The skill ports almost line-for-line.
+- **Transport layer — `chrome.debugger.attach({tabId})`, not
+  `--remote-debugging-port`.** This is Chrome's *internal* CDP
+  gateway, exposed to extensions that hold the `debugger`
+  permission ([API ref](https://developer.chrome.com/docs/extensions/reference/api/debugger)).
+  No TCP port flag, no separate Chrome instance, no user-data-dir
+  gymnastics, no Seatbelt sandbox crossing. Chrome routes the
+  protocol in-process. **Materially better than the
+  CDP-over-TCP path** that
+  [`../duo-in-browser/README.md` Walk 4](../duo-in-browser/README.md)
+  validated; the recommended-next-step "fork chrome-cdp-skill, swap
+  Unix sockets for TCP+token" becomes *unnecessary* in this shape —
+  the extension *is* the bridge.
+- **The yellow infobar UX papercut.** Whenever an extension calls
+  `chrome.debugger.attach`, Chrome displays a non-dismissable yellow
+  banner across the top of the affected tab: *"Duo started debugging
+  this browser. Cancel"*. Extensions cannot suppress it. The user
+  can click Cancel and force-detach. For agent workflows running
+  ambient in the background, this is a constant visual reminder and
+  a one-click kill switch a user might hit by accident. Tolerable
+  for some workflows, painful for others.
+- **One MV3 caveat:** "Service workers may terminate after the tab
+  is created, breaking debugger.attach" — same SW-lifetime problem
+  applies to debugger sessions. Keep-alive matters here too. Also,
+  Chrome auto-detaches the debugger when the user opens DevTools on
+  the same tab.
+
+#### Hybrid: use the lighter APIs first, attach the debugger only when CDP is genuinely needed
+
+Not every operation requires the full CDP surface. The cleanest
+design is to route through `chrome.tabs` / `chrome.scripting` for
+the common case (no yellow banner) and only attach the debugger
+when we need a CDP-only capability:
+
+| Operation | `chrome.debugger` (yellow banner) | Lighter API (no banner) |
+|---|---|---|
+| Screenshot | `Page.captureScreenshot` | `chrome.tabs.captureVisibleTab` |
+| Click / fill form | `Input.dispatchMouseEvent` | `chrome.scripting.executeScript` |
+| Read DOM text | `Runtime.evaluate` | `chrome.scripting.executeScript` |
+| Navigate | `Page.navigate` | `chrome.tabs.update({url})` |
+| Read page URL / title | `Target.getTargetInfo` | `chrome.tabs.get(tabId)` |
+| AX tree | `Accessibility.getFullAXTree` | *(no equivalent — needs CDP)* |
+| Network capture | `Network.*` | *(no equivalent — needs CDP)* |
+| Console / errors | `Runtime.consoleAPICalled` | *(no equivalent — needs CDP)* |
+| Long-lived CDP session | needed | n/a |
+
+Implication: the agent-facing CLI verbs that map cleanly onto
+lighter APIs (`duo navigate`, `duo click`, `duo type`,
+`duo screenshot`, `duo url`, `duo title`) run debugger-banner-free.
+Verbs that need CDP-only surfaces (`duo ax`, `duo network`,
+`duo console`, `duo errors`) attach the debugger explicitly,
+banner appears for the duration. Document this asymmetry in the
+agent help and CLI verbs themselves so the user-facing surface
+makes the trade-off legible.
+
+---
+
+## One coordinator per profile
+
+Chrome MV3 gives the extension exactly **one service worker per
+Chrome profile**. That singleton is the architectural pivot for the
+whole shape: every UI surface (each side panel in each window, each
+canvas tab) is a client of the same SW, and the SW holds the only
+Native Messaging port to the only helper process.
+
+```
+              ┌──────────── service worker (singleton per profile) ──────────────┐
+              │   ↑ connectNative once → one helper process                       │
+              │   ↑ port routing, file watches, dirty-buffer registry             │
+              └──────────────────┬─────────────────────┬─────────────────┬────────┘
+                       chrome.runtime.connect (many)
+                                 │                     │                 │
+                  ┌──────────────┴────┐    ┌───────────┴─────┐    ┌──────┴───────┐
+                  │ side panel        │    │ canvas tab #1   │    │ canvas tab #2│
+                  │ (one per window)  │    │ foo.md          │    │ deck.html    │
+                  └───────────────────┘    └─────────────────┘    └──────────────┘
+```
+
+What this gets us — and what it doesn't:
+
+- **One helper, one coordinator.** No N-way fan-out at the helper.
+  The helper sees a single port from the SW and dispatches PTY data,
+  file I/O, and watch events through it. The SW splits messages out
+  to whichever UI surface owns each PTY session / file path.
+- **Multi-window is free.** Two Chrome windows → two side panels,
+  same SW, same helper. File tree state stays consistent because
+  it's read from the helper, not held per-window.
+- **Two tabs of the same file is solved by the helper, not by the
+  tabs.** Both `canvas.html?path=foo.md` documents subscribe to the
+  same file-watch event and read from the same dirty-buffer record.
+  No different in shape from how Electron *would* handle it if we
+  ever allowed multi-window — single source of truth lives below the
+  UI layer.
+- **Same-origin pubsub for UI-only sync.** All extension pages
+  (side panel + canvas tabs) share an origin
+  (`chrome-extension://<id>/`), so a `BroadcastChannel` lets them
+  push lightweight UI events (focus, theme changes, "the user is
+  typing in tab N") directly to each other without round-tripping
+  through the SW. Useful escape hatch for keystroke routing across
+  surfaces — one of the soft blockers above gets cheaper because of
+  this.
+- **One profile is one instance.** A user running work + personal
+  Chrome profiles gets two SWs and two helper processes — fully
+  isolated. This is almost certainly what you want.
+
+Two caveats inherited from MV3:
+
+1. **The SW's in-memory state evaporates on idle.** Any state we'd
+   want to recall on resume has to live in `chrome.storage.local`
+   (persistent, async) or in the helper (the source of truth
+   anyway). Don't store transient session state in SW memory and
+   expect it to be there 60 seconds later.
+2. **The SW is the only thing that can hold the Native Messaging
+   port.** Side panel and canvas tabs cannot `connectNative`
+   themselves — they can only relay through the SW. So when the SW
+   dies, every UI surface's helper-bound traffic is interrupted.
+   This is the structural reason
+   [claude-code#16350](https://github.com/anthropics/claude-code/issues/16350)
+   matters so much: the SW isn't *one of* the coordinators, it's
+   *the* coordinator.
+
+Implication for Phase 0: the keep-alive test isn't just "does the
+helper survive" — it's "does the SW stay warm enough that *every*
+client port the user opens (side panel + N canvas tabs) gets a live
+helper without reconnect dance."
+
+---
+
+## What the walking skeleton tests
+
+Five phases, each ~half-day to one day. Land each one fully before
+proceeding — early phases collapse the highest-uncertainty unknowns.
+
+### Phase 0 — Hello-world Native Messaging + idle survival
+
+**Question:** Does the SW + Native-Messaging-host pair survive a
+realistic user idle pattern (read docs for 30 minutes, come back,
+type into terminal)?
+
+**Build:** Minimal extension with one button "ping helper." Helper
+echoes back. Extension also schedules a `chrome.alarms` keep-alive
+at 25-second intervals (mitigation for the 30s idle timeout).
+
+**Pass criteria:** After 30 minutes of zero user interaction, the
+button still works on first click without re-establishing the port.
+Track: how many times the helper process restarted during the idle
+window. Goal: zero. Failure mode predicted by
+[claude-code#16350](https://github.com/anthropics/claude-code/issues/16350)
+is "helper dies silently after ~30s." Reproduce, then fix.
+
+**Decision:** If keep-alive doesn't keep the helper alive across
+realistic idles, the entire shape is suspect. Stop here.
+
+### Phase 1 — Real PTY in the side panel
+
+**Question:** Does an xterm.js terminal in a 360px side panel with
+real `node-pty` over Native Messaging feel like a terminal?
+
+**Build:** Side panel hosts xterm. Helper spawns shell, pipes
+stdin/stdout through Native Messaging. Re-use
+[`renderer/components/TerminalPane.tsx`](../../../renderer/components/TerminalPane.tsx)
+behind a thin shim.
+
+**Pass criteria:** `vim`, `less`, `htop` render correctly. Resize
+events propagate. Backspace doesn't lag. ⌘+C / ⌘+V work.
+
+**Watch for:** Native Messaging messages are JSON-encoded with a
+4-byte length prefix and capped at 1MB per message
+([docs](https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging)).
+A full-screen `cat` of a 5MB log file generates many small frames —
+fine. A single binary blob > 1MB needs chunking. Document either way.
+
+### Phase 2 — Filetree + canvas-per-tab
+
+**Question:** Does opening a markdown file in a new tab (instead of
+a side-panel-adjacent right pane) feel coherent or disjointed?
+
+**Build:** FileTree above terminal in side panel. Click a `.md` file
+→ extension opens a new tab pointing at the canvas page. Canvas page
+hosts MarkdownEditor, talks to SW over port for file r/w.
+
+**Pass criteria:** Subjective. Edit the file in the canvas tab, see
+the FileTree's "modified" badge update. Save in the canvas tab,
+modify the file from the terminal (`echo foo >> file`), see the
+canvas tab pick up the change.
+
+**Watch for:** The canvas tab has no privileged access to the
+filesystem. All file I/O routes SW → helper. Latency of round-trips
+matters; the editor is currently designed against a synchronous
+shim (Electron IPC is fast). Need to measure.
+
+### Phase 3 — Drive a real Chrome tab via chrome.debugger
+
+**Question:** Can an agent in the side-panel terminal drive the
+user's gmail tab (or any auth'd tab) via chrome.debugger?
+
+**Build:** Add a "drive this tab" picker. CLI verb `duo nav <url>`
+calls `chrome.debugger.attach({tabId}, '1.3')`, sends
+`Page.navigate`, `Page.captureScreenshot`. Returns the screenshot
+to the requesting CLI invocation.
+
+**Pass criteria:** Works against gmail.com on the user's actual
+account. Returns the same kind of full-render screenshot Walk 4 of
+the duo-in-browser exploration produced.
+
+**Watch for:** Chrome auto-detaches the debugger when the user
+opens DevTools on the same tab. Show a banner in the side panel.
+
+### Phase 4 — Distribution dry-run
+
+**Question:** Can a Trailblazer install the extension + helper
+without hand-holding?
+
+**Build:** A README with: "(1) install extension from Web Store, (2)
+download `duo-helper-darwin.pkg`, (3) run installer." Helper
+installer drops a Native Messaging manifest at
+`~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.duo.helper.json`
+pointing at the helper binary, plus the binary itself.
+
+**Pass criteria:** A friend who isn't a developer can complete the
+flow. Compare to "drag Duo.dmg to Applications" — is the friction
+materially higher?
+
+**Watch for:** The Native Messaging manifest's `allowed_origins`
+field has to list the extension ID, which means the manifest is
+generated post-Web-Store-publication. Two-step install. The current
+Electron app installer is one step; extension + helper is two.
+
+---
+
+## Hard blockers, soft blockers, and open questions
+
+### Hard blockers (would kill the shape)
+
+- **Service-worker idle / helper death** ([claude-code#16350](https://github.com/anthropics/claude-code/issues/16350))
+  — if keep-alive can't reliably keep the helper alive across
+  realistic user idle patterns, the architecture is unstable by
+  design. Phase 0 collapses this.
+- **Enterprise extension policies.** Many corporate Chrome deployments
+  block or audit extensions requesting `debugger`, `nativeMessaging`,
+  and `tabs` together — that combination is a credible facsimile of a
+  remote-access trojan from a security-tooling perspective. Audit
+  whether any meaningful Trailblazer audience can install this
+  extension without a permission-policy battle.
+
+### Soft blockers (livable but documented)
+
+- **Side panel 360px minimum.** Terminal is cramped. Detach-to-popup
+  mitigation works but adds UX surface.
+- **No privileged keyboard surface across windows.** The current
+  global-shortcut registry in
+  [`renderer/keyboard/globalShortcuts.ts`](../../../renderer/keyboard/globalShortcuts.ts)
+  fires inside one renderer process. Across multiple Chrome tabs +
+  side panel, the shim has to forward keystrokes through the SW.
+  Possible, but the four-pattern keyboard escape doc in
+  [`CLAUDE.md`](../../../CLAUDE.md) needs a fifth pattern entry.
+- **Native Messaging 1MB per-message ceiling.** Streaming chunked
+  payloads is fine; one-shot large reads need chunking.
+- **Two-step installer.** Web Store listing + helper PKG.
+
+### Open questions
+
+- **Single-user assumption.** The extension is per-Chrome-profile.
+  Users with multiple profiles get N helpers. Acceptable?
+- **Headless mode.** Today the Electron app launches its own window;
+  agent-only "headless" use isn't supported. The extension shape
+  forces the user to have Chrome open. Forcing-function or constraint?
+- **Where does the
+  [`docs/design/atelier/`](../../design/atelier/) visual identity
+  apply?** Chrome's side-panel chrome (header, expand button) is
+  immutable. Atelier owns inside-the-panel; outside is Chrome's.
+- **Auto-update.** Web Store handles extension auto-update. Helper
+  binary needs its own update mechanism — Sparkle? In-app prompt
+  delivered via SW? Easier than Electron's full-bundle update, harder
+  than no-thinking-required.
+
+---
+
+## Why this is *not* a successor to duo-in-browser
+
+[`../duo-in-browser/README.md`](../duo-in-browser/README.md) was about
+"can the renderer run inside a regular browser tab against a daemon."
+It walked, it worked, and the recommendation was *not* to ship it
+because the install dance wasn't materially easier than the Electron
+app and the auth-blocking premise was narrower than expected.
+
+This exploration is shaped differently:
+
+| | duo-in-browser | duo-as-chrome-extension |
+|---|---|---|
+| Renderer | One browser tab → SPA | Side panel + N tabs (one per canvas) |
+| Helper | Standalone daemon, user-launched | Native Messaging host, Chrome-launched |
+| Embedded browser | Removed (D5) | Removed (drives real tabs instead) |
+| Distribution | Daemon binary download | Web Store + helper PKG |
+| Auth surface | Same as Electron (separate tabs in user's Chrome) | The user's actual Chrome tabs, drivable |
+| Notarization | Daemon needs signing | Helper PKG needs signing; renderer doesn't |
+
+The most interesting differentiator: **the extension's right "pane"
+is the user's actual Chrome.** That gets us the auth-pinning win
+that duo-in-browser couldn't deliver, *and* relegates the
+embedded-browser machinery to the trash.
+
+---
+
+## Recommendation
+
+**Walk Phase 0 first.** It's a half-day investment that collapses the
+biggest unknown (does the SW + helper actually survive realistic
+idle?). The MV3 service-worker idle bug is well-attested at
+[claude-code#16350](https://github.com/anthropics/claude-code/issues/16350)
+and the lifecycle docs admit the constraint is real. Either keep-alive
+holds, in which case proceed to Phase 1, or it doesn't, in which case
+the entire shape is structurally fragile and we close out the research
+with a one-paragraph addendum here.
+
+**Do not build any of Phases 1–4 until Phase 0 passes.** Each
+subsequent phase compounds investment on top of the keep-alive bet.
+If Phase 0 fails, Phases 1–4 build on sand.
+
+**Estimated cost to a Phase-0-pass-or-fail signal:** half a day,
+maybe a full day. **Estimated cost to a full walking skeleton through
+Phase 4:** 4–6 days. **Compare to:** Stage 21 (DMG + notarization +
+auto-update) absorbed somewhere north of two weeks across Stages
+21a/c. The extension shape, if it works, retires that ongoing cost
+and replaces it with a Web Store submission + a much smaller helper-
+binary-update problem. The arithmetic is favorable *if and only if*
+Phase 0 passes.
+
+**Out of scope for now (don't build until the question is asked):**
+keystroke-routing across windows, multi-terminal tab strip in the
+side panel, theme synchronization across tabs, SSO-pinned-EDR
+empirical test (same as duo-in-browser — needs managed hardware).
+
+---
+
+## Artifacts
+
+- [`build-roadmap.md`](./build-roadmap.md) — **the unified plan.**
+  Sequences the refactor, the MVP build, stabilization, cross-platform,
+  feature parity, distribution, and the long-term strategic
+  decision into one execution sequence with explicit gates. Read this
+  first if you're picking up the work.
+- [`README.md`](./README.md) — this document (feasibility analysis).
+- [`mvp-plan.md`](./mvp-plan.md) — concrete MVP build plan with
+  D-numbered decisions, phase-by-phase pass criteria, and a ~10-day
+  effort estimate. Reads on top of this README.
+- [`refactor-analysis.md`](./refactor-analysis.md) — what the
+  codebase would look like under a committed dual-target
+  (Electron app + Chrome extension), filtered for which changes
+  are no-regrets even if we abandon the extension. Identifies
+  ~2.5 days of refactor work that pays off either way.
+- *(Phase 0+ prototypes will land here as `phase-N/` subdirectories
+  if/when walked. Currently empty — no prototype yet.)*
+
+---
+
+## Walk methodology notes (for whoever picks this up)
+
+- **Read [`../duo-in-browser/README.md`](../duo-in-browser/README.md)
+  first.** It has load-bearing precedent for the `window.electron`
+  shim approach (D1) and the CDP-over-TCP fallback (Walk 4). Don't
+  re-derive what's already in there.
+- **Test the SW idle pattern with a real human idle.** Don't simulate
+  with `setTimeout` — the kernel's SW scheduler interacts with system
+  idle hints and wall-clock time in ways `setTimeout` can't capture.
+  Use the extension for half an hour while doing real work in another
+  app, then come back.
+- **Helper binary should reuse the existing `cli/duo` esbuild bundle
+  pattern.** A second binary, same build pipeline as
+  [`cli/duo`](../../../cli/duo). One source of truth for the protocol
+  shape in [`shared/types.ts`](../../../shared/types.ts).
+- **Do not refactor `renderer/` to be host-agnostic.** Same lesson as
+  duo-in-browser: the shim approach is faster than the abstraction
+  refactor. If the extension shape ships, *then* maybe abstract.
+- **Stage 21d (Trailblazers) is the natural distribution gate to
+  evaluate against.** If the extension shape's install friction is
+  meaningfully higher than the DMG, Trailblazers is the wrong
+  audience to test it on.

--- a/docs/research/duo-as-chrome-extension/build-roadmap.md
+++ b/docs/research/duo-as-chrome-extension/build-roadmap.md
@@ -1,0 +1,714 @@
+# Build roadmap — Duo Chrome extension
+
+**Status:** Roadmap, 2026-04-29. The unified plan composing the
+research project's three reference docs into a single
+do-this-then-this sequence: refactor, build, test, evolve.
+
+This is **the** plan. The other docs in this directory are reference:
+
+- [`README.md`](./README.md) — feasibility rationale and
+  surface-by-surface architectural analysis.
+- [`mvp-plan.md`](./mvp-plan.md) — phase-by-phase MVP build detail
+  with D-numbered decisions and pass criteria.
+- [`refactor-analysis.md`](./refactor-analysis.md) — full
+  dual-target refactor analysis and the no-regrets filter that
+  identifies moves 1–4.
+
+This roadmap pulls those threads into one execution sequence and
+extends past the MVP into stabilization, cross-platform, feature
+parity, distribution, and the long-term strategic decision.
+
+---
+
+## The full sequence at a glance
+
+```
+   ┌──────────────────────────────── pre-extension ───────────────────────────────┐
+   │                                                                              │
+   │   Stage A          Stage B (gate)                                            │
+   │   Refactor         Phase 0:                                                  │
+   │   (moves 1–4)      keep-alive proof                                          │
+   │   ~2.5 days        ~0.5 day                                                  │
+   │                                                                              │
+   └──────────────────────┬──────────────────┬────────────────────────────────────┘
+                          │                  │
+                       PASS               FAIL → close research with addendum;
+                          │                       no-regrets refactor still landed
+                          ↓
+   ┌────────────────────────────── extension build & test ─────────────────────────┐
+   │                                                                                │
+   │   Stage C                  Stage D                Stage E                      │
+   │   MVP build (Phases 1–8)   Stabilization          Cross-platform helper        │
+   │   ~7–10 days               ~5–7 days              ~5–7 days                    │
+   │                                                                                │
+   └──────────────────────────────────────┬─────────────────────────────────────────┘
+                                          │
+                                       READY for early users
+                                          ↓
+   ┌──────────────────────── feature parity & distribution ────────────────────────┐
+   │                                                                                │
+   │   Stage F                  Stage G                                              │
+   │   Feature parity           Distribution                                         │
+   │   ~10–15 days              ~3–5 days                                            │
+   │                                                                                │
+   └──────────────────────────────────────┬─────────────────────────────────────────┘
+                                          │
+                                  shippable, comparable to Electron
+                                          ↓
+   ┌──────────────────────────────── long-term ───────────────────────────────────┐
+   │                                                                              │
+   │   Stage H — strategic decision (sibling forever / supersede / companion)    │
+   │   ongoing                                                                     │
+   │                                                                              │
+   └──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Total to shippable-comparable-to-Electron:** ~8–10 weeks of focused
+work. **Total to "decided on dual-target future":** ~3–4 months.
+
+**The single most important property of this plan:** Stage A is
+no-regrets. Even if Stage B's gate fails and we never ship the
+extension, Stage A leaves the codebase materially cleaner. This is
+the only stage you should do without conditional commitment.
+
+---
+
+## Gates and go/no-go points
+
+Only proceed past each gate on a green light.
+
+| Gate | When | What it tests | Failure mode |
+|---|---|---|---|
+| **G1** | End of Stage A | Smoke matrix passes; no Electron-app regressions | Roll back the refactor, investigate. |
+| **G2** | End of Stage B Phase 0 | SW + helper survive 30 min idle | Close research; add closing addendum to README. |
+| **G3** | End of Stage C MVP demo | Phase 8 demo runs end-to-end | Identify load-bearing failures; decide stay-here vs. continue. |
+| **G4** | End of Stage D | Trailblazer pilot can run for a week without owner intervention | Polish loop; don't expand scope until stable. |
+| **G5** | End of Stage F | Feature parity sufficient for the user audience we picked | Take a breath before public distribution. |
+
+**G2 is the load-bearing gate.** If Phase 0 fails, ~80% of the plan
+collapses. If G2 passes, the rest is execution risk only — the
+architecture is proven.
+
+---
+
+## Stage A — No-regrets refactor (moves 1–4)
+
+**Detail level:** Full. Drives the decision to start.
+
+**Outcome:** `core/` exists as a top-level package; the
+truly-Electron-coupled surface in `electron/` is reduced from 17
+files to ~6; the renderer's host contract is a first-class
+interface; `shared/types.ts` is split into protocol + domain.
+
+**Effort:** ~2.5 days. Detail in
+[`./refactor-analysis.md`](./refactor-analysis.md) under "The
+seven moves a committed dual-target codebase needs."
+
+### A1 — Extract pure services to `core/` (~1 day)
+
+Move the 9 ✓-marked files to `core/`, update imports in
+[`electron/main.ts`](../../../electron/main.ts) and any cross-imports
+inside the moved files:
+
+```
+core/
+├── browser-history/BrowserHistoryService.ts
+├── claude/{ClaudePresence.ts, resolveClaude.ts}
+├── constants.ts
+├── nav-pins/NavPinsService.ts
+├── pins/PinsService.ts
+├── session-state/SessionStateService.ts
+├── skills/SkillsScanner.ts
+└── socket-server/{SocketServer.ts, commands.ts}
+```
+
+**Validation:** `npm run typecheck` clean; `npm run dev` launches
+without behavioral change; smoke matrix passes.
+
+### A2 — `EventSink` adapter for the surface-coupled trio (~0.5 day)
+
+[`electron/pty-manager.ts`](../../../electron/pty-manager.ts),
+[`electron/files-service.ts`](../../../electron/files-service.ts),
+and `electron/update-checker.ts` use `WebContents.send()` to push
+events. Replace with `EventSink`:
+
+```ts
+// core/transport/EventSink.ts
+export interface EventSink {
+  send(channel: string, payload: unknown): void;
+}
+```
+
+Move the now-pure cores to `core/pty/PtyManager.ts`,
+`core/files/FilesService.ts`, `core/update/UpdateChecker.ts`.
+Keep a thin `electron/adapters/WebContentsEventSink.ts` (5 lines)
+as the Electron-side adapter.
+
+**Validation:** Same as A1.
+
+### A3 — Split `shared/types.ts` (~0.5 day)
+
+Today's [`shared/types.ts`](../../../shared/types.ts) (1338 lines)
+splits into:
+
+```
+shared/
+├── protocol/{ipc.ts, commands.ts, events.ts}
+├── domain/{files.ts, canvas.ts, editor.ts, browser.ts}
+└── (existing) html-boilerplate.ts, ulid.ts, fork-config.d.ts
+```
+
+Use `shared/types.ts` as a re-export shim during the migration so
+no existing import path breaks. Migrate imports gradually as files
+are touched.
+
+**Validation:** Typecheck clean throughout.
+
+### A4 — Formalize the renderer's `HostApi` interface (~0.5 day)
+
+Promote `window.electron`'s implicit shape to a first-class
+interface in `shared/host/HostApi.ts`. Make
+[`electron/preload.ts`](../../../electron/preload.ts) implement it
+explicitly. Renderer's global declaration becomes
+`declare global { interface Window { duoHost: HostApi } }` (or keep
+`window.electron` for now — pure cosmetics).
+
+**Validation:** Typecheck clean. The interface catches any
+preload/renderer drift that exists today.
+
+### Stage A exit criteria (Gate G1)
+
+- Smoke matrix passes per
+  [`docs/dev/smoke-checklist.md`](../../dev/smoke-checklist.md).
+- Three CLI verbs spot-checked end-to-end (`duo edit`, `duo nav`,
+  `duo theme`).
+- Zero behavior regressions reported in a 24-hour use window.
+
+**If G1 fails:** Investigate the regression. Do not proceed to Stage
+B until the refactor is clean. The extension build is gated on a
+working pre-state.
+
+---
+
+## Stage B — Phase 0 keep-alive proof (the load-bearing gate)
+
+**Detail level:** Full. This gate decides everything downstream.
+
+**Outcome:** Empirical answer to the
+[claude-code#16350](https://github.com/anthropics/claude-code/issues/16350)
+problem — does an extension service worker + Native Messaging
+helper pair survive 30 minutes of real user idle?
+
+**Effort:** ~0.5 day. Detail in
+[`./mvp-plan.md`](./mvp-plan.md#phase-0--native-messaging-keep-alive-proof--½-day).
+
+### Build
+
+- Skeletal MV3 manifest, `nativeMessaging` permission only.
+- SW connects to a 50-line hello-world helper via
+  `chrome.runtime.connectNative`.
+- 25-second `chrome.alarms` keep-alive.
+- Test page sends a ping every interaction; helper logs an
+  "alive" line every 30s.
+
+### Pass criteria (Gate G2)
+
+- 30 minutes of zero user interaction → SW responds to a ping in
+  <100ms on first call.
+- `pgrep -c duo-helper` → exactly 1 throughout the test.
+- No port-closed events in SW console.
+- *Repeated test* with 60-min idle.
+
+### Failure handling
+
+If keep-alive cannot keep the helper alive:
+
+1. Try 15s, 10s alarm cadences before giving up.
+2. Close out the research with a one-paragraph addendum to
+   [`./README.md`](./README.md).
+3. Stage A's refactor still landed — no regret.
+4. Reconsider the embedded-browser path or duo-in-browser's intranet
+   variant as alternative R&D directions.
+
+---
+
+## Stage C — Extension MVP build (Phases 1–8)
+
+**Detail level:** Phase-level here; per-phase detail in
+[`./mvp-plan.md`](./mvp-plan.md).
+
+**Outcome:** A walkable extension MVP that satisfies the demo
+script — terminal in side panel, navigator drawer, markdown canvas
+in a Chrome tab, agent-driven Gmail screenshot, AX tree via
+`chrome.debugger`.
+
+**Effort:** ~7–10 days.
+
+### Phase summary (full detail in `mvp-plan.md`)
+
+| Phase | Deliverable | Days |
+|---|---|---|
+| 1 | Side panel UI scaffolding + nav drawer (mock data) | 1.0 |
+| 2 | Real PTY through Native Messaging — leverages `core/pty/PtyManager` from Stage A | 1.0 |
+| 3 | Real filetree + open canvas-as-tab — leverages `core/files/FilesService` | 1.0 |
+| 4 | MarkdownEditor in canvas tab, file r/w through helper | 1.0 |
+| 5 | Tab-driving via lighter `chrome.tabs`/`chrome.scripting` APIs | 1.0 |
+| 6 | `chrome.debugger` for CDP-only operations | 0.5 |
+| 7 | Distribution dry-run — Web Store unlisted + helper PKG | 1.0 |
+| 8 | End-to-end demo + buffer | 0.5 |
+| **Total** | | **7.0** |
+
+Add 30% buffer for MV3 papercuts: **~9 working days.**
+
+### Stage A's downstream effect on Stage C
+
+Because Stage A landed, Phases 2 and 3 are materially cheaper:
+
+- Phase 2's helper imports `PtyManager` from `core/pty/`. The
+  helper is the second `EventSink` consumer (the Electron app is
+  the first); the PTY logic itself doesn't need re-implementing.
+- Phase 3 same shape with `FilesService`.
+- The CLI's transport-agnostic refactor (Move 5) lands as part of
+  Phase 5 instead of separately.
+
+### Stage C exit criteria (Gate G3)
+
+The Phase 8 demo runs end-to-end without papercuts:
+
+1. Click extension icon → side panel opens.
+2. ⌘+B toggles drawer, navigate, dismiss.
+3. Run `claude` in terminal.
+4. Agent runs `duo edit README.md` → new tab opens with markdown.
+5. Agent runs `duo nav https://gmail.com` → Gmail loads.
+6. Agent runs `duo screenshot` → returns rendered image.
+7. Agent runs `duo ax` → yellow banner, AX tree returns, banner
+   clears.
+
+**If G3 fails:** Identify load-bearing failures. Decide stay-here
+(fix in Stage C) vs. continue (defer to Stage D).
+
+---
+
+## Stage D — Stabilization
+
+**Detail level:** Medium. Production-ready foundation before
+expanding scope.
+
+**Outcome:** A Trailblazer pilot can run for a week without the
+owner needing to debug helper-died papercuts or restart the
+extension.
+
+**Effort:** ~5–7 days.
+
+### Sub-stages
+
+#### D1 — SW resilience (~1.5 days)
+
+Keep-alive cadence proven; now harden the failure modes:
+
+- **Reconnect logic** in the SW: if the Native Messaging port
+  disconnects, retry with backoff. If the helper has died, surface
+  a side-panel banner instead of failing silently.
+- **State recovery on SW resume:** the SW's in-memory `Map<requestId,
+  port>` evaporates on idle; track the in-flight request set in
+  `chrome.storage.session` so resumed SW can complete or fail
+  cleanly.
+- **Sentinel pings** every 25s from the SW to the helper *and* every
+  25s from each side panel / canvas tab to the SW — both directions
+  matter.
+
+#### D2 — Helper auto-update (~1.5 days)
+
+The Web Store auto-updates the extension. The helper PKG doesn't.
+Two options:
+
+- (a) Helper checks GitHub releases on startup; surfaces an
+  "update available" event the side panel renders. User clicks →
+  re-downloads PKG, runs installer, restarts Chrome.
+- (b) The extension's SW monitors a manifest version number;
+  surfaces the prompt the same way.
+
+Pick (b); it composes with the version-mismatch warning the CLI
+already has logic for (see
+[`cli/duo.ts`](../../../cli/duo.ts) version-check banner).
+
+#### D3 — Protocol versioning (~1 day)
+
+Add a `protocolVersion` field to every Native Messaging message and
+every SW-port message. Reject mismatched versions with a clean error
+("Helper v0.6.0 incompatible with extension v0.5.4 — please update
+the helper").
+
+This is the protocol shape that lets us evolve the extension and
+helper independently going forward.
+
+#### D4 — Smoke checklist for the extension target (~1 day)
+
+[`docs/dev/smoke-checklist.md`](../../dev/smoke-checklist.md) is
+shaped for the Electron app. Add an extension counterpart:
+`docs/dev/smoke-checklist-extension.md`. Same kind of structure —
+walk through every CLI verb, every UI gesture, every keystroke.
+
+#### D5 — Regression test coverage for `core/` (~1.5 days)
+
+Stage A made `core/` services unit-testable without spinning up
+Electron. *Write* the unit tests now:
+
+- `core/pty/PtyManager.test.ts` — spawn shell, write, read, kill.
+- `core/files/FilesService.test.ts` — list, read, write, watch.
+- `core/socket-server/SocketServer.test.ts` — protocol round-trip.
+- `core/skills/SkillsScanner.test.ts` — fixture-based scan output.
+
+Run on CI for both targets. This is how we catch regressions
+faster than smoke-matrix walks.
+
+### Stage D exit criteria (Gate G4)
+
+- Pilot user (Trailblazer) runs the extension for 7 days without
+  the project owner intervening.
+- No "helper died, restart Chrome" reports.
+- All `core/` unit tests pass on CI.
+
+---
+
+## Stage E — Cross-platform helper
+
+**Detail level:** Medium.
+
+**Outcome:** The extension+helper pair installs cleanly on macOS,
+Linux, and Windows. The Native Messaging manifest paths differ per
+platform but the helper itself is one source.
+
+**Effort:** ~5–7 days.
+
+### Sub-stages
+
+#### E1 — Helper build matrix (~1 day)
+
+Extend the helper's esbuild bundle target list. Same source, three
+binaries (`duo-helper-darwin`, `duo-helper-linux`,
+`duo-helper-win32.exe`).
+
+#### E2 — Per-platform installers (~3 days)
+
+| Platform | Installer | Manifest target |
+|---|---|---|
+| macOS | Signed + notarized PKG | `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/` |
+| Linux | `.deb` and `.rpm` | `~/.config/google-chrome/NativeMessagingHosts/` (and Chromium variants) |
+| Windows | MSI | Registry key `HKEY_CURRENT_USER\Software\Google\Chrome\NativeMessagingHosts\<name>` |
+
+Each installer drops the binary, writes the manifest, and (on macOS)
+notarizes for Gatekeeper.
+
+#### E3 — Per-browser variants (~1 day)
+
+Edge, Brave, and other Chromium-based browsers have their own
+Native Messaging manifest paths. The Linux installer should
+populate all of them; macOS and Windows similarly.
+
+Firefox uses a different extension API (WebExtensions) and doesn't
+ship `chrome.sidePanel`. Out of scope for this stage.
+
+#### E4 — Per-platform smoke tests (~1 day)
+
+Run the extension's smoke checklist on each platform. Catch
+path-resolution and shell-spawning quirks early.
+
+### Stage E exit criteria
+
+- Friend on Linux installs and runs the demo script.
+- Friend on Windows installs and runs the demo script.
+- Same friction profile as macOS (<5 min install).
+
+---
+
+## Stage F — Feature parity expansion
+
+**Detail level:** Medium-light. Each sub-stage is its own
+mini-project; the order is suggestive.
+
+**Outcome:** The extension can do anything the Electron app can do
+(modulo the genuinely-removed parts: embedded `WebContentsView`,
+`webContents.debugger`-driven CDP).
+
+**Effort:** ~10–15 days.
+
+### Sub-stages, ordered by user-visible impact
+
+#### F1 — HTML canvas (Stage 17 surface) (~3 days)
+
+Today's [`renderer/components/HtmlCanvas/`](../../../renderer/components/HtmlCanvas/)
+hosts an iframe-sandboxed HTML editor. Same component, mounted in
+a canvas-as-tab page (variant of `canvas/CanvasPage.tsx` from MVP).
+The `duo html *` verbs route through the helper to the renderer
+(now in a Chrome tab).
+
+#### F2 — Multi-PTY tab strip (~2 days)
+
+The MVP shipped with one PTY per side panel. Restore the tab strip
+from the Electron app:
+[`renderer/components/WorkingTabStrip.tsx`](../../../renderer/components/WorkingTabStrip.tsx)
++ multi-PTY routing in the helper. Each PTY is its own subprocess;
+the SW routes data by sessionId.
+
+#### F3 — Skills panel (~1.5 days)
+
+[`renderer/components/SkillsPanel.tsx`](../../../renderer/components/SkillsPanel.tsx)
++ `core/skills/SkillsScanner` (already extracted in Stage A). Mount
+in the side panel under a second nav-rail icon.
+
+#### F4 — Selection sharing across surfaces (~2 days)
+
+The Electron app's selection-pill machinery
+([`renderer/components/Selection*`](../../../renderer/components/))
+shares the user's text selection between canvas and terminal. In
+the extension, this becomes a `BroadcastChannel` (D9 in the MVP
+plan) carrying selection events between same-origin extension pages.
+
+#### F5 — Theme synchronization (~0.5 day)
+
+Side panel + canvas tabs subscribe to a single source-of-truth theme
+via `chrome.storage.local` + `BroadcastChannel`. `duo theme` writes,
+all surfaces re-render.
+
+#### F6 — Browser history + autocomplete (~1 day)
+
+The Stage 21c address bar history feature
+([`electron/browser-history-service.ts`](../../../electron/browser-history-service.ts),
+already moved to `core/` in Stage A) becomes part of the
+`duo nav`-targeted tab driver: agents can suggest URLs from the
+user's recent history.
+
+#### F7 — Session restore across browser restart (~2 days)
+
+Equivalent of the Electron app's Stage 21c session-restore: when the
+user reopens Chrome, their open canvas tabs restore from the helper's
+persisted state. (Chrome's tab restore is per-extension.)
+
+#### F8 — Network capture (`Network.*` CDP) (~1.5 days)
+
+The remaining `chrome.debugger`-only territory.
+`duo network` attaches the debugger, records all network events for
+N seconds, returns a HAR-like dump. Yellow banner appears for the
+duration.
+
+#### F9 — Drag-and-drop (~1 day)
+
+Drag-from-filetree-to-canvas-tab and drag-from-tab-to-filetree.
+Cross-tab drag is structurally awkward in browsers; might require
+a "drop target" in each canvas tab listening for path strings.
+
+### Stage F exit criteria (Gate G5)
+
+The extension does ~95% of what the Electron app does. Decide what
+to deliberately leave in the Electron-only column (e.g., the
+embedded `WebContentsView` is permanently gone in the extension
+shape).
+
+---
+
+## Stage G — Distribution
+
+**Detail level:** Light.
+
+**Outcome:** The extension ships to public users.
+
+**Effort:** ~3–5 days.
+
+### Sub-stages
+
+#### G1 — Web Store listing (~1 day)
+
+- Public listing copy (positioning, screenshots, demo video).
+- Privacy policy and permission justifications.
+- Support contact and bug-report URL.
+
+#### G2 — Trailblazer pilot announcement (~0.5 day)
+
+Stage 21d in the existing roadmap is the Trailblazer cohort. The
+extension shape rides on that pilot but with a separate install
+flow. Add a second README to the Trailblazer onboarding doc.
+
+#### G3 — Helper PKG public release infrastructure (~1 day)
+
+Sparkle-style helper auto-update for macOS. GitHub Releases hosting.
+SHA-256 verification before installing.
+
+#### G4 — Onboarding flow (~1.5 days)
+
+First-launch banner in the side panel:
+
+- Detect if `claude` CLI is installed; offer link to install.
+- Detect if user has any tabs open the extension would want to
+  drive; explain the lighter-API vs `chrome.debugger` distinction.
+- Offer the `cut-version` skill or equivalent guided-setup flow.
+
+#### G5 — Documentation overhaul (~1 day)
+
+- Update [`docs/VISION.md`](../../VISION.md) to acknowledge the
+  dual-target shape.
+- Add an extension-specific `docs/EXTENSION.md` covering the
+  install / troubleshoot flow.
+- Update `docs/CLI-COVERAGE.md` to mark which verbs are
+  extension-supported.
+
+### Stage G exit criteria
+
+- Public Web Store listing live.
+- A non-Trailblazer user finds, installs, and uses the extension
+  without owner intervention.
+
+---
+
+## Stage H — Long-term: the strategic decision
+
+**Detail level:** Light. This is months out and depends on data we
+don't have yet.
+
+**Outcome:** A locked-in long-term decision about the relationship
+between the Electron app and the Chrome extension.
+
+**Effort:** Ongoing — not a single phase.
+
+### Three possible futures
+
+#### H-a: Dual-target indefinitely
+
+Both ship. Different audiences (engineers who want the focused
+desktop app vs. browser-native users). Maintenance cost is the
+moves 6–7 dual-target tax from
+[`./refactor-analysis.md`](./refactor-analysis.md). Roadmap
+stages have to be evaluated against both targets.
+
+#### H-b: Extension supersedes Electron
+
+If usage data shows extension users dominating, deprecate the
+Electron app over a 6-month sunset. The `core/` extraction makes
+this clean — `electron/` shrinks to nothing, `core/` + `extension/`
++ `helper/` is the codebase.
+
+#### H-c: Electron remains primary, extension is companion
+
+If Electron users dominate, keep the extension as a lightweight
+companion for users who specifically want browser-native shape.
+Maintain a smaller extension feature set (the "core 60%") rather
+than full parity.
+
+### Decision inputs
+
+- Usage telemetry (which target are people running?).
+- User feedback on each shape's friction profile.
+- Maintenance burden (which target gets more bug reports?).
+- Strategic context (what the broader Anthropic / Claude Code
+  ecosystem looks like at that point).
+
+### Decision artifacts
+
+- ADR in [`docs/DECISIONS.md`](../../DECISIONS.md) — the chosen
+  future, the inputs that drove it, the deprecation timeline if
+  applicable.
+- Roadmap stages adjusted accordingly.
+- Communication to existing users (if any deprecation is in play).
+
+---
+
+## Cumulative effort
+
+| Stage | Days | Cumulative |
+|---|---|---|
+| A — Refactor (moves 1–4) | 2.5 | 2.5 |
+| B — Phase 0 gate | 0.5 | 3.0 |
+| C — MVP build (Phases 1–8) | 9.0 | 12.0 |
+| D — Stabilization | 6.0 | 18.0 |
+| E — Cross-platform helper | 6.0 | 24.0 |
+| F — Feature parity | 12.0 | 36.0 |
+| G — Distribution | 4.0 | 40.0 |
+| H — Long-term decision | ongoing | — |
+
+**40 working days** to a publicly shippable extension at near-parity
+with the Electron app. **~3 working days** to either a no-go
+decision (G2 fails) or a working MVP demo (G3 passes).
+
+The asymmetry is deliberate: most of the cost is in stages D–F. The
+risk-bearing investment — does the architecture work at all? — is
+~3 days. We'll know in a week whether to commit the further 7.
+
+---
+
+## Risks throughout
+
+Carried forward from the README and refactor-analysis docs, mapped
+to the stage that catches each:
+
+| Risk | Caught in |
+|---|---|
+| Stage A regression breaks Electron app | A exit (G1) |
+| SW idle / native-host death | B (G2) |
+| 360px terminal too cramped even with hover navigator | C Phase 1 |
+| Native Messaging 1MB ceiling on large file reads | C Phase 4 |
+| `chrome.debugger` yellow banner intolerable | C Phase 6 |
+| Two-step install too friction-heavy | C Phase 7 |
+| Pilot user runs into helper-died papercuts | D (G4) |
+| Cross-platform path/manifest issues | E |
+| Selection-sharing UX awkward across tabs | F4 |
+| Enterprise extension policy blocks the permission set | G or before |
+| Long-term maintenance burden becomes load-bearing | H |
+
+---
+
+## Decision points along the way
+
+Each decision is small, but they compound:
+
+- **Before A1:** Schedule the refactor PR. (Outside the technical
+  plan; just calendar-level.)
+- **End of A:** Do we land moves 1–4 as one PR or split into four?
+  (Recommend: one — the smoke matrix runs once.)
+- **End of B (G2):** Continue to C, or close research?
+- **Mid C, end of Phase 1:** Is 360px terminal usable? If not,
+  consider abandoning the side-panel-only shape and going
+  popup-window-first.
+- **End of C (G3):** Promote to a roadmap stage card on
+  [`docs/roadmap.html`](../../roadmap.html), or keep as research?
+- **End of D (G4):** Open the Trailblazer pilot, or polish more?
+- **End of F (G5):** What's deliberately staying Electron-only?
+- **Stage H:** The long-term strategic call.
+
+---
+
+## What this plan does NOT cover
+
+- **ADR text for [`docs/DECISIONS.md`](../../DECISIONS.md).** If/when
+  Stage C succeeds, write the ADR documenting the dual-target choice.
+- **Roadmap card text for
+  [`docs/roadmap.html`](../../roadmap.html).** Each stage in this
+  plan that gets promoted needs its own card with status, scope,
+  and per-stage decisions.
+- **Detailed UX for stages D+.** The MVP plan is detailed; later
+  stages are less so by design — we'll know more about the right
+  UX once Stage C ships and users are using it.
+- **Pricing / packaging.** If the extension ships under a different
+  distribution model (e.g., free, paid tier, Trailblazer-only), that
+  decision is a separate strategic conversation.
+- **Internationalization, accessibility audit, security review.**
+  These cross-cut every stage; surface them as their own pre-
+  Stage-G checklists when distribution looms.
+
+---
+
+## Walk methodology notes
+
+- **Don't skip Stage A even if Phase 0 fails.** The refactor stands
+  on its own merit. Land it.
+- **Don't skip Stage B's gate.** Phases 1–8 building on a sandy SW
+  foundation is the failure mode the duo-in-browser exploration's
+  Walk 4 narrowly avoided. Pay the half-day.
+- **Re-read [`./README.md`](./README.md) at the start of each stage**
+  — the architectural premises will look different from inside the
+  build than from the planning seat.
+- **The mvp-plan's D-numbered decisions are locked through Stage C.**
+  Each one flips at most once; document the flip in this roadmap and
+  re-up the affected sub-stage's pass criteria.
+- **Don't optimize for parity in Stages D–E.** Stabilization and
+  cross-platform are foundation work. Feature parity comes in F.
+  Mixing those cycles makes both worse.

--- a/docs/research/duo-as-chrome-extension/build-roadmap.md
+++ b/docs/research/duo-as-chrome-extension/build-roadmap.md
@@ -4,7 +4,34 @@
 research project's three reference docs into a single
 do-this-then-this sequence: refactor, build, test, evolve.
 
-This is **the** plan. The other docs in this directory are reference:
+> **Relationship to the main Duo roadmap** ([`/ROADMAP.md`](../../../ROADMAP.md) /
+> [`docs/roadmap.html`](../../roadmap.html)) — read first, then the
+> rest of this document.
+>
+> The main roadmap is the **Electron app shipping path** (Stages
+> 1–21, ongoing). This file is the **Chrome-extension exploration
+> roadmap** (Stages A–H). They do **not** gate each other.
+>
+> | Where it lives | What it is | Touches main app? | Merges back to `main`? |
+> |---|---|---|---|
+> | **Stage A — refactor** (`core/`, `electron/`, `shared/host-api.ts`, `tsconfig.node.json`, `scripts/postinstall.ts`) | Pure-Node service extraction + EventSink + host-api split. Identified as **no-regrets** in [`refactor-analysis.md`](./refactor-analysis.md). | Yes — same files the Electron app builds from. `npm run typecheck` + `npm run build` are clean; smoke-matrix walk pending. | **Yes** — these are merge candidates back to `main` once smoke-walked. They benefit the Electron app whether or not the extension ever ships. |
+> | **Stage B/C work** (`phase0/` directory, helper script) | Extension prototype, Native Messaging helper, side panel scaffolding, real PTY, real filetree, etc. | No — `phase0/` isn't in the Electron build pipeline. | **No** — exploration-only, lives on the `duo-chrome-extension-exploration` branch. If the extension ships, a future migration moves these out of `phase0/` and into proper top-level `extension/` + `helper/` directories with build pipeline. |
+> | **Research artifacts** (`docs/research/duo-as-chrome-extension/`) | This planning bundle. | No. | Yes — docs are safe to land on `main` whenever; they don't affect any build. |
+>
+> **Practical guidance:**
+>
+> - Working on a main-roadmap stage? You can ignore this file
+>   entirely. Stage A's refactor *did* move services from `electron/`
+>   to `core/` — if you need a service, look in `core/` first. (See
+>   `refactor-analysis.md` for the move map.)
+> - Picking up extension work? Read this file end-to-end, then the
+>   referenced PRDs.
+> - Wondering if extension work is blocking a main release? **No.**
+>   The exploration branch is non-gating. Main releases proceed
+>   independently.
+
+This is **the** extension build plan. The other docs in this
+directory are reference:
 
 - [`README.md`](./README.md) — feasibility rationale and
   surface-by-surface architectural analysis.

--- a/docs/research/duo-as-chrome-extension/mvp-plan.md
+++ b/docs/research/duo-as-chrome-extension/mvp-plan.md
@@ -1,0 +1,566 @@
+# Duo-as-Chrome-extension — MVP build plan
+
+**Status:** Plan, 2026-04-29. Not started. Reads on top of
+[`./README.md`](./README.md) — that document is the feasibility
+analysis; this one is the actual build sequence.
+
+> **Note (2026-04-29 update):** [`./build-roadmap.md`](./build-roadmap.md)
+> now composes this MVP plan with the [`./refactor-analysis.md`](./refactor-analysis.md)
+> moves and post-MVP stages into a single end-to-end sequence. Phases
+> 0–8 in this document are Stage C of that roadmap. Read
+> `build-roadmap.md` first for the full picture; come here for
+> phase-level detail.
+
+**Outcome we're building toward:** A Trailblazer can install the
+extension + helper in under five minutes, run a Claude Code agent in
+the side-panel terminal, edit a markdown file the agent opens in a
+new browser tab, and watch the agent take a screenshot of their
+already-authenticated Gmail tab. End-to-end, < 5 min idle pause
+mid-session, no helper-died reconnect dance.
+
+**Estimated effort:** ~10 working days, **gated at Phase 0** (half a
+day). If Phase 0 fails, the plan stops here and the README's "Why
+this is *not* a successor to duo-in-browser" gets a closing
+addendum.
+
+---
+
+## What's in MVP, what's deferred
+
+Tightly scoped — the goal is to learn whether the shape works, not
+to ship parity with the Electron build.
+
+### In MVP
+
+- **One side panel** with one terminal + a default-collapsed
+  navigator drawer (D3 below).
+- **One PTY at a time** in that terminal, running the user's shell.
+- **Markdown canvas-as-tab** — `duo edit foo.md` opens a new Chrome
+  tab hosting `renderer/components/editor/MarkdownEditor.tsx`.
+- **File I/O through the helper** — read, write, watch.
+- **Tab-driving via lighter APIs first** — `duo nav`, `duo click`,
+  `duo type`, `duo screenshot`, `duo url`, `duo title` go through
+  `chrome.tabs` + `chrome.scripting` (no yellow banner).
+- **`chrome.debugger` attach for CDP-only ops** — `duo ax`,
+  `duo console`, `duo errors`. Yellow banner appears during attach.
+- **macOS only.** Linux / Windows deferred.
+- **Two-step install** — Web Store extension + signed helper PKG.
+
+### Deferred (do not build for MVP)
+
+- HTML canvas (the iframe-sandboxed Stage 17 surface)
+- Multi-PTY tab strip in the side panel
+- Theme synchronization across tabs
+- Network capture / interception (`Network.*` CDP)
+- Auto-update for the helper binary (manual update for MVP)
+- Multi-profile UX (each profile gets its own helper; that's fine)
+- Drag-and-drop between filetree and canvas tabs
+- Selection-sharing between canvas and terminal
+  (`renderer/components/Selection*` machinery)
+- Skills panel
+- Browser history persistence
+- Session restore across browser restart
+- Anything currently sitting in `electron/browser-manager.ts` —
+  that whole subsystem retires in this shape
+
+If a deferred capability turns out to be load-bearing during the
+build, raise it explicitly and reconsider scope; do not silently
+bring it in.
+
+---
+
+## D-numbered decisions
+
+Locked before code starts. If one of these flips during the build,
+update the doc.
+
+- **D1 — `window.electron` shim, not abstraction refactor.** Inherited
+  from the duo-in-browser exploration's D1. The shim forwards every
+  call from the renderer components to the SW via
+  `chrome.runtime.connect`, and the SW forwards over Native Messaging
+  to the helper. `renderer/components/*` host verbatim.
+- **D2 — One Native Messaging connection, owned by the SW.** The SW
+  is the only thing that calls `chrome.runtime.connectNative`. Side
+  panel and canvas tabs cannot. They relay through the SW. (See
+  README § "One coordinator per profile.")
+- **D3 — Navigator as default-collapsed hover drawer.** The side
+  panel's default state is full-width terminal. The navigator lives
+  in a thin (32px) icon rail on the leading edge; clicking it slides
+  a 280px navigator panel in over the terminal (`position: absolute`,
+  `transform: translateX`, 200ms ease). Click outside, press Escape,
+  or click a file → drawer collapses. This buys the terminal real
+  estate back at default and accepts a one-click cost when the user
+  wants to navigate. **A keystroke binding (probably ⌘+B) toggles the
+  drawer** — single source of truth in
+  [`renderer/keyboard/globalShortcuts.ts`](../../../renderer/keyboard/globalShortcuts.ts).
+- **D4 — Markdown canvas only in MVP.** HTML canvas (Stage 17) is
+  deferred. `fileClassifier` returns `unknown` for `.html` for now.
+- **D5 — Lighter `chrome.tabs`/`chrome.scripting` APIs first;
+  `chrome.debugger` only for CDP-only ops.** See README § "Hybrid:
+  use the lighter APIs first" for the table. CLI verbs are tagged
+  in their help output with `(attaches debugger)` when the yellow
+  banner will appear.
+- **D6 — 25-second `chrome.alarms` keep-alive for SW.** Phase 0
+  proves the cadence; if it isn't enough, raise the alarm cadence
+  before moving on. Document the actual interval that worked.
+- **D7 — Single PTY in MVP.** No tab strip in the side panel. If
+  the user wants a second terminal, they open a popup window
+  (deferred to v0.1 if needed).
+- **D8 — macOS only for MVP.** Helper PKG is signed + notarized for
+  Darwin. Cross-platform helper builds (Linux deb / rpm, Windows
+  MSI) are post-MVP work.
+- **D9 — `BroadcastChannel` for cross-tab UI events.** Theme,
+  focus, "another tab opened the same file" — peer-to-peer between
+  same-origin extension pages. Stateful coordination still goes
+  through the SW (D2). This is the structural answer to the
+  cross-window keystroke routing concern in the README's soft
+  blockers.
+
+---
+
+## Architecture
+
+```
+                                         Chrome (one user profile)
+   ┌─────────────────────────────────────────────────────────────────────────────────┐
+   │                                                                                  │
+   │   ┌─ extension manifest_version 3 ──────────────────────────────────────────┐   │
+   │   │                                                                          │   │
+   │   │   ┌─ side panel ──────────────┐    ┌─ canvas tab(s) ──────────────────┐  │   │
+   │   │   │ extension/sidepanel/      │    │ extension/canvas/                │  │   │
+   │   │   │  ├─ SidePanel.tsx         │    │  └─ CanvasPage.tsx               │  │   │
+   │   │   │  ├─ NavRail.tsx (32px)    │    │     hosts MarkdownEditor         │  │   │
+   │   │   │  ├─ NavDrawer.tsx (280px) │    │     (renderer/components/editor) │  │   │
+   │   │   │  └─ TerminalPane (reuse)  │    └──────────────────────────────────┘  │   │
+   │   │   └─────────────┬─────────────┘                  │                       │   │
+   │   │                 │                                │                       │   │
+   │   │                 └────── chrome.runtime.connect ports ────┐               │   │
+   │   │                                                          ↓               │   │
+   │   │                                                ┌─────────────────────┐   │   │
+   │   │                                                │  service worker     │   │   │
+   │   │                                                │  extension/sw.ts    │   │   │
+   │   │                                                │  ├ port router      │   │   │
+   │   │                                                │  ├ debugger orch.   │   │   │
+   │   │                                                │  ├ chrome.alarms    │   │   │
+   │   │                                                │  │   keep-alive     │   │   │
+   │   │                                                │  └ chrome.runtime   │   │   │
+   │   │                                                │    .connectNative ──┼───┼───┼───→ helper
+   │   │                                                └─────────────────────┘   │   │
+   │   └──────────────────────────────────────────────────────────────────────────┘   │
+   │                                                                                  │
+   │   ┌─ chrome.debugger.attach({tabId}, '1.3') ─────────────────────────────────┐   │
+   │   │  ── attached only for CDP-only verbs (D5) ───────────────────────────────┘   │
+   │   │     yellow banner shows during attach                                        │
+   │   └──────────────────────────────────────────────────────────────────────────────┘
+   └──────────────────────────────────────────────────────────────────────────────────┘
+                                                                                       │
+                                                          Native Messaging stdio JSON  │
+                                                                                       ↓
+                                                                        ┌─────────────────────┐
+                                                                        │  helper (Node)      │
+                                                                        │  helper/main.ts     │
+                                                                        │  ├ pty-bridge       │
+                                                                        │  │    node-pty      │
+                                                                        │  ├ files-bridge     │
+                                                                        │  │    chokidar      │
+                                                                        │  │    fs            │
+                                                                        │  └ protocol.ts      │
+                                                                        └─────────────────────┘
+```
+
+### File layout
+
+```
+extension/
+  manifest.json                       — MV3 manifest
+  sw.ts                               — service worker entry
+  sidepanel/
+    SidePanel.tsx                     — root layout (rail + terminal + drawer)
+    NavRail.tsx                       — 32px icon rail (D3)
+    NavDrawer.tsx                     — sliding 280px filetree drawer (D3)
+    sidepanel.html
+  canvas/
+    CanvasPage.tsx                    — hosts MarkdownEditor in a tab
+    canvas.html
+  shim/
+    window-electron.ts                — D1 compat layer; same shape as renderer expects
+    port-bridge.ts                    — chrome.runtime.connect + reconnect logic
+  shared/
+    protocol.ts                       — message types (re-exports shared/types.ts)
+
+helper/
+  main.ts                             — Native Messaging host (stdin/stdout JSON)
+  pty-bridge.ts                       — node-pty integration
+  files-bridge.ts                     — chokidar + fs
+  protocol.ts                         — shared with extension/shared/protocol.ts
+  bin/
+    duo-helper                        — packaged binary (esbuild same as cli/duo)
+
+installer/
+  com.duo.helper.json                 — Native Messaging manifest template
+  build-pkg.sh                        — macOS PKG build (signs + notarizes)
+
+reused (NO COPIES — direct imports / reuse):
+  renderer/components/TerminalPane.tsx
+  renderer/components/FileTree.tsx
+  renderer/components/editor/MarkdownEditor.tsx
+  renderer/components/fileClassifier.ts
+  renderer/keyboard/globalShortcuts.ts
+  shared/types.ts                     — extended, not forked
+  cli/duo.ts                          — adapted to talk to helper (TBD whether
+                                        this is an adaptation or a sibling
+                                        cli/duo-ext.ts; decide in Phase 5)
+```
+
+### IPC contract
+
+The shim's `window.electron` shape stays compatible with the
+existing one in [`electron/preload.ts`](../../../electron/preload.ts).
+The transport changes:
+
+```
+renderer component
+   ↓ window.electron.foo.bar(args)
+shim (extension/shim/window-electron.ts)
+   ↓ port.postMessage({channel: 'foo:bar', requestId, args})
+service worker (extension/sw.ts)
+   ↓ nativePort.postMessage({channel, requestId, args})
+helper (helper/main.ts)
+   ↓ <native-pty-or-fs-call>
+   ↑ {requestId, result | error}
+service worker
+   ↑ port.postMessage(...)
+shim
+   ↑ resolves the request promise
+renderer component
+```
+
+Event subscriptions (file watch, PTY data) go the other way through
+the same port pair. The SW maintains a `Map<requestId, port>` and a
+`Map<subscriptionId, port>` to route responses and events back to
+the right tab.
+
+---
+
+## Build phases
+
+Each phase ends in something demoable. Don't start phase N+1 until
+phase N's pass criteria are green.
+
+### Phase 0 — Native Messaging keep-alive proof (½ day)
+
+**Gate.** If this fails, stop.
+
+Build:
+
+- Skeletal extension manifest with `nativeMessaging` permission only.
+- SW that connects to a hello-world helper over
+  `chrome.runtime.connectNative` and pings every 25s via
+  `chrome.alarms`.
+- Helper is a 50-line Node script that echoes back
+  `{ok: true, t: Date.now()}` for every message and logs a "still
+  alive" line every 30s.
+
+Pass criteria:
+
+- After 30 minutes of zero user interaction, the SW responds to a
+  `from-test-page` ping in <100ms on first call.
+- Helper process count remains exactly 1 throughout the test
+  (`pgrep -c duo-helper`).
+- No "port closed" / "host disconnected" events in the SW console.
+
+If it fails: try increasing the alarm cadence (15s, 10s). If that
+fails too, the SW is being aggressively killed for memory reasons
+even with active alarms — which is the failure mode at
+[claude-code#16350](https://github.com/anthropics/claude-code/issues/16350).
+Close out the research with this finding.
+
+### Phase 1 — Side panel UI scaffolding (1 day)
+
+**Validate the 360px ergonomics with the hover navigator pattern
+before wiring real PTY.**
+
+Build:
+
+- `extension/sidepanel/SidePanel.tsx` — 360px-min layout with
+  32px nav rail on the left edge.
+- `extension/sidepanel/NavRail.tsx` — single folder icon button
+  (more icons later for skills, settings, etc.).
+- `extension/sidepanel/NavDrawer.tsx` — 280px slide-in panel with
+  mock filetree (hardcoded entries). `position: absolute`, slide
+  from `translateX(-100%)` to `translateX(0)`, 200ms ease,
+  backdrop-blur on terminal area.
+- `TerminalPane` placeholder — empty xterm with mock prompt.
+- ⌘+B toggles the drawer.
+
+Pass criteria:
+
+- Terminal is comfortably wide at default (no nav drawer): 360px
+  minus 32px rail = ~328px ≈ ~44 columns. Acceptable for the kind
+  of work an agent does.
+- Drawer slide-in feels responsive (<250ms perceived).
+- Click outside / Esc / file click all dismiss.
+- ⌘+B works.
+- Multi-window test: open a second Chrome window, second side panel
+  opens, both share keyboard bindings, drawer state is per-window.
+
+### Phase 2 — Real PTY (1 day)
+
+Wire the terminal pane to a real `node-pty` process through the
+helper.
+
+Build:
+
+- `helper/pty-bridge.ts` — spawns `node-pty`, pipes stdin/stdout
+  through Native Messaging frames.
+- `extension/shim/window-electron.ts` — implement `pty.create`,
+  `pty.write`, `pty.resize`, `pty.kill`, `pty.onData`, `pty.onExit`.
+- `extension/sidepanel/SidePanel.tsx` — replace mock terminal with
+  the real
+  [`renderer/components/TerminalPane.tsx`](../../../renderer/components/TerminalPane.tsx)
+  importing from a local copy or via path mapping.
+
+Pass criteria:
+
+- `vim`, `less`, `htop` render correctly.
+- Backspace doesn't lag.
+- Resize event propagates (drag the panel wider, terminal cols update).
+- ⌘+C / ⌘+V work.
+- Run `claude` in the terminal — agent prompt loads, agent can run
+  shell commands.
+
+### Phase 3 — Real filetree + open canvas-as-tab (1 day)
+
+Build:
+
+- `helper/files-bridge.ts` — `files.list`, `files.read`,
+  `files.write`, `files.watch` (chokidar).
+- `extension/sidepanel/NavDrawer.tsx` — replace mock with real
+  [`renderer/components/FileTree.tsx`](../../../renderer/components/FileTree.tsx).
+- File click handler: `chrome.tabs.create({url:
+  chrome.runtime.getURL('canvas/canvas.html?path=' + encodeURIComponent(path))})`.
+- Canvas page placeholder for now — just renders the path.
+
+Pass criteria:
+
+- Filetree expands / collapses correctly.
+- Modifying a file from the terminal (`echo hi >> foo.md`) updates
+  the tree's modified indicator within 500ms.
+- Click a `.md` file → new tab opens with the path in the URL bar.
+
+### Phase 4 — MarkdownEditor in canvas tab (1 day)
+
+Build:
+
+- `extension/canvas/CanvasPage.tsx` — reads `?path=` from the URL,
+  loads file via shim, mounts
+  [`renderer/components/editor/MarkdownEditor.tsx`](../../../renderer/components/editor/).
+- File change events from the helper push through to the canvas
+  tab via SW → port routing.
+- Drawer's nav drawer also subscribes; "modified" badge updates in
+  the side panel when a canvas tab saves.
+
+Pass criteria:
+
+- Open `foo.md` in canvas tab, edit, save (⌘+S). Reopen the same
+  file in a second canvas tab — sees the edits.
+- Modify the file from the terminal — both canvas tabs pick up the
+  change. (Conflict resolution: last-writer-wins for MVP; flag if
+  this gets ugly.)
+- Close all canvas tabs, helper still has zero leaked file watches
+  (`lsof` check).
+
+### Phase 5 — Tab-driving via lighter APIs (1 day)
+
+Build:
+
+- CLI verb dispatcher (decide in this phase: adapt
+  [`cli/duo.ts`](../../../cli/duo.ts) or write a sibling
+  `cli/duo-ext.ts`). The CLI runs *inside* the helper-spawned PTY,
+  talks to helper over a local socket / pipe, helper bounces the
+  command up to the SW.
+- `duo nav <url>` — `chrome.tabs.update({tabId, url})` or
+  `chrome.tabs.create({url})` depending on flag.
+- `duo click <selector>` — `chrome.scripting.executeScript`
+  injecting a click handler.
+- `duo type <text>` — same pattern.
+- `duo screenshot` — `chrome.tabs.captureVisibleTab`.
+- `duo url`, `duo title` — `chrome.tabs.get`.
+
+Pass criteria:
+
+- Run all six verbs against an already-open Gmail tab while the
+  user is signed in. No yellow banner appears.
+- `duo screenshot` returns an image of the user's actual inbox.
+- The "tab picker" UX (which tab is `duo nav` operating on?) feels
+  reasonable — propose: target the active tab in the focused
+  window by default; `--tab <id>` for explicit targeting; `duo tabs`
+  lists open tabs with IDs.
+
+### Phase 6 — `chrome.debugger` for CDP-only ops (½ day)
+
+Build:
+
+- `duo ax` — attach debugger, send `Accessibility.getFullAXTree`,
+  detach.
+- `duo console` — attach + stream `Runtime.consoleAPICalled` for
+  the next N seconds, then detach.
+- `duo errors` — attach + filter console for errors.
+- SW orchestrates attach/detach so the yellow banner appears only
+  for the duration of the operation.
+
+Pass criteria:
+
+- `duo ax` returns ~140-node AX tree on Gmail (matches
+  duo-in-browser Walk 4 finding).
+- Yellow banner appears during attach, disappears on detach.
+- User clicking "Cancel" on the banner gracefully fails the
+  in-flight call and emits an `agent.banner_cancelled` event the
+  CLI prints clearly.
+
+### Phase 7 — Distribution dry-run (1 day)
+
+Build:
+
+- `installer/build-pkg.sh` — packages the helper binary, the Native
+  Messaging manifest, and an uninstaller. Signs with the same
+  Developer ID Application cert Stage 21a uses. Notarizes via
+  `notarytool`.
+- Web Store unlisted submission of the extension.
+- README install steps:
+  1. Install extension from Web Store (paste the unlisted URL).
+  2. Download `duo-helper-<version>.pkg`.
+  3. Run installer.
+
+Pass criteria:
+
+- A friend who isn't a developer completes the flow in <5 min.
+- `chrome://extensions` shows the extension listed.
+- `chrome://extensions/?id=<id>` "details" view shows the requested
+  permissions; the friend understands what they're for.
+- Side panel opens. Terminal works. `duo edit foo.md` works.
+
+### Phase 8 — Demo + buffer (½ day)
+
+A scripted end-to-end demo that exercises every MVP capability in
+one ~3 minute video / live session:
+
+1. Open Chrome, click extension icon, side panel opens.
+2. Toggle drawer with ⌘+B, navigate to a project, dismiss drawer.
+3. Run `claude` in the terminal.
+4. Agent runs `duo edit README.md` — new tab opens with markdown.
+5. User edits in the new tab, saves.
+6. Agent runs `duo nav https://gmail.com` — Gmail loads in another
+   tab.
+7. Agent runs `duo screenshot` — gets the rendered inbox.
+8. Agent runs `duo ax` — yellow banner appears, AX tree returns,
+   banner disappears.
+
+If any step is awkward, fix it in this buffer or surface it
+explicitly as a follow-up.
+
+---
+
+## Risks
+
+Carried forward from the README's hard/soft blockers, with the
+phase that catches each one:
+
+| Risk | Severity | Caught in |
+|---|---|---|
+| SW idle / native-host death | Hard | Phase 0 |
+| 360px terminal too cramped even with hover navigator | Soft | Phase 1 |
+| Native Messaging 1MB message ceiling on large file reads | Soft | Phase 4 |
+| `chrome.debugger` yellow banner intolerable for ambient agent use | Soft | Phase 6 |
+| Two-step install too friction-heavy for Trailblazers | Soft | Phase 7 |
+| File-conflict UX (two tabs of same file) ugly | Soft | Phase 4 |
+| Enterprise extension policy blocks the permission set | Hard | Out of MVP — pre-Trailblazer audit |
+
+---
+
+## Definition of done
+
+The MVP is done when **all** of the following are true:
+
+1. Phase 0 passed and the SW + helper survive 30+ min of real idle.
+2. A Trailblazer-shaped friend installs both pieces in <5 minutes
+   without hand-holding from the project owner.
+3. The Phase 8 demo runs end-to-end without a single
+   reconnect-the-helper papercut.
+4. The README's hard blockers are either resolved or have been
+   explicitly re-classified as soft (with rationale).
+5. A short follow-up addendum to
+   [`./README.md`](./README.md) closes the research with a
+   "ship-it / shelve-it / pivot-to-X" call.
+
+---
+
+## Effort estimate
+
+| Phase | Days |
+|---|---|
+| 0 — Native Messaging keep-alive | 0.5 |
+| 1 — Side panel + drawer | 1.0 |
+| 2 — Real PTY | 1.0 |
+| 3 — Filetree + canvas-as-tab | 1.0 |
+| 4 — MarkdownEditor in canvas | 1.0 |
+| 5 — Tab-driving (lighter APIs) | 1.0 |
+| 6 — `chrome.debugger` ops | 0.5 |
+| 7 — Distribution dry-run | 1.0 |
+| 8 — Demo + buffer | 0.5 |
+| **Total** | **7.5** |
+
+Add a 30% buffer for MV3 papercuts and unknown unknowns: **≈ 10
+working days**.
+
+For comparison: Stage 21 (DMG + cert + notarization +
+auto-update) absorbed somewhere north of two weeks across 21a/c.
+The MVP, if it works, retires that ongoing cost going forward.
+
+---
+
+## What this plan does NOT cover
+
+- **Roadmap promotion.** This is research. If the MVP succeeds, the
+  next conversation is "do we promote this to a Stage card on
+  [`docs/roadmap.html`](../../roadmap.html), and how does it
+  sequence against the existing Trailblazer / Stage 21 work?" Not a
+  Phase 8 task.
+- **Skill / agent docs.** The `skill/` and `agents/duo.md` work for
+  the extension's CLI verbs is post-MVP. The current verbs in
+  [`skill/SKILL.md`](../../../skill/SKILL.md) and
+  [`agents/duo.md`](../../../agents/duo.md) assume the Electron
+  app's transport. The CLI plumbing checklist in
+  [`CLAUDE.md`](../../../CLAUDE.md) needs an extension-shape
+  variant added before the verbs ship to agents.
+- **Architectural ADR.** If the MVP succeeds and we promote it,
+  [`docs/DECISIONS.md`](../../DECISIONS.md) needs an ADR:
+  "Extension + helper as a peer distribution shape to the Electron
+  app" — including whether they coexist (two distribution targets)
+  or the extension supersedes Electron over time.
+- **Cross-platform helper.** Linux / Windows ports are a
+  post-MVP build, not a polish step.
+
+---
+
+## Walk methodology notes
+
+- Match
+  [`../duo-in-browser/README.md`](../duo-in-browser/README.md) on
+  reuse pattern: shim approach, no abstraction refactor of
+  `renderer/`. The duo-in-browser walk validated this; don't
+  re-litigate.
+- Phase 0 is a real gate — no peeking ahead. The cost of building
+  Phases 1–8 on a sandy SW foundation is not worth shaving the
+  half-day.
+- Helper binary should match the [`cli/duo`](../../../cli/duo) build
+  pattern: esbuild bundle, tracked in git, committed alongside the
+  source. One toolchain, two binaries.
+- Test the Phase 0 idle pattern with a real human idle, not
+  `setTimeout`. The SW scheduler interacts with system idle hints
+  and wall-clock time in ways `setTimeout` cannot capture.
+- The extension's manifest will need `host_permissions: ["<all_urls>"]`
+  for `chrome.scripting`/`chrome.tabs` against arbitrary tabs. This
+  is an alarm-bell permission set; document it crisply in the Web
+  Store listing and the install README so the user understands what
+  they're granting.

--- a/docs/research/duo-as-chrome-extension/refactor-analysis.md
+++ b/docs/research/duo-as-chrome-extension/refactor-analysis.md
@@ -1,0 +1,459 @@
+# Refactor analysis — dual-target codebase
+
+**Status:** Analysis, 2026-04-29. Reads on top of
+[`./README.md`](./README.md) and
+[`./mvp-plan.md`](./mvp-plan.md). The MVP plan walks the extension
+shape *as a sibling to* the Electron app; this document asks the
+deeper question: **what would the codebase look like if we
+committed to supporting both targets long-term, and which of those
+changes are wins regardless of whether the extension ever ships?**
+
+> **Note (2026-04-29 update):** [`./build-roadmap.md`](./build-roadmap.md)
+> composes this analysis's no-regrets moves 1–4 (now Stage A) and
+> the MVP plan's phases (now Stage C) with post-MVP stages into a
+> single end-to-end sequence. Read `build-roadmap.md` first for the
+> full picture; come here for the no-regrets framing.
+
+---
+
+## TL;DR
+
+**Most of `electron/` isn't actually Electron-specific.** Empirically,
+[`grep "from 'electron'" electron/*.ts`](../../../electron/) shows
+**9 of 17 files** import nothing from Electron at all — they sit in
+`electron/` only because the main process imports them from there.
+Of the 8 that do import, **3 of those use Electron only at the
+surface** (a `WebContents.send` call to push events to the renderer)
+with a Node-pure core underneath. So the truly-Electron-coupled
+surface is **5 files out of 17** (`main`, `preload`,
+`browser-manager`, `cdp-bridge`, `auto-updater`, `install-service`,
++ the one Electron API call inside `pty-manager`/`files-service`).
+
+The headline implication: **a service-extraction refactor is
+already overdue and pays off whether or not we ship the extension.**
+It's the largest single chunk of dual-target work and it's also the
+biggest single hygiene win on the existing app. Doing it first makes
+the [MVP plan's Phase 0](./mvp-plan.md#phase-0--native-messaging-keep-alive-proof--½-day)
+much cleaner — the helper just imports from `core/` instead of
+re-implementing five services.
+
+What follows: today's structure, the seven moves a committed
+dual-target codebase needs, then a filter pass on each move for
+no-regrets / conditional / cosmetic.
+
+---
+
+## Today's structure
+
+```
+duo/
+├── electron/                              17 .ts files, 5 truly Electron-coupled
+│   ├── main.ts                            ★ Electron — app lifecycle
+│   ├── preload.ts                         ★ Electron — contextBridge / ipcRenderer
+│   ├── browser-manager.ts                 ★ Electron — WebContentsView
+│   ├── cdp-bridge.ts                      ★ Electron — webContents.debugger
+│   ├── auto-updater.ts                    ★ Electron — electron-updater
+│   ├── install-service.ts                 ★ Electron — permission UI
+│   ├── pty-manager.ts                     ◐ Electron at surface, Node-pure core
+│   ├── files-service.ts                   ◐ Electron at surface, Node-pure core
+│   ├── update-checker.ts                  ◐ Electron at surface, HTTP-pure core
+│   ├── browser-history-service.ts         ✓ pure Node — only fs
+│   ├── claude-presence.ts                 ✓ pure Node — child_process + ps
+│   ├── constants.ts                       ✓ pure Node
+│   ├── nav-pins-service.ts                ✓ pure Node — fs
+│   ├── pins-service.ts                    ✓ pure Node — fs
+│   ├── resolve-claude.ts                  ✓ pure Node — fs path resolution
+│   ├── session-state-service.ts           ✓ pure Node — fs
+│   ├── skills-scanner.ts                  ✓ pure Node — fs
+│   └── socket-server.ts                   ✓ pure Node — net.createServer
+├── renderer/                              React, xterm, TipTap, HtmlCanvas
+├── shared/
+│   ├── types.ts                           1338 lines — IPC shapes + UI types mixed
+│   ├── html-boilerplate.ts                143 lines
+│   ├── fork-config.d.ts                   39 lines
+│   └── ulid.ts                            46 lines
+└── cli/
+    └── duo.ts                             single binary, talks Unix socket / TCP
+
+Legend:
+  ★  fundamentally tied to Electron — stays where it is
+  ◐  surface-coupled — needs an interface adapter
+  ✓  already pure Node — could move to core/ today with zero behavior change
+```
+
+The pure-Node services are the bulk of the file I/O, persistence,
+process detection, and skill-scanning logic. They're sitting in
+`electron/` because of where they happened to be born, not because
+of any architectural reason.
+
+---
+
+## The seven moves a committed dual-target codebase needs
+
+Sequenced from "purely a file-rename and import-update" to "a
+genuine maintenance commitment."
+
+### Move 1 — Extract pure services to `core/`
+
+Promote the nine ✓-marked files to a top-level `core/` package:
+
+```
+core/
+├── browser-history/BrowserHistoryService.ts
+├── claude/ClaudePresence.ts
+├── claude/resolveClaude.ts
+├── constants.ts
+├── nav-pins/NavPinsService.ts
+├── pins/PinsService.ts
+├── session-state/SessionStateService.ts
+├── skills/SkillsScanner.ts
+└── socket-server/
+    ├── SocketServer.ts                    moved from electron/
+    └── commands.ts                        the Stage-20 dispatcher
+```
+
+Mechanical move — no behavior change. Update imports in
+[`electron/main.ts`](../../../electron/main.ts). Done.
+
+**Cost:** ~1 day including import-update sweep and a typecheck pass.
+
+### Move 2 — Split the surface-coupled trio
+
+[`electron/pty-manager.ts`](../../../electron/pty-manager.ts)
+imports `WebContents` from electron and calls `webContents.send()`
+to push PTY data to the renderer. Same for
+[`electron/files-service.ts`](../../../electron/files-service.ts).
+[`electron/update-checker.ts`](../../../electron/update-checker.ts)
+similar pattern.
+
+Replace the `WebContents` dependency with an `EventSink` interface:
+
+```ts
+// core/transport/EventSink.ts
+export interface EventSink {
+  send(channel: string, payload: unknown): void;
+}
+```
+
+Electron implementation: a five-line adapter wrapping `WebContents`.
+Helper implementation (post-extension): wraps the SW port. The
+service code itself sees only `EventSink`.
+
+After this move, `core/pty/PtyManager.ts` and
+`core/files/FilesService.ts` are pure Node + node-pty + chokidar.
+
+**Cost:** ~half a day. The interface is small, the surface is local.
+
+### Move 3 — Split `shared/types.ts`
+
+Today's [`shared/types.ts`](../../../shared/types.ts) is 1338 lines
+mixing IPC channel shapes, command types, UI prop types, and various
+domain models. Split into:
+
+```
+shared/
+├── protocol/                              IPC + CLI message shapes
+│   ├── ipc.ts                             channels, request/response shapes
+│   ├── commands.ts                        DuoCommandName + per-verb args
+│   └── events.ts                          PTY data, file watch, nav events
+├── domain/                                pure data types
+│   ├── files.ts                           FileNode, classifications
+│   ├── canvas.ts                          HtmlOpRequest, edit-log entries
+│   ├── editor.ts                          DuoSelection, doc shapes
+│   └── browser.ts                         tab state, history entries
+└── (existing) html-boilerplate.ts, ulid.ts, fork-config.d.ts
+```
+
+Mechanical re-organization. Imports change shape; nothing breaks.
+
+**Cost:** ~half a day plus careful re-export work to avoid churn in
+every renderer file. Could be done as `shared/types.ts` re-exporting
+from the new files, then files migrate to direct imports gradually.
+
+### Move 4 — Formalize the renderer's host interface
+
+Today the contract that
+[`electron/preload.ts`](../../../electron/preload.ts) builds is
+implicit — `window.electron` is whatever shape preload happens to
+construct. The renderer declares the type via
+`renderer/electron-window.d.ts` (or similar).
+
+Promote the contract to a first-class interface:
+
+```ts
+// shared/host/HostApi.ts
+export interface HostApi {
+  pty: PtyHostApi;
+  files: FilesHostApi;
+  browser: BrowserHostApi;
+  nav: NavHostApi;
+  editor: EditorHostApi;
+  canvas: CanvasHostApi;
+  // ...
+}
+```
+
+Two implementations:
+
+- `electron/preload.ts` — today's flow, but now satisfies
+  `HostApi` at the type level.
+- `extension/shim/window-electron.ts` — the SW-port version (built
+  if/when we walk the extension).
+
+The renderer's global declaration becomes
+`declare global { interface Window { duoHost: HostApi } }`. (Optional
+rename: `window.electron` → `window.duoHost`. The lying name is
+harmless if you skip the rename; it's a one-replace-all if you do
+it.)
+
+**Cost:** ~half a day. Declaring the interface, fixing two or three
+shape mismatches that emerge from the audit.
+
+### Move 5 — Transport-agnostic CLI
+
+[`cli/duo.ts`](../../../cli/duo.ts) today has its transport logic
+inline — Unix-socket-first, TCP fallback. Two refactors needed:
+
+1. **Extract a `Transport` abstraction:**
+
+```ts
+// cli/transport/Transport.ts
+export interface Transport {
+  connect(): Promise<void>;
+  send(req: DuoRequest): Promise<DuoResponse>;
+  close(): void;
+}
+```
+
+2. **Implement two transports today:**
+   - `UnixSocketTransport` — current code
+   - `TcpTokenTransport` — current Stage-20 fallback
+
+   The extension transport (whatever it ends up being — most likely
+   a helper-spawned local socket the helper-launched PTY can reach)
+   slots in as a third implementation later.
+
+3. **Discovery layer:** the CLI tries each transport in order based
+   on what config files / env vars / port files are present.
+
+**Cost:** ~half a day. Mostly a re-org of existing code.
+
+### Move 6 — Build pipeline for two targets
+
+This is where dual-target stops being free.
+
+```
+package.json scripts (today)
+  dev          → electron + vite
+  build        → electron prod
+  dist         → DMG
+
+package.json scripts (dual-target)
+  dev:electron     → today's flow
+  dev:ext          → vite for extension + helper watch + Chrome reload hook
+  build:electron   → today's prod
+  build:ext        → packs extension/ for Web Store
+  build:helper     → packs helper binary
+  dist:electron    → DMG
+  dist:ext         → Web Store zip + helper PKG
+```
+
+Vite needs two configs (one per target's entry points). The renderer
+component imports stay the same; only the entry scaffolding differs.
+
+**Cost:** ~1 day of build-pipeline work, plus ongoing CI / release-
+script maintenance whenever the build moves.
+
+### Move 7 — Plumbing-checklist evolution
+
+[`CLAUDE.md`](../../../CLAUDE.md) has the **CLI plumbing checklist**:
+adding a new verb touches `shared/types.ts`, `electron/preload.ts`,
+`electron/main.ts`, `electron/socket-server.ts`, `cli/duo.ts`,
+`skill/SKILL.md`, `agents/duo.md`, `docs/CLI-COVERAGE.md`. That's
+8 files today.
+
+Dual-target:
+
+- The first three (`shared/types.ts`, preload, main.ts) split into
+  protocol + Electron-specific main vs. extension-specific SW.
+- `socket-server.ts` is now in `core/` and serves both targets, so
+  one file instead of two.
+- `cli/duo.ts` still one file (the transport layer hides the
+  difference).
+- Skill, agent, coverage docs unchanged.
+
+Net: ~10 files instead of 8. The cost isn't the additional touches
+— it's that adding a verb now means *testing in both targets* every
+time. That's a real maintenance commitment.
+
+**Cost:** Small per-verb. Aggregated cost: real. Adding 50 verbs
+over a year at +5 min each is 4 hours of additional testing labor
+spread across a year. Tolerable, not trivial.
+
+---
+
+## No-regrets filter
+
+For each move, ask: **does this pay off if we never ship the
+extension?** Filter into three buckets.
+
+| Move | Cost | Pays off if extension never ships? | Verdict |
+|---|---|---|---|
+| 1 — Extract pure services to `core/` | 1 day | **Yes — large.** Cleaner main.ts, services testable without Electron, kills 17-file `electron/` directory smell. | **No-regrets.** Do regardless. |
+| 2 — Split surface-coupled trio (PTY, Files, UpdateChecker) via `EventSink` | 0.5 day | **Yes — moderate.** Same testability win. The `EventSink` adapter is a 5-line cost vs. ongoing benefit of testable services. | **No-regrets.** Do regardless. |
+| 3 — Split `shared/types.ts` into `protocol/` + `domain/` | 0.5 day | **Yes — small but real.** 1338-line files are smell. Helps every future contributor read the codebase. | **No-regrets.** Do regardless. |
+| 4 — Formalize renderer `HostApi` interface | 0.5 day | **Yes — small.** Catches preload/renderer drift at compile time. Today's drift would surface as runtime errors only. Modest unit-test enabling. | **Advantageous.** Do regardless. |
+| 5 — Transport-agnostic CLI | 0.5 day | **Marginal.** Today's Unix/TCP fallback already does the job inline. The abstraction only pays off if a third transport appears (extension). | **Conditional.** Defer until the extension MVP walks. |
+| 6 — Build pipeline for two targets | 1 day | **No.** Pure cost — second build, second test matrix, second release ritual. Actively wasteful if we don't ship the extension. | **Conditional.** Only do if extension MVP passes Phase 0. |
+| 7 — Plumbing-checklist evolution | per-verb tax | **No.** Pure ongoing cost. Every new verb costs more to ship. | **Conditional.** Only do if dual-target ships. |
+
+### The shape of this filter
+
+Moves 1–4 are **architecture hygiene that pays off today** and
+*also* happens to enable the extension cheaply. Roughly **2.5 days of
+work** to land them, with no behavioral change to the existing app.
+Risk surface: import statements and a small number of type-shape
+adjustments.
+
+Moves 5–7 are **dual-target tax** — only worth paying if we
+actually commit to a second target.
+
+The interesting consequence: **doing moves 1–4 first turns the
+extension MVP from "build a parallel-stack from scratch" into
+"compose existing services through a different transport."** The
+helper goes from "re-implements PtyManager, FilesService,
+SocketServer, the protocol surface, and the command dispatcher"
+to "imports each of those from `core/` and wires up Native
+Messaging." That's probably **half** the current MVP plan's effort,
+and most of the de-risking comes for free.
+
+Pre-MVP, moves 1–4 also retire a long-standing question that's been
+lurking in the codebase: *"why does this Node service live in
+`electron/`?"* The honest answer has always been "it doesn't, we
+just put it there." Now we can stop carrying that.
+
+---
+
+## Sequencing recommendation
+
+Two distinct paths, depending on what gets prioritized first.
+
+### Path A — refactor first, walk second (recommended)
+
+1. **Land moves 1–4 as a self-contained refactor.** ~2.5 days. Open
+   a single PR, ship it as a dot release with an explicit "no
+   functional change, internal restructure" call-out. Run the full
+   smoke matrix per
+   [`docs/dev/smoke-checklist.md`](../../dev/smoke-checklist.md).
+2. **Then walk MVP Phase 0** (the half-day gate from
+   [`./mvp-plan.md`](./mvp-plan.md)). The helper is now ~50 lines:
+   `helper/main.ts` imports from `core/`, exposes Native Messaging
+   stdio, done.
+3. **Then walk Phases 1–8** if Phase 0 passes — significantly
+   cheaper because services and protocol are already shared.
+4. **Move 5 (transport-agnostic CLI)** lands as Phase 5 of the MVP,
+   not as an isolated refactor.
+5. **Moves 6–7** land if and only if the extension is committed to
+   ship.
+
+### Path B — walk first, refactor second
+
+1. Walk MVP Phase 0 immediately (no refactor).
+2. If Phase 0 passes, *then* do moves 1–4 to deduplicate code
+   between the helper (which Phase 0 implemented) and the Electron
+   app.
+3. Continue with MVP Phases 1–8 against the cleaned-up tree.
+
+Path B is what you'd do if you wanted the **fastest possible signal
+on whether the extension shape works at all**. The cost is a small
+amount of throw-away work in Phase 0's hello-world helper, and a
+slightly messier mid-build refactor.
+
+### Why we recommend Path A
+
+The moves 1–4 work is so independently valuable, and so cheap, that
+not doing it requires a positive justification. The only argument
+for Path B is "we're not sure the extension is worth doing at all,
+so don't pre-pay for it" — but moves 1–4 aren't pre-paying for
+the extension. They're paying for cleaner Electron-app code. The
+extension just rides on the side effect.
+
+---
+
+## Risk to existing behavior
+
+Each move can be done with zero behavioral change if executed
+carefully. Specifically:
+
+- **Move 1** (file relocations + import updates): caught by typecheck.
+  No runtime risk if typecheck passes. **Verifiable mechanically.**
+- **Move 2** (`EventSink` adapter): the Electron adapter is a
+  one-liner; renderer behavior identical. **Verifiable by smoke
+  matrix.**
+- **Move 3** (split `shared/types.ts`): re-exports preserve every
+  existing import path during the migration window. **Verifiable by
+  typecheck.**
+- **Move 4** (formalize `HostApi` interface): pure type-system
+  work; no runtime change. **Verifiable by typecheck.**
+
+The smoke matrix is the source of truth for behavioral regression
+post-refactor. Run
+[`docs/dev/smoke-checklist.md`](../../dev/smoke-checklist.md) before
+calling moves 1–4 done.
+
+---
+
+## Effort summary
+
+| | Best case | Realistic | Worst case |
+|---|---|---|---|
+| Moves 1–4 (no-regrets refactor) | 2 days | 2.5 days | 4 days |
+| MVP Phase 0 (post-refactor) | 0.5 day | 0.5 day | 1 day |
+| MVP Phases 1–8 (post-refactor) | 5 days | 7 days | 10 days |
+| Moves 5–7 (conditional, only if shipping extension) | 1.5 days | 2 days | 3 days |
+
+If we walk the full path (refactor + extension MVP):
+**~10–14 working days** end-to-end, **gated at Phase 0** half a day
+in. If Phase 0 fails after the refactor, we're left with a
+materially cleaner Electron codebase — no regret.
+
+---
+
+## Recommendation
+
+**Do moves 1–4 now, regardless of any decision on the extension.**
+
+The 2.5 days of refactor work pays off three times:
+
+1. Today's `electron/` directory stops misleading anyone who reads
+   it about what's actually Electron-specific.
+2. Pure services become unit-testable without spinning up Electron.
+   Several have outstanding QA gaps that this unblocks.
+3. *If* the extension MVP gets walked, Phase 0 onwards is materially
+   cheaper because the helper imports from `core/` instead of
+   re-implementing.
+
+The only argument against is "we have higher-priority work in the
+queue" — which is a scheduling question, not a correctness question.
+
+**Defer moves 5–7 until and unless the extension MVP passes Phase 0
+and we're committed to shipping it.** Each of those is dual-target
+tax, not codebase hygiene.
+
+---
+
+## What this analysis does NOT cover
+
+- **Whether to walk the MVP at all.** That's the question
+  [`./README.md`](./README.md) addresses; this doc takes "we might
+  walk it" as given.
+- **An ADR for the dual-target commitment.** If the extension ships,
+  [`docs/DECISIONS.md`](../../DECISIONS.md) needs an ADR documenting
+  the sibling-distribution choice and the maintenance commitment.
+- **Roadmap stage card.** Promotion of moves 1–4 into a stage on
+  [`docs/roadmap.html`](../../roadmap.html) is a separate
+  conversation. They're small enough to land as a single dot
+  release; large enough to warrant a card if we want them tracked.
+- **Test coverage for the new `core/`.** Pulling services out of
+  Electron makes them testable; *writing* the tests is a separate
+  decision and a separate cost.

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -133,6 +133,17 @@
       <h1>Duo Roadmap</h1>
       <div class="sub">Snapshot 2026-04-29 (post-v0.5.2, bug-smashing sprint) · v0.5.2 closes 5 canvas/install bugs (BUG-031..035) + 2 enhancements (ENH-014 preset pane sizes via View menu + ⌘⌥1/2/3 + <code>duo split</code>; ENH-017 install banner "Add to PATH" button) · v0.5.1 polish + claude-presence gate · v0.5.0 navigator polish (Stage 26 PRs 1+2) + fork-friendly architecture (Stage 21e) · v0.4.3 owner punch-list patch · v0.4.2 auto-update (Stage 21c Phase 1) + session restore (Phase 2 — closes <a href="https://github.com/dudgeon/duo/issues/24">issue #24</a>) + new <a href="HOW-TO-FORK.md" style="color: var(--accent-ink);">HOW-TO-FORK</a> doc · v0.4.1 sandbox-resilience (Stage 20 TCP fallback + <code>duo doctor</code> + sandbox-writable install path) + DMGs <strong>signed + notarized</strong> · v0.4.0 context-pedagogy · v0.3.1 cleanup · v0.3.0 Duo-aware Claude · v0.2.0 FTUX · comments save locally to your browser</div>
       <div class="sub" style="margin-top: 8px;">This file is the canonical roadmap · synced markdown view: <a href="https://github.com/dudgeon/duo/blob/main/ROADMAP.md" style="color: var(--accent-ink);"><code>ROADMAP.md</code></a> · per-stage PRDs in <a href="https://github.com/dudgeon/duo/tree/main/docs/prd" style="color: var(--accent-ink);"><code>docs/prd/</code></a> · architecture decisions in <a href="https://github.com/dudgeon/duo/blob/main/docs/DECISIONS.md" style="color: var(--accent-ink);"><code>DECISIONS.md</code></a></div>
+      <div class="sub" style="margin-top: 12px; padding: 10px 14px; background: rgba(180, 140, 60, 0.08); border-left: 3px solid var(--accent-ink); border-radius: 3px;">
+        <strong>Chrome-extension exploration is a separate, non-gating roadmap.</strong>
+        Lives on branch <code>duo-chrome-extension-exploration</code>; tracked in
+        <a href="https://github.com/dudgeon/duo/blob/duo-chrome-extension-exploration/docs/research/duo-as-chrome-extension/build-roadmap.md" style="color: var(--accent-ink);"><code>build-roadmap.md</code></a>
+        as Stages A–H. None of those stages gate any stage on this main roadmap.
+        <strong>Stage A</strong> (services extracted from <code>electron/</code> to
+        <code>core/</code>, EventSink adapter, <code>shared/host-api.ts</code> split) is a
+        no-regrets refactor that benefits both targets and is a merge candidate
+        back to <code>main</code> once smoke-walked. The <code>phase0/</code> prototype
+        directory is exploration-only — not in the Electron build pipeline.
+      </div>
     </header>
 
     <details class="prework">


### PR DESCRIPTION
## Summary
- Adds `docs/research/duo-as-chrome-extension/` (README, mvp-plan, refactor-analysis, build-roadmap) — the planning artifacts behind the `duo-chrome-extension-exploration` branch.
- Adds cross-reference callouts to `ROADMAP.md`, `docs/roadmap.html`, `CLAUDE.md`, and the build-roadmap itself so anyone reading main understands: the exploration is **non-gating**, Stage A is a no-regrets merge candidate, and `phase0/` is exploration-only.

Pure docs — zero code changes. Cherry-picked from the exploration branch so main has visibility while the exploration continues without blocking main-app evolution.

## Test plan
- [ ] Skim `ROADMAP.md` callout — clear what is and isn't blocking
- [ ] Skim `CLAUDE.md` "Where to look" entry — points future Claude instances at the exploration branch
- [ ] Open `docs/research/duo-as-chrome-extension/build-roadmap.md` — "Relationship to the main Duo roadmap" section reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)