### PR TITLE
docs(extension): cleanup — bring final exploration docs to main

### DIFF
--- a/docs/dev/session-log.md
+++ b/docs/dev/session-log.md
@@ -111,29 +111,80 @@ upload step.
    live in the helper to support both contexts; the CLI's fallback
    logic is what makes "works inside Claude Code" the default.
 
-**What's owed (in priority order):**
+**Evening update (post-verification + Stage A landed):**
 
-- 🟡 **Phases 5/6/6.5 verification.** Geoff to test in real Chrome
-  tonight. Verbs and rail buttons listed in `phase0/README.md` →
-  *"Phase 6.5 — driving Chrome from a terminal"* + the build-
-  roadmap status row notes.
-- ⬜ **Stage A merge to main.** Smoke-walk per
-  `docs/dev/smoke-checklist.md`; PR; merge. Foundation step before
-  any Phase 7 code. Currently parked on exploration branch as
-  commits `366fe4e` (services to `core/`) + `613a87a` (host-api
-  split).
-- ⬜ **Phase 7 execution.** File-by-file work per the implementation
-  plan. ~2 working days. Gated on verification + Stage A merge.
+After Geoff got home: walked the verification checklist
+(`phase0/VERIFICATION-CHECKLIST.md`) end-to-end. All ✅:
+- **Phase 5** rail buttons: `tabs:list` returned "232 tabs — active:
+  Orders - Etsy"; `scripting:title` returned active tab title.
+- **Phase 6** CDP gear button: yellow "Duo started debugging" bar
+  flashed and auto-detached; banner showed "✓ tab #N CDP eval →
+  number 2".
+- **Phase 6.5** from a regular terminal: doctor (sock + tcp OK),
+  tabs (232-element JSON), title, eval — all clean. From inside a
+  sandboxed Claude Code session: same commands worked. Interesting
+  finding — Geoff's specific Claude-Code sandbox didn't block the
+  Unix socket on this run, but the TCP fallback is still load-
+  bearing for sandbox configs that do (per CLAUDE.md's documented
+  failure mode). Belt-and-suspenders earns its keep.
+
+Build-roadmap rows 5/6/6.5 flipped 🟡 → ✅.
+
+Then drove **Stage A → main via PR #42** with computer-use:
+quit production Duo, ran `npm run dev` from the worktree, walked
+the smoke checklist's load-bearing sections via screenshots:
+- App boot: three columns rendered, no mount crashes
+- PTY echo: typed `echo "stage-a-smoke: $(date +%s)"` — output
+  echoed back; multi-tab isolation verified (separate scrollbacks)
+- Socket-server: `duo url`, `duo doctor`, `duo title`, `duo open
+  https://example.com` — all round-tripped through the new
+  `core/socket-server.ts` import path
+- Browser-manager: `duo open` created tab #2 active at example.com
+- Update-checker: dev log line confirms `new UpdateChecker(app.getVersion())`
+  constructed cleanly with the new constructor signature
+
+PR #42 merged. **`core/`, `EventSink`, and `shared/host-api.ts` are
+now on main.** Phase 7's NM-shim refactor can build directly
+against them.
+
+**Five PRs merged to main today:**
+- [#38](https://github.com/dudgeon/duo/pull/38) — research bundle (README, mvp-plan, refactor-analysis, build-roadmap)
+- [#39](https://github.com/dudgeon/duo/pull/39) — distribution strategy (both shapes ship; Electron-as-NM-host)
+- [#40](https://github.com/dudgeon/duo/pull/40) — session-log entry (this entry, originally)
+- [#41](https://github.com/dudgeon/duo/pull/41) — `docs/PRIVACY.md`
+- [#42](https://github.com/dudgeon/duo/pull/42) — Stage A refactor (services → core/, host-api split)
+
+Plus this commit: docs cleanup that brings the build-roadmap status
+flips, the Phase 7 implementation plan, and the Web Store listing
+pre-bake to main.
+
+**What's owed (in priority order, post-verification):**
+
+- ✅ ~~Phases 5/6/6.5 verification~~ — done
+- ✅ ~~Stage A merge to main~~ — landed via PR #42
+- ⬜ **Phase 7 execution.** File-by-file work per
+  [`docs/research/duo-as-chrome-extension/phase7-implementation-plan.md`](../research/duo-as-chrome-extension/phase7-implementation-plan.md).
+  ~2 working days. The exploration branch's `phase0/` directory
+  becomes the basis for the cutover but doesn't merge to main as-is —
+  the helper logic collapses into a `--nm-shim` mode in
+  `electron/main.ts`, the extension surface lands at top-level
+  `extension/` (renamed from `phase0/extension/`).
 - ⬜ **Web Store unlisted upload + Trailblazers cohort dogfood.**
   Phase 7 milestone; runs ≥30 days before public promotion.
+  Listing copy + permission justifications + privacy policy
+  pre-baked at [`docs/research/duo-as-chrome-extension/web-store-listing.md`](../research/duo-as-chrome-extension/web-store-listing.md).
 - ⬜ **Public Web Store promotion + background-mode menu bar.**
   Phase 8.
 
 **Branch state at session end:**
-`duo-chrome-extension-exploration` is 14 commits ahead of `main`.
-Two PRs merged to main this session ([#38](https://github.com/dudgeon/duo/pull/38) docs research bundle,
-[#39](https://github.com/dudgeon/duo/pull/39) distribution strategy). Latest exploration
-commit: `9178264 chore(phase7-prep): prod bundle script + duo-ext skill + Web Store listing draft`.
+- `main` has all docs + Stage A. Five PRs merged today.
+- `duo-chrome-extension-exploration` retains the `phase0/` prototype
+  for the Phase 7 cutover. 21 commits ahead of `main`; nothing in
+  that delta needs to merge as-is — Phase 7's refactor will replace
+  the relevant pieces.
+- The local worktree at `.claude/worktrees/elegant-sanderson-05aa7a`
+  was deleted at session end. Next pickup happens on the origin
+  repo at `~/Documents/GitHub/duo`.
 
 ---
 

--- a/docs/research/duo-as-chrome-extension/build-roadmap.md
+++ b/docs/research/duo-as-chrome-extension/build-roadmap.md
@@ -273,17 +273,39 @@ in a Chrome tab, agent-driven Gmail screenshot, AX tree via
 
 ### Phase summary (full detail in `mvp-plan.md`)
 
-| Phase | Deliverable | Days |
-|---|---|---|
-| 1 | Side panel UI scaffolding + nav drawer (mock data) | 1.0 |
-| 2 | Real PTY through Native Messaging — leverages `core/pty/PtyManager` from Stage A | 1.0 |
-| 3 | Real filetree + open canvas-as-tab — leverages `core/files/FilesService` | 1.0 |
-| 4 | MarkdownEditor in canvas tab, file r/w through helper | 1.0 |
-| 5 | Tab-driving via lighter `chrome.tabs`/`chrome.scripting` APIs | 1.0 |
-| 6 | `chrome.debugger` for CDP-only operations | 0.5 |
-| 7 | Distribution dry-run — Web Store unlisted + helper PKG | 1.0 |
-| 8 | End-to-end demo + buffer | 0.5 |
-| **Total** | | **7.0** |
+| Phase | Deliverable | Days | Status |
+|---|---|---|---|
+| 1 | Side panel UI scaffolding + nav drawer (mock data) | 1.0 | ✅ |
+| 2 | Real PTY through Native Messaging — leverages `core/pty/PtyManager` from Stage A | 1.0 | ✅ |
+| 3 | Real filetree + open canvas-as-tab — leverages `core/files/FilesService` | 1.0 | ✅ |
+| 4a | File r/w through helper (`files:read` / `files:write`); plain textarea editor in canvas tab — validates the r/w path before adding the React toolchain | 0.3 | ✅ |
+| 4b | esbuild bundle + React + TipTap markdown editor in canvas tab — validates the React toolchain question without a Vite reorg | 0.5 | ✅ |
+| 5 | Tab-driving via lighter `chrome.tabs`/`chrome.scripting` APIs | 0.3 | ✅ |
+| 6 | `chrome.debugger` for CDP-only operations — `agent:cdp:eval` attach/eval/detach gate | 0.2 | ✅ |
+| 6.5 | CLI bridge — helper-side Unix socket + TCP fallback (sandbox-tolerant); `duo-ext` binary | 0.5 | ✅ |
+| 7 | Distribution refactor — Electron-app-as-NM-host + Web Store unlisted (see `distribution-strategy.md`) | 2.0 | ⬜ |
+| 8 | Public Web Store promotion + background-mode menu bar (see `distribution-strategy.md`) | 1.0 | ⬜ |
+| **Total** | | **7.0** | |
+
+**Status legend:** ✅ shipped + verified · 🟡 shipped, awaiting Geoff
+verification (test in real Chrome before flipping to ✅) · ⬜ not yet
+started.
+
+**Distribution strategy** for Phase 7/8 lives in
+[`distribution-strategy.md`](./distribution-strategy.md). TL;DR:
+both shapes ship indefinitely; the Electron app is the foundation
+and serves as the Native Messaging host (`Duo.app --nm-shim`); no
+separate helper PKG; explicit `chrome:` / `embedded:` verb prefixes
+disambiguate the two browser surfaces.
+
+**Phase 4 split rationale.** The original Phase-4 deliverable
+("MarkdownEditor in canvas tab + file r/w through helper") bundles two
+unknowns: (a) does file r/w work end-to-end through Native Messaging,
+and (b) does Vite + React + TipTap build cleanly inside the extension
+shape? Splitting into 4a (textarea + r/w) and 4b (build toolchain +
+MarkdownEditor) lets each unknown land independently — each half is
+small enough to validate in one session. Phase 4a also keeps `phase0/`
+"no build step, vanilla JS" until 4b explicitly opts in.
 
 Add 30% buffer for MV3 papercuts: **~9 working days.**
 

--- a/docs/research/duo-as-chrome-extension/phase7-implementation-plan.md
+++ b/docs/research/duo-as-chrome-extension/phase7-implementation-plan.md
@@ -1,0 +1,294 @@
+# Phase 7 implementation plan
+
+> **Status:** Draft, 2026-04-30. Concretizes
+> [`distribution-strategy.md`](./distribution-strategy.md) into
+> file-level work. Phase 7 is scoped to the architectural cutover
+> (Electron app becomes the NM host, `phase0/helper/` becomes a
+> 50-line shim, extension talks to Electron's socket-server). Phase 8
+> handles the rename from `phase0/` to top-level + Web Store
+> promotion + background-mode menu bar.
+
+## Prerequisites
+
+Before any code changes:
+
+- 🟡 **Phases 5/6/6.5 verified** — the agent verb wire format and
+  CLI bridge protocol are proven working. Without this, Phase 7
+  builds on potentially-broken contracts.
+- ⬜ **Stage A merged to main** — `core/` is the foundation that
+  the Electron app's main process and the NM shim both share.
+  Smoke-walk per `docs/dev/smoke-checklist.md`, PR, merge.
+- ⬜ **Decision review** — re-read `distribution-strategy.md` decision
+  log; confirm none of those choices have aged out (auto-launch vs.
+  background-mode, `chrome:` prefix, Web Store name, etc.).
+
+## Scope summary — what changes
+
+| File / area | Change | LOC est. |
+|---|---|---|
+| `electron/main.ts` | New `--nm-shim` startup branch; bypass BrowserWindow, run stdio↔socket proxy loop | +60 |
+| `electron/socket-server.ts` | Add `agent:*` and `cli:request` message dispatch; reuse existing CLI verb path | +80 |
+| `electron/install-nm-manifest.ts` (new) | First-run install routine that drops the NM manifest at `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.duo.app.json` | +40 |
+| `electron/menu.ts` | Add Help → "Reset Chrome integration" menu item | +10 |
+| `cli/duo.ts` | Add `chrome:` / `embedded:` prefix routing; protocol-version handshake awareness | +60 |
+| `phase0/extension/sw.js` | Switch port name from `com.duo.phase0` to `com.duo.app`; add protocol handshake | +30 |
+| `phase0/extension/manifest.json` | Bump to v0.7.0; description/permissions roll forward | +0 |
+| `phase0/helper/duo-helper.js` | **DELETE most of it**. Becomes a 50-line stdio↔socket proxy shim. PTY/files/CLI-bridge code moves to Electron. | -350 |
+| `phase0/helper/install.sh` | **DELETE**. NM install moves into the Electron app's first-run routine. | -150 |
+| `phase0/cli/duo-ext` | **DELETE**. Functionality merges into `cli/duo.ts`. | -250 |
+
+Net: roughly **-470 LOC** (much of `phase0/helper/` collapses; the
+NM shim is tiny). One new ~40 LOC file (`install-nm-manifest.ts`).
+
+## File-by-file detail
+
+### `electron/main.ts` — `--nm-shim` startup branch
+
+```ts
+// At the top of main(), before any Electron BrowserWindow setup:
+if (process.argv.includes('--nm-shim')) {
+  await runNmShim()
+  return
+}
+
+// ... rest of main() unchanged ...
+```
+
+The `runNmShim()` function:
+
+1. Opens stdio in binary framing mode (length-prefixed JSON, same
+   format as Chrome's NM protocol).
+2. Connects to the running Electron app's socket at
+   `~/Library/Application Support/duo/duo.sock` (with TCP fallback
+   per Stage 20 ADR).
+3. If the socket isn't reachable: `child_process.spawn` Duo.app via
+   `/usr/bin/open -gj /Applications/Duo.app`; poll the socket every
+   200ms for up to 5 seconds; bail with a clean error if it never
+   comes up.
+4. Once connected, proxy stdin frames → socket and socket replies →
+   stdout, both as the same length-prefixed JSON envelope. No
+   schema awareness — this is a dumb pipe.
+5. On stdin EOF (Chrome closed the NM port), close the socket and
+   exit 0.
+
+The shim runs as a *separate process invocation* of the same Duo
+app binary. Chrome spawns one shim per NM connection; the Electron
+app stays running across many shim spawns.
+
+### `electron/socket-server.ts` — accept agent verbs + cli:request
+
+The current socket-server.ts handles CLI verbs from `cli/duo` (the
+existing CLI). The diff:
+
+1. **Add `agent:*` cases** to the existing switch statement. Each
+   maps to a method on `BrowserManager` (for embedded surface) or
+   uses `chrome.tabs` / `chrome.scripting` semantics… **wait** —
+   those don't exist server-side. Server-side, the `agent:*` verbs
+   coming from the extension are *requests to drive Chrome*, which
+   the Electron app cannot do directly. So the routing inverts:
+   - `agent:*` from extension → echo back via the same NM shim
+     pipe to the extension SW, which uses `chrome.tabs` /
+     `chrome.scripting` / `chrome.debugger` to actually drive
+     Chrome.
+   - `embedded:*` from extension or local CLI → Electron's
+     BrowserManager / CdpBridge handles directly.
+   - `chrome:*` from local CLI → goes through the NM shim back
+     into the extension SW, which runs the agent verb against
+     Chrome.
+
+   This is the key insight. The CLI verb prefixes route to
+   *different driver instances*, and the socket-server is the
+   switchboard.
+
+2. **Add `cli:request` handling** for the bridge case: a CLI verb
+   needs to round-trip out to the extension SW. The socket-server
+   maintains a map of `extensionPorts` (each NM shim that connects
+   adds a port; on cli:request with a `chrome:` verb, route to one
+   of those ports and await the response).
+
+3. **Add the protocol handshake** as the first message any new
+   port receives:
+   ```json
+   {"type": "hello-ack", "ok": true,
+    "electronVersion": "0.7.0", "supportedProtocols": [1]}
+   ```
+
+### `electron/install-nm-manifest.ts` — new file
+
+Called once on Electron app first launch (and again whenever the
+"Reset Chrome integration" menu item is picked). Idempotent.
+
+```ts
+// Drops a JSON manifest at the Chrome NM lookup path pointing at
+// the running Duo.app's binary with --nm-shim flag.
+//
+// Strips com.apple.provenance xattr from the binary if Chrome's
+// hardened-runtime sandbox blocks the spawn (per phase0/README.md
+// "Known gotchas"). Logs the install to ~/.claude/duo/install.log.
+
+export async function installNmManifest(extensionId: string): Promise<void>
+```
+
+Key details:
+- Manifest path: `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.duo.app.json`
+- Binary path: `/Applications/Duo.app/Contents/MacOS/Duo --nm-shim`
+  (or `app.getPath('exe')` for dev)
+- `allowed_origins`: starts with the extension's published ID once
+  Web Store publishes; for unlisted/dev cohort, include the
+  current sideloaded extension ID.
+
+### `cli/duo.ts` — verb prefix routing + handshake
+
+Current `cli/duo.ts` already speaks the Electron socket protocol.
+Phase 7 adds:
+
+1. **Verb prefix parsing** before sending to socket:
+   ```ts
+   // duo nav <url>          → DuoCommandName 'nav', target='auto'
+   // duo embedded:nav <url> → DuoCommandName 'nav', target='embedded'
+   // duo chrome:nav <url>   → DuoCommandName 'nav', target='chrome'
+   ```
+2. The socket-server reads `target` to decide routing. `auto`
+   defaults to whichever surface matches the calling PTY's session
+   origin (env var `DUO_SESSION_ORIGIN=embedded|chrome`).
+3. **Protocol version** in the first message. The CLI doesn't need
+   to handle mismatch (the user gets a clear error from the
+   server's reply); the extension does.
+
+### `phase0/extension/sw.js` — name + handshake
+
+1. Change `HELPER_NAME = 'com.duo.phase0'` to `'com.duo.app'`.
+2. After `connectNative`, send `hello` with `{protocolVersion: 1, extensionVersion: chrome.runtime.getManifest().version}`.
+3. On `hello-ack` with `ok: false`: dispatch a side-panel error
+   message (rendered as the failure card per the strategy doc's
+   failure-UX table).
+4. Otherwise resume normal operation.
+
+### `phase0/helper/duo-helper.js` — collapses to a shim
+
+Most of the current 250+ line helper goes away. PTY logic, files
+logic, agent verb dispatch, CLI socket — all of these now live in
+the Electron app. What remains is just the 50-line stdio↔socket
+proxy described above… which, since the same logic is also in
+`electron/main.ts`'s `--nm-shim` mode, means **the helper file
+deletes entirely**. The NM manifest points at Duo.app's binary, not
+at the helper.
+
+```bash
+git rm phase0/helper/duo-helper.js
+git rm phase0/helper/install.sh
+git rm -r phase0/helper/  # whole directory goes
+```
+
+### `phase0/cli/duo-ext` — collapses
+
+Same fate. The unified `cli/duo` handles all transports. Delete:
+
+```bash
+git rm phase0/cli/duo-ext
+git rm -r phase0/cli/
+```
+
+## Testing matrix
+
+After Phase 7 work, walk this matrix before promoting:
+
+1. **Electron app standalone (no extension installed)** — terminal,
+   embedded browser, file edits, canvas, all CLI verbs without
+   prefix. Should be indistinguishable from v0.6.x.
+2. **Electron app + extension, both running** — open extension's
+   side panel; agent verbs reach Chrome; embedded verbs reach the
+   Electron app's pane; auto-launch isn't triggered (app already
+   up).
+3. **Extension only, Electron app not running** — open extension's
+   side panel; auto-launch fires; Duo.app comes up; extension
+   connects after ~3s; verbs work.
+4. **Extension on Electron-too-old** — install extension v0.7+ but
+   keep Electron at v0.6.x; protocol mismatch should produce the
+   side-panel error card with a download link.
+5. **Sandbox-tolerant CLI** — run `duo tabs` and `duo embedded:nav`
+   from inside a Claude Code sandbox; both succeed via the TCP
+   fallback path.
+6. **Reset Chrome integration menu** — menu item re-installs the
+   NM manifest cleanly; existing extension port reconnects on next
+   activity.
+
+## Web Store prep checklist
+
+Independent of code work; can run in parallel:
+
+- [ ] Icon — 128x128 PNG (Web Store requirement). Use existing Duo
+      app icon.
+- [ ] Screenshots — at least 3, 1280x800 or 640x400. Side panel
+      open showing terminal + filetree; canvas tab with markdown
+      editor; agent verb running.
+- [ ] Privacy policy — short page on the Duo website (or GitHub
+      Pages) covering what the extension reads (active tab content
+      via `<all_urls>` for `chrome.scripting`) and what it sends
+      where (only to the local Duo.app via NM; nothing leaves the
+      machine).
+- [ ] Description — 132 chars + 16,000 char detailed. Position as
+      "companion to Duo Desktop", reference the website, link the
+      privacy policy.
+- [ ] Permission justifications — one paragraph each for `<all_urls>`,
+      `tabs`, `scripting`, `debugger`, `nativeMessaging`, `sidePanel`.
+- [ ] Single-purpose justification — Web Store rule: one core use
+      case per extension. Use case = "Pair your Chrome with Duo
+      Desktop's terminal sessions; let Claude drive your tabs."
+- [ ] Web Store dev account — $5 one-time fee. Use Geoff's
+      personal account or a dedicated Duo account.
+
+## Out of scope for Phase 7
+
+These are deliberately deferred:
+
+- **Background-mode menu bar.** Auto-launch covers the first-time
+  case; background-mode is an optimization. Phase 8 if cohort
+  feedback says always-on matters.
+- **Cross-platform.** Electron app is macOS-only; extension follows.
+  Linux/Windows is its own discussion.
+- **`phase0/` rename to top-level.** That's Phase 8 cleanup once
+  the architecture is stable on `main`.
+- **`cli/duo` consolidation polish** — auto-detect transport, drop
+  duplicate verbs, etc. Phase 7 just adds prefix routing and the
+  handshake; further polish is Phase 8.
+- **Skill update for Chrome surface.** `skill/SKILL.md` and
+  `agents/duo.md` need new entries for `chrome:nav`, `chrome:title`,
+  etc. Mechanical work; can run in parallel with Phase 7 code.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Electron app crash during NM shim spawn → extension shows ECONNREFUSED forever | Shim has 5s connect timeout + clean error; auto-launch retries once on initial failure |
+| User has multiple Electron app instances (e.g. dev build + production) | Manifest's `allowed_origins` is per-extension-ID; only one Duo binary registered at a time. Document the conflict in install routine |
+| Chrome NM spawn fails silently due to xattr (Sequoia gotcha) | Install routine strips `com.apple.provenance` from the Duo.app binary before writing the manifest |
+| Web Store reviewer rejects `<all_urls>` | Permission justification text emphasizes localhost-only data flow + agent-pair-coding use case; alternative is to scope to specific origins (slack, github, gmail, etc.) but loses generality |
+| Two Electron apps + one extension creates port conflict | Socket-server uses TCP `0` (ephemeral port); port file rotates per app instance. Extension reconnects to whichever app is currently running |
+| Auto-launch annoys users | Add a manifest setting "Don't auto-launch" → extension shows "Click to start Duo" button instead. v0.7.x ships auto-launch on; v0.8.x can let user opt out |
+
+## Effort
+
+Roughly **2 working days** end-to-end:
+
+- 0.5 day: NM shim + first-run install routine + handshake
+- 0.5 day: socket-server agent verb routing + extension SW changes
+- 0.5 day: CLI prefix routing + tests
+- 0.5 day: Web Store listing prep + walking the test matrix
+
+Web Store review takes 3-5 business days separately; submit early.
+
+## Done definition
+
+Phase 7 is done when:
+
+- ✅ Test matrix above all-green
+- ✅ Unlisted Web Store listing live with private install URL
+- ✅ Stage 21d Trailblazers cohort can install both shapes from a
+  single set of instructions and have everything work first try
+- ✅ `phase0/helper/` and `phase0/cli/` directories are gone
+- ✅ `cli/duo` handles `chrome:` and `embedded:` prefixes correctly
+- ✅ Helper log heartbeat in `~/.claude/duo/phase0-helper.log` is
+  replaced by an Electron-app log path that the user can tail
+- ✅ `docs/research/duo-as-chrome-extension/build-roadmap.md`
+  Phase 7 row flips ✅

--- a/docs/research/duo-as-chrome-extension/web-store-listing.md
+++ b/docs/research/duo-as-chrome-extension/web-store-listing.md
@@ -1,0 +1,356 @@
+# Web Store listing — Duo for Chrome
+
+> **Status:** Draft, 2026-04-30. Pre-baked content for the Chrome
+> Web Store submission that lands in Phase 7. Reviewed before
+> upload; iterate based on Web Store reviewer feedback.
+
+## Listing metadata
+
+| Field | Value |
+|---|---|
+| Extension name | `Duo for Chrome` |
+| Short summary (132 chars max) | `Pair Claude Code terminals with your Chrome — let your AI agent drive tabs, edit markdown, and live in your real browser.` |
+| Category | Developer Tools |
+| Language | English (United States) |
+| Pricing | Free |
+| Visibility (initial) | Unlisted (Trailblazers cohort) |
+| Visibility (eventual) | Public — gated on cohort dogfood signal per `distribution-strategy.md` Phase 8 |
+| Website | https://github.com/dudgeon/duo |
+| Support email | dudgeon@gmail.com (or a project-specific alias) |
+
+## Description (16,000 chars max)
+
+```markdown
+**Duo for Chrome** is the browser-side companion to Duo Desktop,
+an AI-paired coding workspace. The extension turns Chrome's side
+panel into a Duo terminal session and gives the agent in your
+terminal the ability to drive your Chrome tabs — read what's on
+screen, navigate, click, fill forms, and run scripts in any page.
+
+## What's it for?
+
+You're working with Claude Code on a coding task that touches the
+web — debugging an API call against a live page, scaffolding code
+based on a documentation site, filling forms in a staging
+environment, or asking the agent to look something up while you
+write. Without Duo, you context-switch: tell Claude what you saw,
+copy-paste between windows, lose your place. With Duo for Chrome,
+the agent is *already in your browser*, alongside the terminal
+session. Same Chrome you use every day — same cookies, same
+sign-ins, same extensions, same history.
+
+## What it does
+
+- **Terminal in the side panel.** A real PTY (zsh / bash / fish)
+  running locally on your machine, displayed in Chrome's side
+  panel. Open it from any tab; xterm-class fidelity (256 colors,
+  proper scrollback, copy/paste).
+- **Filetree + canvas-tab editor.** Browse and edit markdown files
+  from your home directory. Editor opens in a Chrome tab; full
+  TipTap-based markdown surface (headings, lists, code, tables).
+- **Agent drives Chrome.** The CLI in your terminal exposes verbs
+  like `duo chrome:nav`, `duo chrome:title`, `duo chrome:script`
+  — so when you tell Claude "open the docs page and grab the rate
+  limit value," it just does that, in your real browser.
+
+## Requirements
+
+- **Duo Desktop** — the extension is the Chrome-side companion to
+  Duo Desktop, the macOS app. Install Duo Desktop first from
+  https://github.com/dudgeon/duo/releases. The extension auto-
+  launches Duo Desktop when needed; close it any time and the
+  side panel reconnects on next use.
+- **macOS only (today).** The extension itself works in any
+  Chromium-based browser, but Duo Desktop is currently macOS-only.
+  Linux / Windows support is on the roadmap.
+- **Chrome 120+** for the side panel API and Manifest V3 features
+  this extension uses.
+
+## Permissions — why we ask for each
+
+- **`<all_urls>`** — required so the agent can read and script
+  pages on any site you visit. The data **stays on your machine**;
+  it's read by `chrome.scripting` and forwarded only to Duo
+  Desktop running locally on your computer. Nothing is sent to
+  any remote server.
+- **`tabs`** — list, open, close, focus tabs.
+- **`scripting`** — run small functions in the page (read DOM,
+  click elements, fill forms). The lighter alternative to
+  `chrome.debugger` for routine ops.
+- **`debugger`** — used only for ops `chrome.scripting` can't
+  perform (full Runtime.evaluate, network interception, etc.).
+  When this is active, Chrome shows a yellow "Duo started
+  debugging this tab" bar — that's a Chrome-imposed security
+  surface, not something we can hide. Auto-detaches when the op
+  completes.
+- **`nativeMessaging`** — talk to Duo Desktop on your computer.
+- **`alarms`** — keep the service worker alive at a 25-second
+  cadence (defeats Chrome's idle-timeout, which would otherwise
+  kill the helper connection — empirically validated against
+  the failure mode documented in
+  https://github.com/anthropics/claude-code/issues/16350).
+- **`sidePanel`** — host the terminal + filetree UI.
+
+## Privacy
+
+We don't collect anything. The extension talks only to Duo Desktop
+running locally on your computer (via Chrome's Native Messaging
+protocol — `chrome.runtime.connectNative`). No data leaves your
+machine. We have no servers. We don't have analytics. We can't see
+what you do, and neither can anyone else.
+
+For complete details:
+https://github.com/dudgeon/duo/blob/main/docs/PRIVACY.md
+
+## Open source
+
+GPL-3.0 licensed. Source at https://github.com/dudgeon/duo. Issues
+and pull requests welcome.
+```
+
+## Single-purpose statement (Web Store rule — one core use case)
+
+> Duo for Chrome's single purpose is to let an AI coding agent
+> running in a local terminal session pair with the user's Chrome
+> browser — reading page state, driving navigation, and editing
+> local markdown files in a Chrome tab. The terminal, file editor,
+> and tab-driving capabilities all serve this one workflow: AI-
+> paired coding that doesn't require the user to leave their
+> browser.
+
+## Permission justifications (verbatim, for Web Store submission form)
+
+Each gets a single short paragraph:
+
+### `<all_urls>`
+
+```
+The agent in the user's terminal session needs to read and script
+pages on any site the user is browsing. The data stays on the
+user's machine — pages are read via chrome.scripting and forwarded
+only to the local Duo Desktop application via Native Messaging.
+There is no remote endpoint and no telemetry. Without <all_urls>,
+the agent cannot operate on the user's daily browsing context,
+defeating the extension's purpose.
+```
+
+### `tabs`
+
+```
+The extension lets the agent list open tabs, open new tabs, close
+tabs, and focus tabs from the side-panel-adjacent terminal. This
+is the lightest-weight Chrome API surface for those ops; the
+heavier chrome.debugger API is reserved for tasks where
+chrome.tabs and chrome.scripting are insufficient.
+```
+
+### `scripting`
+
+```
+The agent runs small functions in the active page — to click an
+element, read text, fill a form field, or extract structured data.
+Each invocation is one short function executed in the page context;
+no long-running scripts are injected. The user can see exactly
+what the agent does because the side-panel terminal logs every
+verb invocation.
+```
+
+### `debugger`
+
+```
+Used only for operations chrome.scripting cannot perform: complete
+Runtime.evaluate (for cases requiring expression evaluation
+returning by value), Network domain interception, and similar
+operations that strictly need CDP. When debugger is active, Chrome
+shows the user a "Duo started debugging this tab" yellow bar
+(Chrome-imposed and visible, not something we can suppress). The
+extension always detaches the debugger when each operation
+completes; the bar disappears.
+```
+
+### `nativeMessaging`
+
+```
+Used to talk to Duo Desktop, a macOS application that runs locally
+on the user's machine. The extension does not connect to any
+remote server. All terminal sessions, file I/O, and agent verb
+dispatch happen via this Native Messaging channel between Chrome
+and the local Duo Desktop process.
+```
+
+### `alarms`
+
+```
+Sets a 25-second-period alarm to keep the Manifest V3 service
+worker alive between user interactions. Without this, Chrome's
+idle timeout (~30s) would kill the service worker and disconnect
+the Native Messaging port to Duo Desktop. The user would see the
+extension fail mid-task with no signal of why. This pattern is
+documented as a known MV3 issue at
+https://github.com/anthropics/claude-code/issues/16350.
+```
+
+### `sidePanel`
+
+```
+The extension's primary surface is the Chrome side panel — it
+hosts the terminal, file navigator, and agent test buttons.
+Without this permission the extension would have no UI surface.
+```
+
+## Icons
+
+| Size | Source | Status |
+|---|---|---|
+| 16×16 | Generated from `build/icon.icns` via `sips -z 16 16` | ✅ `phase0/extension/icons/icon-16.png` |
+| 32×32 | Same | ✅ `phase0/extension/icons/icon-32.png` |
+| 48×48 | Same | ✅ `phase0/extension/icons/icon-48.png` |
+| 128×128 | Web Store listing icon. Required. | ✅ `phase0/extension/icons/icon-128.png` |
+
+Wired into `manifest.json`'s `icons` and `action.default_icon`
+fields so Chrome surfaces them in the toolbar, extension picker,
+and Web Store listing without further wiring. Re-extract from the
+desktop icns if the desktop icon ever changes:
+
+```bash
+for s in 16 32 48 128; do
+  sips -s format png -z $s $s build/icon.icns \
+       --out phase0/extension/icons/icon-$s.png
+done
+```
+
+## Screenshots
+
+Web Store requires at least one, recommends 3-5. Each must be 1280×800
+or 640×400 PNG/JPG.
+
+Plan for Phase 7:
+
+1. **Side panel hero shot** — Chrome window with the side panel
+   open, terminal showing `claude` running, ⌘B drawer open with a
+   filetree visible. Caption: "A real terminal in your side panel.
+   Real PTY, real shell, real Claude Code."
+2. **Canvas tab editor** — A second Chrome tab opened to a markdown
+   file via the side panel filetree. Caption: "Edit markdown files
+   from your home directory in a Chrome tab. Real TipTap editor."
+3. **Agent driving Chrome** — Side panel terminal showing
+   `duo chrome:nav github.com` followed by Chrome navigating; the
+   active tab in the screenshot reflects the navigation.
+   Caption: "Tell Claude what to do. The CLI drives your real
+   Chrome."
+4. **Auto-launch Duo Desktop** — Side panel showing "Connected to
+   Duo Desktop v0.7.0" status. Caption: "Pairs with the Duo Desktop
+   macOS app. Auto-launches when you need it."
+
+Capture flow:
+- Run extension in real Chrome on macOS.
+- Use Cmd-Shift-4 (with space) to capture window with shadow.
+- Crop to 1280×800 in Preview.app.
+
+## Submission checklist
+
+- [ ] Web Store developer account ($5, one-time) — Geoff's personal
+      Google account vs. dedicated `duo@…` account decision
+- [ ] Privacy policy hosted at a stable URL (this doc + a short
+      summary at https://github.com/dudgeon/duo/blob/main/docs/PRIVACY.md)
+- [ ] Icons generated (4 sizes)
+- [ ] Screenshots captured (3-5)
+- [ ] Listing copy reviewed (description above)
+- [ ] Permission justifications copy-pasted into the Web Store form
+- [ ] Single-purpose statement copy-pasted
+- [ ] Build the production CRX:
+      `npm run build:ext-canvas:prod`
+      `cd phase0/extension && zip -r ../../duo-extension-vX.X.X.zip .`
+- [ ] Upload the CRX to the Web Store dashboard
+- [ ] Set visibility to **Unlisted** (not Public)
+- [ ] Save the install URL — share with the Trailblazers cohort
+- [ ] Wait for review (3-5 business days typical for unlisted)
+- [ ] Once approved, run Phase 8 cohort dogfood for ≥30 days
+- [ ] Promote to Public per the strategy doc's gate criteria
+
+## Privacy policy stub
+
+This will live at `docs/PRIVACY.md` on the main repo (cherry-pick to
+main as part of Phase 7). Pre-baked content:
+
+```markdown
+# Duo for Chrome — Privacy Policy
+
+Last updated: 2026-04-30 (draft; effective on first Web Store
+publication).
+
+## TL;DR
+
+Duo for Chrome does not collect any data. It talks only to Duo
+Desktop running locally on your computer. No data leaves your
+machine.
+
+## What we do not do
+
+- We do not run any servers.
+- We do not collect any user data.
+- We do not have analytics.
+- We do not transmit page content, form data, or any other browser
+  state to any remote endpoint.
+- We do not embed third-party trackers, advertising networks, or
+  fingerprinting code.
+
+## What the extension does locally
+
+The extension connects to Duo Desktop, a macOS application running
+on your own computer, via Chrome's Native Messaging protocol. All
+terminal output, file I/O, and agent commands flow over this local
+connection. No part of this connection traverses the internet.
+
+When the agent uses `chrome.scripting` or `chrome.debugger` to
+read a page, the page content is read from Chrome and forwarded
+to Duo Desktop. Both endpoints are on your machine.
+
+## What Chrome sees
+
+Chrome's Web Store policy requires us to declare what user data
+we access. Chrome treats the following as "user data" even though
+nothing leaves your computer:
+
+- **Page content** of tabs you visit — read by `chrome.scripting`
+  when an agent verb requires it.
+- **Tab list, URLs, titles** — read by `chrome.tabs`.
+- **Cookies, local storage, etc.** — never directly accessed by
+  this extension.
+
+If you stop using the extension or uninstall it, no data persists
+anywhere — there's nowhere for data to persist *to*.
+
+## Source code
+
+The extension is open-source: https://github.com/dudgeon/duo. You
+can audit exactly what it does.
+
+## Contact
+
+Questions: dudgeon@gmail.com
+Issues: https://github.com/dudgeon/duo/issues
+```
+
+## Risk: review rejection
+
+Web Store review can reject for:
+
+1. **`<all_urls>` overreach.** Mitigation: emphasize the local-only
+   data flow in the permission justification (above). If still
+   rejected, fall back to declaring specific origins (slack,
+   github, gmail, etc.) — but lose generality.
+2. **Single-purpose ambiguity.** Reviewers sometimes flag
+   "terminal + editor + agent" as multi-purpose. Mitigation: the
+   single-purpose statement above frames everything as "AI-paired
+   coding that doesn't require leaving the browser" — one purpose,
+   multiple capabilities.
+3. **Naming collision.** "Duo" might be flagged as confusable with
+   Cisco Duo. Mitigation: "Duo for Chrome" disambiguates in
+   listing search; in-extension UI just says "Duo".
+4. **Native Messaging warning.** Web Store sometimes flags NM
+   extensions for additional review. Mitigation: clear privacy
+   policy + open-source code helps.
+
+If rejection happens, iterate the listing copy and resubmit. Most
+rejections take 1-2 rounds to resolve.


### PR DESCRIPTION
## Summary

Final docs cleanup from today's autonomous Chrome-extension exploration session. After all MVP phases ✅ and Stage A landed via #42, bringing the remaining forward-looking docs to main:

- **build-roadmap.md** — status flips (rows 1-6.5 all ✅; rows 7-8 expanded scope)
- **phase7-implementation-plan.md** (new) — file-level cutover plan, ~2-day estimate
- **web-store-listing.md** (new) — pre-baked Web Store submission content
- **session-log.md** — evening update on the 2026-04-30 entry covering verification + Stage A merge

## What's NOT in this PR (intentionally)

The exploration branch's `phase0/` directory stays on the exploration branch. Phase 7's refactor will replace those files when it lands:
- `phase0/helper/duo-helper.js` → collapses into `electron/main.ts`'s `--nm-shim` mode
- `phase0/extension/*` → moves to top-level `extension/`
- `phase0/cli/duo-ext` → folds into `cli/duo` with `chrome:` / `embedded:` prefix routing

Bringing them to main now would create churn for Phase 7 to undo.

## Test plan
- [ ] Skim build-roadmap.md — phase status table accurate, status legend present
- [ ] Skim phase7-implementation-plan.md — actionable when next coding session picks up
- [ ] Skim web-store-listing.md — copy is reusable for the actual submission
- [ ] Skim session-log evening update — captures the day's full arc

🤖 Generated with [Claude Code](https://claude.com/claude-code)