### PR TITLE
Sanitize company-specific references in CLAUDE.md + add guardrail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,17 @@ naturally as it runs shell commands.
 
 Owner: Geoff.
 
+## Audience and references
+
+Duo is a personal, open-source project intended for both individual
+users and enterprise teams. **Do not write company-specific
+references into the codebase, docs, or commit messages** — no
+employer names, internal project / program / cohort codenames, or
+anything else that ties Duo to a specific organization. Use generic
+descriptors instead (e.g. "early-adopter cohort", not a real cohort
+name). Exceptions: references to Claude / Anthropic, and specific
+domain names that appear in the browser blocklist.
+
 ## Where to look
 
 - **`docs/roadmap.html`** — canonical roadmap (status, layered build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ sessions with an embedded Chrome browser, connected by a local CLI
 bridge (`duo`) so Claude Code can read and drive the browser as
 naturally as it runs shell commands.
 
-Owner: Geoff (Capital One, AI in Product program).
+Owner: Geoff.
 
 ## Where to look
 
@@ -304,13 +304,13 @@ routed around ad hoc.
 | Brainstem / MCP | **Not included** — Skills panel is CWD-scan only |
 | Skills CWD source | PTY launch CWD (not moving shell CWD); two scopes (project + home) |
 | First-launch install | Electron permission dialog before installing CLI + skill + agent (deferred; currently manual) |
-| Distribution / cert | Stage 21a ✅ shipped v0.4.1 (signed + notarized DMG via `bash scripts/dist-signed.sh`); 21c Phase 1+2 ✅ shipped v0.4.2 (auto-update + session restore); 21c Phase 3 ✅ shipped v0.5.1 (browser history persistence + datalist autocomplete; closes [issue #27](https://github.com/dudgeon/duo/issues/27)); 21b app icon ✅ shipped v0.5.1; 21e ✅ shipped v0.5.0 (fork-friendly architecture). Still ⬜: 21b DMG background image · 21d Trailblazers cohort (socket auth + agent-driven-nav notifications + README). |
+| Distribution / cert | Stage 21a ✅ shipped v0.4.1 (signed + notarized DMG via `bash scripts/dist-signed.sh`); 21c Phase 1+2 ✅ shipped v0.4.2 (auto-update + session restore); 21c Phase 3 ✅ shipped v0.5.1 (browser history persistence + datalist autocomplete; closes [issue #27](https://github.com/dudgeon/duo/issues/27)); 21b app icon ✅ shipped v0.5.1; 21e ✅ shipped v0.5.0 (fork-friendly architecture). Still ⬜: 21b DMG background image · 21d early-adopter cohort (socket auth + agent-driven-nav notifications + README). |
 
 ## Open questions needing Geoff's input
 
 | Question | Priority |
 |---|---|
-| Distribution timeline (Trailblazers cohort) | Before Stage 21d (socket auth + Trailblazers README) |
+| Distribution timeline (early-adopter cohort) | Before Stage 21d (socket auth + early-adopter README) |
 | Socket auth approach for cross-machine cohort distribution | Before Stage 21d |
 | Stage 17a.5 directions A/E (template gallery / registry) | Before any code work on templates |
 | BUG-024 follow-up: combine Send → Duo + Comment pills (single split-pill or hover flyout)? | Before any further selection-pill iteration |


### PR DESCRIPTION
## Summary
- Sanitize residual "Capital One" / "Trailblazers" references in `CLAUDE.md` that were missed by the Stage 28 sweep in `c36ed1e` (1 owner-line, 2 cohort-name spots in tables)
- Add a new "Audience and references" subsection codifying the rule, so future writes catch this at author-time instead of via post-hoc sanitization

## Test plan
- [ ] Render `CLAUDE.md` on the PR diff and confirm formatting + section ordering
- [ ] No code or behavior changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)