### PR TITLE
sprint(12): image viewer v2 + table-cell copy fix + terminal-tab Reveal in navigator

### DIFF
--- a/RESUME.md
+++ b/RESUME.md
@@ -1,0 +1,152 @@
+# Resume Sprint 12 — handoff to local Claude
+
+> **Transient file.** This was written by the cloud Claude session
+> that shipped Sprint 12 (PR #45, merged to main). Geoff's next
+> local session uses it to pick up the smoke walk and the cut.
+> **Delete this file as your last commit before tagging the cut**
+> (see § Cleanup at the bottom). It is intentionally NOT linked
+> from CLAUDE.md so it doesn't outlive its purpose.
+
+## Context (one paragraph)
+
+Sprint 12 shipped three things on top of the existing v0.6.10 work:
+**ENH-111** image-viewer chrome (toolbar, zoom, pan, copy, context
+menu — new file `renderer/components/ImageView.tsx` plus two new
+IPCs: `files.stat` and `clipboard.writeImage`); **BUG-108** the
+markdown table-cell-copy fix (new extension
+`renderer/components/editor/extensions/TableCellCopy.ts`); and
+**ENH-115** terminal-tab right-click → "Reveal in navigator" (small
+addition in `TabBar.tsx` + `App.tsx`). Code is on `main` (PR #45
+merged). Typecheck was clean at commit time. Cloud session had no
+computer-use surface so the smoke walk is owed.
+
+## What's owed
+
+1. Walk the smoke-walk page and parse the user's results.
+2. Fix any FAILs (small targeted fixes, not a re-do).
+3. Run the `cut-version` skill for v0.6.10.
+
+## Resume sequence
+
+### 1. Pre-flight (mirrors smoke-walk skill § 4)
+
+```bash
+ps -ef | grep "MacOS/Electron \." | grep -v grep | awk '{print $2}'
+```
+
+- **Zero matches:** start dev:
+  ```bash
+  npm run dev   # via Bash run_in_background:true
+  ```
+  Then poll until the bridge is up:
+  ```bash
+  until duo doctor 2>&1 | grep -q "Unix socket"; do sleep 2; done
+  ```
+- **Exactly one match:** check whether it's the packed app
+  (path contains `/Applications/Duo.app` or `dist/mac-arm64/`)
+  vs a dev (path contains `node_modules/electron`). Packed app
+  → quit it and start dev. Dev → adopt it; the new IPCs need
+  a fresh main process so restart it (kill + spawn per CLAUDE.md
+  § 7a) since this is BEFORE the user starts walking.
+- **Two or more:** stop, name the PIDs, ask the user which to
+  keep (mirrors the violated-2026-05-04 carve-out in the
+  smoke-walk skill).
+
+### 2. Verify the app is clean (smoke-walk § 5b)
+
+```bash
+duo doctor       # CLI version matches app version
+duo nav-state    # renderer alive at IPC layer
+```
+
+If you have computer-use, `request_access` for Electron + screenshot
++ scan for any error overlay (React red panel, ErrorBoundary
+fallback). If anything looks wrong, fix it before handoff.
+
+If you don't have computer-use, exercise the walk's first
+failure-prone step yourself via the CLI — for BUG-108 (which is
+walk item 1) that's `duo edit /tmp/preflight-bug108.md` to mount
+MarkdownEditor. If the editor mounts (file appears as a tab,
+`duo url` matches), proceed. If not, root-cause first.
+
+### 3. Open the smoke walk page
+
+```bash
+duo open docs/dev/smoke-walks/v0.6.10-sprint12.html
+```
+
+Verify focus landed on the page:
+
+```bash
+duo url      # should be file://...v0.6.10-sprint12.html
+duo title    # should be "Smoke walk v0.6.10 · Sprint 12"
+```
+
+### 4. Hand off to Geoff
+
+Brief — page is the spec:
+
+> Smoke walk page is open as a browser tab. 3 items: BUG-108 first
+> (table cell copy), ENH-111 second (image viewer), ENH-115 third
+> (terminal-tab Reveal in navigator). Mark Pass/Fail, add notes,
+> hit Send to Claude or Copy results.
+
+### 5. Parse + react
+
+When Geoff pastes results back:
+
+- For each `[PASS]`: tasks.md entry stays ✅. No action.
+- For each `[FAIL]`: re-open tasks.md entry, flip to 🟡, prepend
+  user-verified failure note + today's date. Add to
+  `docs/dev/active-sprint.md` carry-over section.
+- For each `[SKIP]`: ask Geoff whether to defer or re-walk.
+
+If everything passed → propose `cut-version` skill.
+If anything failed → fix-and-recut. Re-walk for the same version
+is fine.
+
+## Sprint 12 file map (where the changes live)
+
+```
+shared/types.ts                                            # FILES_STAT + CLIPBOARD_WRITE_IMAGE constants
+shared/host-api.ts                                         # FileStatResult type + ElectronFilesAPI.stat + ElectronClipboardAPI.writeImage
+electron/files-service.ts                                  # FilesService.stat()
+electron/main.ts                                           # FILES_STAT + CLIPBOARD_WRITE_IMAGE handlers, nativeImage import
+electron/preload.ts                                        # files.stat + clipboard.writeImage bridges
+renderer/components/ImageView.tsx                          # NEW — image viewer v2 (ENH-111)
+renderer/components/FileRenderers.tsx                      # ImagePreview removed (graduated to ImageView.tsx)
+renderer/components/WorkingPane.tsx                        # ImagePreview → ImageView import swap
+renderer/components/TabBar.tsx                             # onContextMenu on Tab + onRevealCwd prop (ENH-115)
+renderer/App.tsx                                           # onRevealCwd wiring (nav.actions.navigateTo + setRevealChip)
+renderer/components/editor/extensions/TableCellCopy.ts     # NEW — clipboardTextSerializer for intra-table slices (BUG-108)
+renderer/components/editor/MarkdownEditor.tsx              # TableCellCopy import + use (after TableShortcuts)
+docs/dev/smoke-walks/v0.6.10-sprint12.json                 # walk manifest
+docs/dev/smoke-walks/v0.6.10-sprint12.html                 # generated walk page (gitignored — regenerate if missing)
+tasks.md                                                   # ENH-115 filed; BUG-108 closed
+docs/dev/active-sprint.md                                  # Sprint 12 status section updated
+```
+
+If the generated HTML is missing locally:
+
+```bash
+node .claude/skills/worksheet/generate.mjs \
+  docs/dev/smoke-walks/v0.6.10-sprint12.json \
+  docs/dev/smoke-walks/v0.6.10-sprint12.html
+```
+
+(The smoke-walk skill calls `.claude/skills/smoke-walk/generate.mjs`
+which delegates to the worksheet generator with smoke-walk
+defaults.)
+
+## Cleanup
+
+When the cut completes (v0.6.10 tagged, RELEASES.md updated, the
+post-cut version bump committed per `cut-version` skill § Step 7):
+
+```bash
+git rm RESUME.md
+git commit -m "chore: remove RESUME.md handoff after v0.6.10 cut"
+```
+
+Don't forget. This file should not survive the sprint that
+created it.

--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -31,13 +31,25 @@ cut fires.
   serialize to JUST the selected text; only whole-node selections
   yield the markdown-table representation.
 
+### P1 — ENH-115 terminal-tab "Reveal in navigator"
+- **ENH-115** — right-click on a terminal tab → context-menu entry
+  "Reveal in navigator" (label TBD; owner flagged uncertainty —
+  recommend matching the macOS "Reveal in Finder" verb pattern).
+  Reuses `window.electron.menu.popup` (no new IPC) + the existing
+  `nav.actions.navigateTo` + reveal-chip flow from the CLI's
+  `duo reveal` plumbing. ~30min change in `TabBar.tsx` +
+  `App.tsx` wiring. Filed mid-sprint 2026-05-09 per owner.
+
 ### Sequencing
 1. **Image v2 first** — well-scoped, single-component refactor of the
    existing image tab. Lower-risk than BUG-108 (which involves
    TipTap clipboard serialization, more architectural).
 2. **BUG-108 second** — surgical fix in TipTap Table extension config
    + clipboard serializer override.
-3. **Cut v0.6.10** — once both land + smoke walk passes.
+3. **ENH-115 third** — small, isolated UI add in the terminal tab
+   strip. Lands after image v2 is verified so the smoke walk can
+   batch both.
+4. **Cut v0.6.10** — once all three land + smoke walk passes.
 
 ### Deferred to Sprint 13+
 - **JSON viewer (ENH-110)** — research doc landed; pull in once

--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -1,15 +1,37 @@
-# Active sprint state — Sprint 12 (v0.6.10 cut pending, image v2 + BUG-108 first)
+# Active sprint state — Sprint 12 (v0.6.10 cut pending, image v2 + BUG-108 + ENH-115 ready for smoke walk)
 
-**Theme:** Image viewing chrome + the table-cell-copy paper cut.
+**Theme:** Image viewing chrome + the table-cell-copy paper cut + a
+small terminal-tab context-menu QoL.
 
 **Owner directive (2026-05-08 evening, post-walk-3):** *"don't cut yet;
 I want to address image handling (should be in the roadmap now) and
 one more newly discovered bug before cutting: copying cell text from
 a table in the markdown editor just copies '[table]' to the clipboard."*
+**Owner directive (2026-05-09):** *"add another feature (document it
+then add to sprint): right clicking on terminal tab should offer
+option to focus the navigator on that tab's CWD."* → ENH-115.
 
 The cut-version proposal (drafted in chat, not yet applied) is held
-in `RELEASES.md § Pending`. Sprint 12 lands TWO additions before the
-cut fires.
+in `RELEASES.md § Pending`. Sprint 12 lands THREE additions before
+the cut fires; all three landed 2026-05-09 — smoke walk owed before
+the cut.
+
+### Status (2026-05-09)
+- **ENH-111 (image v2):** ✅ committed. Toolbar + zoom + pan +
+  context menu + dimensions/size readout. New IPCs: `files.stat`,
+  `clipboard.writeImage`. Component lives at
+  `renderer/components/ImageView.tsx`.
+- **BUG-108 (table cell copy):** ✅ committed. Higher-priority
+  `clipboardTextSerializer` in
+  `renderer/components/editor/extensions/TableCellCopy.ts` returns
+  the slice's plain text when the slice begins with a table node;
+  defers (returns null) for whole-table copies so tiptap-markdown's
+  existing markdown-table serializer continues to render those.
+- **ENH-115 (terminal tab → Reveal in navigator):** ✅ committed
+  (batched with image v2). One context-menu entry on the terminal
+  tab strip, calls the existing `nav.actions.navigateTo` + reveal
+  chip. Working label: "Reveal in navigator" — revisit during
+  smoke walk if it reads wrong.
 
 ### P0 anchor — image viewer v2 (promoted from Sprint 13)
 - **ENH-111 (image v2)** — toolbar chrome around the existing image

--- a/electron/files-service.ts
+++ b/electron/files-service.ts
@@ -15,7 +15,7 @@ import * as path from 'path'
 import { shell } from 'electron'
 import type { WebContents } from 'electron'
 import chokidar, { FSWatcher } from 'chokidar'
-import type { DirEntry, FileReadResult, FileWriteResult, FileChangeEvent, HtmlFileMeta } from '../shared/types'
+import type { DirEntry, FileReadResult, FileWriteResult, FileChangeEvent, FileStatResult, HtmlFileMeta } from '../shared/types'
 
 // Prevent accidentally shipping 50MB of log file over IPC. Renderer should
 // use `openExternal` for payloads this big.
@@ -215,6 +215,19 @@ export class FilesService {
       if (st.isFile()) return 'file'
       if (st.isDirectory()) return 'folder'
       return null
+    } catch {
+      return null
+    }
+  }
+
+  /** ENH-111 (Sprint 12) — file size + mtime probe for the image
+   *  viewer chrome. Returns null when the path doesn't exist or
+   *  isn't a regular file (we don't surface directory size). */
+  async stat(absPath: string): Promise<FileStatResult | null> {
+    try {
+      const st = await fs.stat(absPath)
+      if (!st.isFile()) return null
+      return { size: st.size, mtimeMs: st.mtimeMs }
     } catch {
       return null
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, dialog, ipcMain, nativeTheme, shell, webContents, clipboard } from 'electron'
+import { app, BrowserWindow, Menu, dialog, ipcMain, nativeImage, nativeTheme, shell, webContents, clipboard } from 'electron'
 import type { MenuItemConstructorOptions, WebContents } from 'electron'
 // electron-context-menu v4 is ESM-only; main bundles as CJS, so we
 // load it via dynamic import inside app.whenReady. The lazy import
@@ -887,6 +887,11 @@ function setupIPC(): void {
     return filesService.kind(p)
   })
 
+  // ENH-111 (Sprint 12) — file-size + mtime probe for image viewer chrome.
+  ipcMain.handle(IPC.FILES_STAT, (_event, { path: p }: { path: string }) => {
+    return filesService.stat(p)
+  })
+
   // Stage 24 — pinned WorkingPane tabs.
   ipcMain.handle(IPC.PINS_LIST, () => {
     return pinsService.list()
@@ -945,6 +950,18 @@ function setupIPC(): void {
   ipcMain.handle(IPC.CLIPBOARD_WRITE_TEXT, (_event, text: string): void => {
     if (typeof text !== 'string') return
     clipboard.writeText(text)
+  })
+
+  // ENH-111 (Sprint 12) — copy an image file to the system clipboard.
+  // Loads via `nativeImage.createFromPath` (handles every codec
+  // Electron can decode: png/jpg/gif/webp/bmp/ico). Returns false
+  // when the path doesn't decode — caller can surface a toast.
+  ipcMain.handle(IPC.CLIPBOARD_WRITE_IMAGE, (_event, p: string): boolean => {
+    if (typeof p !== 'string' || !p) return false
+    const img = nativeImage.createFromPath(p)
+    if (img.isEmpty()) return false
+    clipboard.writeImage(img)
+    return true
   })
 
   ipcMain.handle(IPC.DIALOG_CONFIRM, async (_event, req: import('../shared/types').DialogConfirmRequest): Promise<import('../shared/types').DialogConfirmResult> => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -228,6 +228,9 @@ const api: ElectronAPI = {
     // Stage 26 PR 3 item 8 — path-kind probe (editable breadcrumb).
     kind: (p) => ipcRenderer.invoke(IPC.FILES_KIND, { path: p }),
 
+    // ENH-111 (Sprint 12) — file size + mtime for image viewer chrome.
+    stat: (p) => ipcRenderer.invoke(IPC.FILES_STAT, { path: p }),
+
     watch: async (paths, cb) => {
       // Give every subscription its own id so pushes can be routed back to
       // the caller's callback. The id lives in the renderer; main process
@@ -582,7 +585,9 @@ const api: ElectronAPI = {
   // never call `navigator.clipboard.writeText` from inside a native
   // NSMenu callback chain.
   clipboard: {
-    writeText: (text) => ipcRenderer.invoke(IPC.CLIPBOARD_WRITE_TEXT, text) as Promise<void>
+    writeText: (text) => ipcRenderer.invoke(IPC.CLIPBOARD_WRITE_TEXT, text) as Promise<void>,
+    // ENH-111 (Sprint 12) — image-to-clipboard for image viewer.
+    writeImage: (p) => ipcRenderer.invoke(IPC.CLIPBOARD_WRITE_IMAGE, p) as Promise<boolean>
   }
 }
 

--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -2643,6 +2643,13 @@ export function App() {
                   // from titlebar into the new-tab cluster.
                   isTerminalCollapsed={isTerminalCollapsed}
                   onToggleTerminalCollapsed={toggleCollapseTerminal}
+                  // ENH-115 (Sprint 12) — right-click → "Reveal in
+                  // navigator" reuses the same nav navigateTo + chip
+                  // path that `duo reveal <path>` triggers.
+                  onRevealCwd={(cwd) => {
+                    nav.actions.navigateTo(cwd)
+                    setRevealChip(cwd)
+                  }}
                 />
                 <div className="flex-1 overflow-hidden">
                   <TerminalPane

--- a/renderer/components/FileRenderers.tsx
+++ b/renderer/components/FileRenderers.tsx
@@ -1,22 +1,9 @@
 // Stage 10 Phase 5 — small per-type renderers for the WorkingPane.
-// MarkdownPreview has its own file since it's heavier; this file groups the
-// lightweight glyphs (image / pdf / unknown).
+// PDF + unknown-type fallbacks live here. ImageView (ENH-111, Sprint
+// 12) graduated to its own file when it grew toolbar chrome.
 
 import { useState } from 'react'
 import type { WorkingTab } from '@shared/types'
-
-export function ImagePreview({ tab }: { tab: WorkingTab }) {
-  return (
-    <div className="flex-1 overflow-auto bg-surface-0 flex items-center justify-center p-8">
-      <img
-        src={'file://' + encodeURI(tab.path ?? '')}
-        alt={tab.title}
-        className="max-w-full max-h-full object-contain"
-        style={{ imageRendering: 'auto' }}
-      />
-    </div>
-  )
-}
 
 export function PdfPreview({ tab }: { tab: WorkingTab }) {
   // Electron's built-in Chromium ships a PDF viewer; <embed> with the

--- a/renderer/components/ImageView.tsx
+++ b/renderer/components/ImageView.tsx
@@ -1,0 +1,341 @@
+// ENH-111 (Sprint 12) — image viewer v2: toolbar chrome around the
+// existing image tab. Replaces the bare `<img>` previewer that
+// lived in FileRenderers.tsx through Sprint 11. PM-persona benefit:
+// dragging a screenshot from Slack into Duo currently shows a small
+// image; with chrome the user can zoom in to UI mockups, copy the
+// image to paste into Notion, or jump to Finder/Preview without
+// leaving Duo.
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import type { WorkingTab, MenuTemplateItem } from '@shared/types'
+
+const ZOOM_MIN = 0.05
+const ZOOM_MAX = 32
+const ZOOM_STEP = 1.25
+
+type Mode = 'fit' | 'manual'
+
+interface Dims {
+  w: number
+  h: number
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+export function ImageView({ tab }: { tab: WorkingTab }) {
+  const path = tab.path ?? ''
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const imgRef = useRef<HTMLImageElement | null>(null)
+  const [mode, setMode] = useState<Mode>('fit')
+  const [manualScale, setManualScale] = useState(1)
+  const [dims, setDims] = useState<Dims | null>(null)
+  const [bytes, setBytes] = useState<number | null>(null)
+  const [containerSize, setContainerSize] = useState<Dims>({ w: 0, h: 0 })
+  const [copyFlash, setCopyFlash] = useState<'idle' | 'ok' | 'fail'>('idle')
+
+  // File size readout via files.stat (cheap — no payload transfer).
+  useEffect(() => {
+    let cancelled = false
+    if (!path) return
+    void window.electron.files.stat(path).then((s) => {
+      if (cancelled) return
+      setBytes(s?.size ?? null)
+    })
+    return () => { cancelled = true }
+  }, [path])
+
+  // Track container size so 'fit' mode can compute a percentage
+  // readout that matches what the user sees.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const cr = entry.contentRect
+        setContainerSize({ w: cr.width, h: cr.height })
+      }
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  const onImgLoad = useCallback(() => {
+    const el = imgRef.current
+    if (!el) return
+    setDims({ w: el.naturalWidth, h: el.naturalHeight })
+  }, [])
+
+  // Effective scale shown in the toolbar + driving manual-mode sizing.
+  const fitScale = (() => {
+    if (!dims || containerSize.w === 0 || containerSize.h === 0) return 1
+    return Math.min(containerSize.w / dims.w, containerSize.h / dims.h, 1)
+  })()
+  const effectiveScale = mode === 'fit' ? fitScale : manualScale
+
+  // Image element style — for 'fit' mode, defer to CSS object-contain.
+  // For manual mode, set explicit pixel dimensions so the container
+  // overflows naturally, enabling pan via scroll.
+  const imgStyle: React.CSSProperties = mode === 'fit'
+    ? {
+        maxWidth: '100%',
+        maxHeight: '100%',
+        objectFit: 'contain',
+        userSelect: 'none',
+        pointerEvents: 'none'
+      }
+    : dims
+      ? {
+          width: dims.w * manualScale,
+          height: dims.h * manualScale,
+          maxWidth: 'none',
+          maxHeight: 'none',
+          userSelect: 'none',
+          pointerEvents: 'none'
+        }
+      : { userSelect: 'none', pointerEvents: 'none' }
+
+  // ── actions ────────────────────────────────────────────────────────
+  const setZoomManual = useCallback((nextScale: number) => {
+    const clamped = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, nextScale))
+    setManualScale(clamped)
+    setMode('manual')
+  }, [])
+
+  const zoomIn = useCallback(() => {
+    setZoomManual(effectiveScale * ZOOM_STEP)
+  }, [effectiveScale, setZoomManual])
+
+  const zoomOut = useCallback(() => {
+    setZoomManual(effectiveScale / ZOOM_STEP)
+  }, [effectiveScale, setZoomManual])
+
+  const setFit = useCallback(() => {
+    setMode('fit')
+  }, [])
+
+  const setActualSize = useCallback(() => {
+    setManualScale(1)
+    setMode('manual')
+  }, [])
+
+  const copyImage = useCallback(async () => {
+    if (!path) return
+    try {
+      const ok = await window.electron.clipboard.writeImage(path)
+      setCopyFlash(ok ? 'ok' : 'fail')
+    } catch {
+      setCopyFlash('fail')
+    }
+    setTimeout(() => setCopyFlash('idle'), 1200)
+  }, [path])
+
+  const copyPath = useCallback(() => {
+    if (!path) return
+    void window.electron.clipboard.writeText(path)
+  }, [path])
+
+  const openInDefault = useCallback(() => {
+    if (!path) return
+    void window.electron.files.openExternal(path)
+  }, [path])
+
+  const revealInFinder = useCallback(() => {
+    if (!path) return
+    void window.electron.files.revealInFinder(path)
+  }, [path])
+
+  // ── pan via drag ───────────────────────────────────────────────────
+  const dragState = useRef<{ startX: number; startY: number; startLeft: number; startTop: number } | null>(null)
+  const onMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return
+    const el = containerRef.current
+    if (!el) return
+    if (mode === 'fit') return
+    if (el.scrollWidth <= el.clientWidth && el.scrollHeight <= el.clientHeight) return
+    dragState.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      startLeft: el.scrollLeft,
+      startTop: el.scrollTop
+    }
+    el.style.cursor = 'grabbing'
+  }, [mode])
+  useEffect(() => {
+    function onMove(e: MouseEvent) {
+      const ds = dragState.current
+      const el = containerRef.current
+      if (!ds || !el) return
+      el.scrollLeft = ds.startLeft - (e.clientX - ds.startX)
+      el.scrollTop = ds.startTop - (e.clientY - ds.startY)
+    }
+    function onUp() {
+      const el = containerRef.current
+      if (!el) return
+      dragState.current = null
+      el.style.cursor = ''
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [])
+
+  // Wheel zoom with ⌘ / ⌃ modifier (matches Preview.app + browsers).
+  const onWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+    if (!(e.metaKey || e.ctrlKey)) return
+    e.preventDefault()
+    const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP
+    setZoomManual(effectiveScale * factor)
+  }, [effectiveScale, setZoomManual])
+
+  // Right-click → native context menu.
+  const onContextMenu = useCallback(async (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!path) return
+    const items: MenuTemplateItem[] = [
+      { id: 'copy-image', label: 'Copy image' },
+      { id: 'copy-path', label: 'Copy path' },
+      { type: 'separator' },
+      { id: 'open-default', label: 'Open in default app' },
+      { id: 'reveal', label: 'Reveal in Finder' },
+      { type: 'separator' },
+      { id: 'fit', label: 'Fit to window' },
+      { id: 'actual', label: 'Actual size (1:1)' }
+    ]
+    const res = await window.electron.menu.popup({ items, x: e.clientX, y: e.clientY })
+    switch (res.chosenId) {
+      case 'copy-image': void copyImage(); break
+      case 'copy-path': copyPath(); break
+      case 'open-default': openInDefault(); break
+      case 'reveal': revealInFinder(); break
+      case 'fit': setFit(); break
+      case 'actual': setActualSize(); break
+    }
+  }, [path, copyImage, copyPath, openInDefault, revealInFinder, setFit, setActualSize])
+
+  const zoomPct = Math.round(effectiveScale * 100)
+  const dimsLabel = dims ? `${dims.w} × ${dims.h}` : '—'
+  const sizeLabel = bytes != null ? formatBytes(bytes) : '—'
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden bg-surface-0">
+      {/* Toolbar */}
+      <div className="flex items-center h-8 shrink-0 bg-surface-2 border-b border-border px-2 gap-1 text-[11px] text-ink-mute">
+        <ToolbarButton onClick={zoomOut} title="Zoom out (⌘−)" disabled={effectiveScale <= ZOOM_MIN + 0.001}>
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M2 6h8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </ToolbarButton>
+        <button
+          type="button"
+          onClick={() => setMode(mode === 'fit' ? 'manual' : 'fit')}
+          className="min-w-[3.5rem] px-1.5 h-6 rounded text-ink-mute hover:text-ink hover:bg-surface-3 tabular-nums transition-colors"
+          title="Click to toggle fit/manual"
+        >
+          {zoomPct}%
+        </button>
+        <ToolbarButton onClick={zoomIn} title="Zoom in (⌘+)" disabled={effectiveScale >= ZOOM_MAX - 0.001}>
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M6 2v8M2 6h8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </ToolbarButton>
+        <span aria-hidden="true" className="w-px h-4 bg-paper-rule mx-1" />
+        <ToolbarButton onClick={setFit} title="Fit to window" active={mode === 'fit'}>
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M2 4V2h2M10 4V2H8M2 8v2h2M10 8v2H8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </ToolbarButton>
+        <ToolbarButton onClick={setActualSize} title="Actual size (1:1)" active={mode === 'manual' && Math.abs(manualScale - 1) < 0.001}>
+          <span className="text-[10px] font-medium tracking-tight">1:1</span>
+        </ToolbarButton>
+        <span aria-hidden="true" className="w-px h-4 bg-paper-rule mx-1" />
+        <ToolbarButton
+          onClick={copyImage}
+          title="Copy image to clipboard"
+          flash={copyFlash}
+        >
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <rect x="3" y="3" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M2 8V2.5C2 2.22 2.22 2 2.5 2H8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        </ToolbarButton>
+
+        <div className="ml-auto flex items-center gap-2 tabular-nums text-ink-ghost">
+          <span title="Image dimensions">{dimsLabel}</span>
+          <span aria-hidden="true">·</span>
+          <span title="File size">{sizeLabel}</span>
+        </div>
+      </div>
+
+      {/* Image area */}
+      <div
+        ref={containerRef}
+        className={[
+          'flex-1 overflow-auto',
+          mode === 'fit' ? 'flex items-center justify-center' : '',
+          mode === 'manual' ? 'cursor-grab' : ''
+        ].join(' ')}
+        onMouseDown={onMouseDown}
+        onWheel={onWheel}
+        onContextMenu={onContextMenu}
+        // Checker pattern hints transparency (useful for PNGs / SVGs).
+        style={{
+          backgroundImage:
+            'linear-gradient(45deg, rgba(120,120,120,0.06) 25%, transparent 25%, transparent 75%, rgba(120,120,120,0.06) 75%),' +
+            'linear-gradient(45deg, rgba(120,120,120,0.06) 25%, transparent 25%, transparent 75%, rgba(120,120,120,0.06) 75%)',
+          backgroundSize: '14px 14px',
+          backgroundPosition: '0 0, 7px 7px'
+        }}
+      >
+        <img
+          ref={imgRef}
+          src={'file://' + encodeURI(path)}
+          alt={tab.title}
+          onLoad={onImgLoad}
+          style={imgStyle}
+          draggable={false}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface ToolbarButtonProps {
+  onClick: () => void
+  title: string
+  children: React.ReactNode
+  disabled?: boolean
+  active?: boolean
+  flash?: 'idle' | 'ok' | 'fail'
+}
+
+function ToolbarButton({ onClick, title, children, disabled, active, flash = 'idle' }: ToolbarButtonProps) {
+  const flashCls =
+    flash === 'ok' ? 'text-accent' : flash === 'fail' ? 'text-rose-400' : ''
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      disabled={disabled}
+      className={[
+        'w-6 h-6 flex items-center justify-center rounded transition-colors',
+        active
+          ? 'bg-accent text-white'
+          : 'text-ink-mute hover:text-ink hover:bg-surface-3',
+        disabled ? 'opacity-40 cursor-default hover:bg-transparent hover:text-ink-mute' : '',
+        flashCls
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  )
+}

--- a/renderer/components/TabBar.tsx
+++ b/renderer/components/TabBar.tsx
@@ -24,6 +24,10 @@ interface TabBarProps {
    *  toggles. Active (collapsed) state inverts to the accent fill. */
   isTerminalCollapsed?: boolean
   onToggleTerminalCollapsed?: () => void
+  /** ENH-115 (Sprint 12) — right-click → "Reveal in navigator" on a
+   *  tab fires this with the tab's `cwd`. Parent points the navigator
+   *  at the path (same code path as the CLI's `duo reveal`). */
+  onRevealCwd?: (cwd: string) => void
 }
 
 // Stage 12 Phase 3 — tab-strip rhyme.
@@ -52,7 +56,8 @@ export function TabBar({
   pendingCwd,
   focused = false,
   isTerminalCollapsed = false,
-  onToggleTerminalCollapsed
+  onToggleTerminalCollapsed,
+  onRevealCwd
 }: TabBarProps) {
   const cwdSuffix = pendingCwd ? ` in ${pendingCwd}` : ''
   const claudeTip = `New Claude session (⌘T from terminal focus)${cwdSuffix}`
@@ -89,6 +94,7 @@ export function TabBar({
               onClose(tab.id)
             }}
             canClose={tabs.length > 1}
+            onRevealCwd={onRevealCwd}
             // ENH-024 — only the active tab gets the ref; previous
             // active tab loses the assignment naturally on re-render.
             buttonRef={tab.id === activeTabId ? activeTabRef : undefined}
@@ -166,13 +172,29 @@ interface TabProps {
   /** ENH-024 — passed by the parent on the active tab so it can
    *  `scrollIntoView` whenever the active tab changes. */
   buttonRef?: React.Ref<HTMLButtonElement>
+  /** ENH-115 — right-click → Reveal in navigator. */
+  onRevealCwd?: (cwd: string) => void
 }
 
-function Tab({ tab, isActive, onSelect, onClose, canClose, buttonRef }: TabProps) {
+function Tab({ tab, isActive, onSelect, onClose, canClose, buttonRef, onRevealCwd }: TabProps) {
+  // ENH-115 — right-click → native context menu. Single verb today
+  // ("Reveal in navigator"); leaves room for additional terminal-tab
+  // verbs (Duplicate / Close others) without restructuring.
+  const onContextMenu = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!onRevealCwd || !tab.cwd) return
+    const res = await window.electron.menu.popup({
+      items: [{ id: 'reveal-cwd', label: 'Reveal in navigator' }],
+      x: e.clientX,
+      y: e.clientY
+    })
+    if (res.chosenId === 'reveal-cwd') onRevealCwd(tab.cwd)
+  }
   return (
     <button
       ref={buttonRef}
       onClick={onSelect}
+      onContextMenu={onContextMenu}
       className={[
         'group relative flex items-center gap-1.5 px-2.5 h-7 max-w-[200px] rounded-t-lg shrink-0 transition-colors',
         isActive

--- a/renderer/components/WorkingPane.tsx
+++ b/renderer/components/WorkingPane.tsx
@@ -12,7 +12,8 @@ import { AuxBrowserSlot } from './AuxBrowserSlot'
 import { MarkdownPreview } from './MarkdownPreview'
 import { MarkdownEditor } from './editor/MarkdownEditor'
 import { PageTab } from './Page/PageTab'
-import { ImagePreview, PdfPreview, UnknownFilePreview } from './FileRenderers'
+import { PdfPreview, UnknownFilePreview } from './FileRenderers'
+import { ImageView } from './ImageView'
 import { WorkingTabStrip } from './WorkingTabStrip'
 import { useBrowserState } from '../hooks/useBrowserState'
 import { classifyFile } from './fileClassifier'
@@ -474,7 +475,7 @@ export function WorkingPane({
         />
       )
     }
-    if (tab.type === 'image') return <ImagePreview tab={asWorkingTab(tab)} />
+    if (tab.type === 'image') return <ImageView tab={asWorkingTab(tab)} />
     if (tab.type === 'pdf') return <PdfPreview tab={asWorkingTab(tab)} />
     return <UnknownFilePreview tab={asWorkingTab(tab)} />
   }

--- a/renderer/components/editor/MarkdownEditor.tsx
+++ b/renderer/components/editor/MarkdownEditor.tsx
@@ -30,6 +30,7 @@ import { useAutosavePreference } from './autosavePreference'
 import { buildTiptapEditorActions } from './tiptapEditorActions'
 import type { EditorActions } from './EditorActions'
 import { TableShortcuts } from './extensions/TableShortcuts'
+import { TableCellCopy } from './extensions/TableCellCopy'
 import { PersistentSelection } from './extensions/PersistentSelection'
 import { JustAdded } from './extensions/JustAdded'
 import { MarkdownPaste } from './extensions/MarkdownPaste'
@@ -306,6 +307,14 @@ export function MarkdownEditor({ path, onDirtyChange, isNew, onCommitNewFile, on
       TableHeader,
       TableCell,
       TableShortcuts,
+      // BUG-108 (Sprint 12) — intercept clipboard text serialization
+      // for intra-table selections; without this, tiptap-markdown's
+      // serializer falls through to the HTMLNode "[table]" placeholder
+      // because slice.content always wraps cell selections in the
+      // table node. Higher priority than tiptap-markdown's
+      // markdownClipboard plugin so this hook wins for the table case
+      // and defers (returns null) otherwise.
+      TableCellCopy,
       PersistentSelection,
       JustAdded,
       CodeBlockLowlight.configure({ lowlight }),

--- a/renderer/components/editor/extensions/TableCellCopy.ts
+++ b/renderer/components/editor/extensions/TableCellCopy.ts
@@ -1,0 +1,77 @@
+// BUG-108 (Sprint 12) — copying selected text from inside a markdown
+// table cell yielded the literal string "[table]" instead of the cell
+// text.
+//
+// Root cause: tiptap-markdown's `transformCopiedText` plugin runs
+// `MarkdownSerializer.serialize(slice.content)` on whatever ProseMirror's
+// `selection.content()` returns. ProseMirror builds that slice with
+// `includeParents=true` — so a text selection inside one cell still
+// arrives wrapped in `<table><tr><td>…</td></tr></table>` (with
+// openStart/openEnd marking the open cuts). tiptap-markdown's table
+// serializer then runs `isMarkdownSerializable` which rejects any
+// first-row whose cells aren't all `tableHeader` (a body-cell-only
+// slice always fails this), and the fallback path writes
+// `console.warn(... "node is only available in html mode") + state.write("[" + node.type.name + "]")`
+// — i.e. the literal `[table]` because Duo runs tiptap-markdown with
+// `html: false` for round-trip fidelity reasons.
+//
+// Fix: install a higher-priority `clipboardTextSerializer` that detects
+// "the slice begins with a table node" (the cue that the user selected
+// inside a table) and returns the slice's plain-text content.
+// Whole-table copies — where the user selects across the table boundary
+// — fall through to tiptap-markdown's serializer (`return null`), which
+// renders them as a proper markdown table because the slice in that
+// case includes the header row and `isMarkdownSerializable` passes.
+
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import type { Slice } from '@tiptap/pm/model'
+
+const TABLE_NODE_NAME = 'table'
+
+function sliceStartsWithTable(slice: Slice): boolean {
+  const first = slice.content.firstChild
+  return first?.type.name === TABLE_NODE_NAME
+}
+
+function sliceTextContent(slice: Slice): string {
+  // textBetween with both block + inline separators preserves cell-row
+  // structure as tab-and-newline (matches what every spreadsheet/word
+  // processor writes to the clipboard for a table-cell copy). For
+  // single-cell selections, inline content has no newlines so the
+  // result is just the selected text.
+  return slice.content.textBetween(0, slice.content.size, '\n', '\t')
+}
+
+export const TableCellCopy = Extension.create({
+  name: 'tableCellCopy',
+
+  // Higher priority than tiptap-markdown's `markdownClipboard` plugin
+  // (the Markdown extension declares `priority: 50`). ProseMirror's
+  // `someProp` walks plugins in order and returns the first non-null
+  // result for each clipboard hook — by priority-ordering above
+  // tiptap-markdown, our return value wins for table-cell slices and
+  // we explicitly return null otherwise to defer.
+  priority: 1000,
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('tableCellCopy'),
+        props: {
+          // The TS surface for `clipboardTextSerializer` requires
+          // returning string, but ProseMirror at runtime accepts null
+          // to mean "fall through to the next plugin / default
+          // serialization" (which tiptap-markdown's lower-priority
+          // plugin then handles). Mirrors the runtime-contract cast
+          // pattern used by MarkdownPaste for clipboardTextParser.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          clipboardTextSerializer: ((slice: Slice) => {
+            return sliceStartsWithTable(slice) ? sliceTextContent(slice) : null
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any
+        }
+      })
+    ]
+  }
+})

--- a/shared/host-api.ts
+++ b/shared/host-api.ts
@@ -128,6 +128,13 @@ export interface FileWriteResult {
   mtimeMs: number
 }
 
+/** ENH-111 (Sprint 12) — payload for `files.stat`. Returned for
+ *  regular files; null when the path doesn't exist or stat throws. */
+export interface FileStatResult {
+  size: number
+  mtimeMs: number
+}
+
 export interface HtmlFileMeta {
   /** `<meta name="duo-open-in" content="...">` — declarative routing hint
    *  for HTML files. `browser` opens the file in a browser tab (file://
@@ -181,6 +188,10 @@ export interface ElectronFilesAPI {
    *  breadcrumb's resolution logic. Returns 'file' / 'folder' /
    *  null. Symlinks resolve through to the target. */
   kind: (path: string) => Promise<'file' | 'folder' | null>
+  /** ENH-111 (Sprint 12) — file size + mtime probe for the image
+   *  viewer chrome's "1440 × 900 · 312 KB" readout. Returns null
+   *  when the path doesn't exist or isn't a regular file. */
+  stat: (path: string) => Promise<FileStatResult | null>
   /** Pre-flight read of an HTML file's head (~4KB) to extract Duo's
    *  routing meta tags. Used by the file-open dispatcher to decide
    *  whether an .html file mounts as a browser tab or a canvas tab.
@@ -713,6 +724,12 @@ export interface ElectronDialogAPI {
 // `clipboard` module which has no gesture requirement.
 export interface ElectronClipboardAPI {
   writeText: (text: string) => Promise<void>
+  /** ENH-111 (Sprint 12) — copy an image file to the system
+   *  clipboard. Reads the file in main via `nativeImage.createFromPath`
+   *  and writes via Electron's `clipboard.writeImage`. Returns false
+   *  when the path doesn't decode as an image (createFromPath returns
+   *  an empty native image — we detect via `isEmpty()`). */
+  writeImage: (path: string) => Promise<boolean>
 }
 
 // Stage 21c — session state restored across Duo relaunches.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1093,6 +1093,10 @@ export const IPC = {
   // Stage 26 PR 3 item 8 — path-kind probe for the editable
   // breadcrumb's resolution logic.
   FILES_KIND: 'files:kind',
+  // ENH-111 (Sprint 12) — file-size + mtime probe for the image
+  // viewer chrome's "1440 × 900 · 312 KB" readout. Cheaper than
+  // FILES_READ (no payload transfer).
+  FILES_STAT: 'files:stat',
 
   // Stage 24 — pinned WorkingPane tabs persisted to ~/.claude/duo/pins.json.
   PINS_LIST: 'pins:list',
@@ -1167,6 +1171,14 @@ export const IPC = {
   // `clipboard` module which has no gesture requirement. Used by every
   // "Copy path" / "Copy URL" affordance reachable from a context menu.
   CLIPBOARD_WRITE_TEXT: 'clipboard:write-text',
+  // ENH-111 (Sprint 12) — image-to-clipboard for the image viewer's
+  // "Copy image" toolbar action and right-click "Copy image". The
+  // renderer can't write image data to the clipboard reliably from
+  // a JS-only path (`navigator.clipboard.write` requires a user
+  // gesture and PNG-only `ClipboardItem` support); main's
+  // `nativeImage.createFromPath` + `clipboard.writeImage` covers
+  // every codec Electron can decode.
+  CLIPBOARD_WRITE_IMAGE: 'clipboard:write-image',
 
   // Stage 10 Phase 6 — navigator state + agent-facing commands
   NAV_STATE_PUSH: 'nav:state-push',      // renderer → main (cache state for CLI)

--- a/tasks.md
+++ b/tasks.md
@@ -5879,24 +5879,27 @@ Probably 5-line CSS change. Verify in both light and dark themes — Tailwind Ty
 
 ### BUG-108: Copying cell text from a markdown-editor table copies "[table]" instead
 
-**Status:** 🆕 Filed 2026-05-08 (owner-discovered, pre-cut).
+**Status:** ✅ **Shipped Sprint 12 (2026-05-09).** Root cause confirmed: tiptap-markdown's `transformCopiedText` plugin runs `MarkdownSerializer.serialize(slice.content)`. ProseMirror's `Selection.content()` returns slices with `includeParents=true` — so an intra-cell text selection arrives wrapped in `<table><tr><td>…</td></tr></table>`. tiptap-markdown's table serializer rejects that wrapped slice in `isMarkdownSerializable` (the function requires the first row to be all `tableHeader`; a body-cell-only slice always fails), and the fallback path is `state.write("[" + node.type.name + "]")` — which writes the literal `[table]` because Duo runs tiptap-markdown with `html: false` for round-trip fidelity. Fix lives in [renderer/components/editor/extensions/TableCellCopy.ts](renderer/components/editor/extensions/TableCellCopy.ts) — a higher-priority extension whose `clipboardTextSerializer` detects "slice begins with a table node" and returns the slice's plain-text content via `Fragment.textBetween(0, size, '\n', '\t')` (newline between rows, tab between cells — matches every spreadsheet/word-processor convention). Whole-table selections that include the header row fall through (`return null`) so tiptap-markdown's existing markdown-table serializer continues to render the proper `| key | value |` form for full-table copies.
 **Priority:** **High** — silently destructive: user expects "copy this cell value", clipboard ends up with the literal string `[table]`. Trips up the "select cell text → paste into terminal" workflow that's a primary use of vault tables.
 
 **Symptom.** Open a markdown file containing a table in the TipTap editor. Click into a cell (e.g. the value column). Select text within the cell with the mouse. ⌘C. Paste anywhere — the clipboard contains the string `[table]` (literally that 7-character string), not the selected cell text.
 
-**Hypothesis.** TipTap's Table extension serializes selections-spanning-the-table-node by emitting a placeholder string when copied as plain text. Likely the markdown serializer's `toPlainText` (or equivalent) is producing `[table]` as a fallback for the table node. The expected behavior is that an INTRA-CELL text selection should serialize to JUST the selected text (since the selection doesn't span the whole table); only a selection that selects the table NODE should yield the placeholder (or, ideally, a markdown table representation).
-
-**Likely fix area.** `renderer/components/editor/MarkdownEditor.tsx` — TipTap Table extension config + `Markdown.configure({ transformCopiedText: ... })`. Also check `tiptap-markdown`'s clipboard serializer for any custom toText behavior on Table nodes.
-
-**Reproduction.** Open `/tmp/duo-walk-vault/Index.md` (or any md with a table). Add a table:
+**Reproduction (use to validate the fix).** Open any md file with a table in the TipTap editor. Add or use:
 ```
 | key  | value |
 |------|-------|
 | foo  | hello |
 ```
-Click into "hello", select with double-click or shift-arrow, ⌘C, paste somewhere. Expected: "hello". Actual: "[table]".
+Click into "hello", select with double-click or shift-arrow, ⌘C, paste somewhere. Expected (post-fix): "hello". Pre-fix: "[table]".
 
-**Cross-ref.** Newly discovered 2026-05-08 pre-cut. Pairs with the broader markdown editor polish backlog (BUG-073 dash bullets, etc.).
+**Validation cases owed in the smoke walk.**
+- Intra-cell partial text selection → exact selected substring.
+- Whole-cell selection (triple-click) → cell text.
+- Multi-cell same-row selection → cells joined by `\t`.
+- Multi-row selection → rows joined by `\n`, cells by `\t`.
+- Whole-table selection (⌘A or click outside, drag through table) → markdown table form (existing tiptap-markdown serializer).
+
+**Cross-ref.** Discovered 2026-05-08 pre-cut. Pairs with the broader markdown editor polish backlog (BUG-073 dash bullets, etc.).
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -5957,6 +5957,39 @@ This is how Obsidian works by default — many users use cmd+click as the primar
 
 ---
 
+### ENH-115: Right-click terminal tab → "Reveal in navigator" (focus nav on tab's CWD)
+
+**Status:** 🆕 Filed 2026-05-09 (Sprint 12 P1 — landing alongside image v2 + BUG-108).
+**Priority:** **Medium** — small QoL bridge between the terminal column and the navigator. The terminal tab already knows its `cwd`; the navigator already knows how to navigate-to a path; today there's no gesture to connect them.
+**Filed:** 2026-05-09.
+
+**What's wanted.** Right-click any tab in the terminal tab strip → context menu with at least one entry: **"Reveal in navigator"** (working name). Clicking it calls `nav.actions.navigateTo(tab.cwd)` — same code path that `duo reveal` already uses — and surfaces the existing reveal chip so the user sees what just changed.
+
+The pattern matches macOS's "Reveal in Finder" affordance and Duo's existing `nav.onReveal` plumbing — this is the in-app sibling to the CLI's `duo reveal` verb.
+
+**Naming TBD.** Owner explicitly flagged the label as uncertain. Candidates:
+- **"Reveal in navigator"** — matches the existing "Reveal in Finder" verb pattern; concise. **Recommended.**
+- "Reveal project in navigator" — owner's first instinct; accurate when CWD is a project root, but verbose and "project" is overloaded.
+- "Show CWD in navigator" — explicit but jargon-y.
+- "Focus navigator here" — readable but doesn't reuse the established "Reveal" verb.
+
+Recommend "Reveal in navigator" for the v1 label; revisit during the smoke walk if it reads wrong in context.
+
+**Affected code (estimated, ~30min).**
+- `renderer/components/TabBar.tsx § Tab` — add `onContextMenu` to the tab button. Calls `window.electron.menu.popup({ items: [...], x, y })` with a single entry today, leaving room for additional verbs later (e.g. "Duplicate tab in this CWD", "Close all other tabs").
+- `renderer/components/TabBar.tsx § TabBarProps` — add `onRevealCwd?: (cwd: string) => void` callback so the wiring stays in App.tsx.
+- `renderer/App.tsx` — wire the prop to `nav.actions.navigateTo(cwd)` + `setRevealChip(cwd)` (mirrors the existing `nav.onReveal` handler at line ~1257).
+
+**No new IPC surface needed** — `window.electron.menu.popup` (BUG-105 / ENH-050) and `nav.actions.navigateTo` already exist.
+
+**Open questions for the smoke walk.**
+- Should the menu also offer "Open new terminal here" / "Duplicate tab"? **Defer** — v1 ships the single verb; expand only if the right-click gesture feels under-utilized.
+- Should the reveal chip differentiate "from CLI" vs "from terminal context-menu"? **No** — same source-of-truth, same chip.
+
+**Cross-ref:** Pairs with the existing `duo reveal <path>` CLI verb (Stage 10) and the `nav.onReveal` listener at [renderer/App.tsx:1257](renderer/App.tsx).
+
+---
+
 ### BUG-109: ⌘T new browser tab — caret not in URL bar (regression, surfaced 2026-05-07 walk-1)
 
 **Status:** ✅ **Shipped Sprint 9 (2026-05-07).** Walk-3 user-verified PASS. Walk-1 fix landed `window.electron.keyboard.reclaimFocus()` BEFORE the rAF chain in newBrowserTab — pulls OS focus from the WCV to the renderer so by the time the URL input's `.focus()` fires, the renderer owns OS focus and the caret renders blue/active. Owner walk-3: "[PASS]."


### PR DESCRIPTION
## Sprint 12 — three additions before the v0.6.10 cut

Owner directives this sprint:
- 2026-05-08: *"don't cut yet; address image handling and one more newly discovered bug"* → ENH-111 + BUG-108.
- 2026-05-09: *"add another feature: right clicking on terminal tab should offer option to focus the navigator on that tab's CWD"* → ENH-115.

All three landed; smoke walk owed before the cut.

### ENH-111 — image viewer v2 (PRD persona: dragging a screenshot from Slack into Duo)
Replaces the bare `<img>` previewer with a toolbar over the image area:
- Zoom in / out (⌘/⌃-wheel also zooms), fit-to-window, 1:1 actual size, click-to-toggle fit/manual.
- Copy image (full bitmap to system clipboard).
- Dimensions + file-size readout: `1440 × 900 · 312 KB`.
- Drag-to-pan when the image overflows the container.
- Right-click → native context menu: Copy image, Copy path, Open in default app, Reveal in Finder, Fit to window, Actual size.

New IPCs (both small, new in this sprint):
- `files.stat(path)` → `{ size, mtimeMs }` — cheaper than `files.read` which would transfer the whole payload just for a size readout.
- `clipboard.writeImage(path)` → `boolean` — main-process route via `nativeImage.createFromPath` + `clipboard.writeImage`. Renderer's `navigator.clipboard.write` is unreliable: needs a user gesture and is PNG-only. Main covers every codec Electron decodes.

`ImageView.tsx` is a new sibling to `FileRenderers.tsx` — outgrew the "lightweight glyphs" scope of the old file.

### BUG-108 — markdown table-cell copy yields plain text (not `[table]`)

**Root cause.** tiptap-markdown's `transformCopiedText` plugin runs `MarkdownSerializer.serialize(slice.content)`. ProseMirror's `Selection.content()` returns slices with `includeParents=true` — so an intra-cell text selection arrives wrapped in `<table><tr><td>…</td></tr></table>`. tiptap-markdown's table serializer rejects that wrapped slice in `isMarkdownSerializable` (the function requires the first row to be all `tableHeader`; a body-cell-only slice always fails), and the fallback path is `state.write("[" + node.type.name + "]")` — which writes the literal `[table]` because Duo runs tiptap-markdown with `html: false` for round-trip fidelity.

**Fix.** New `TableCellCopy` extension at `renderer/components/editor/extensions/TableCellCopy.ts` (priority 1000, above tiptap-markdown's `markdownClipboard` at priority 50) installs a `clipboardTextSerializer` that detects "slice begins with a table node" and returns the slice's plain-text content via `Fragment.textBetween(0, size, '\n', '\t')` — newline between rows, tab between cells (matches every spreadsheet/word-processor convention). Whole-table selections that include the header row fall through (return null) so tiptap-markdown's existing markdown-table serializer continues to render proper `| key | value |` form.

### ENH-115 — terminal-tab right-click → "Reveal in navigator"

Right-click any tab in the terminal tab strip → context-menu entry "Reveal in navigator". Reuses `window.electron.menu.popup` (BUG-105 / ENH-050) + the same `nav.actions.navigateTo` + reveal-chip flow that the CLI's `duo reveal` triggers. No new IPC.

Working name follows the macOS "Reveal in Finder" verb pattern. Owner flagged the label as uncertain — revisit during the smoke walk if it reads wrong.

## Test plan (smoke walk owed)

ENH-111 — image viewer:
- [ ] Open a PNG / JPG / GIF / WEBP via the navigator. Toolbar renders; dimensions + size show real values.
- [ ] Click `+` / `−` / `1:1` / fit buttons — zoom level updates; image grows/shrinks; container scrolls when manual zoom > fit.
- [ ] ⌘-wheel inside the image area — zoom in/out.
- [ ] Drag inside a manually-zoomed image — pans.
- [ ] Right-click → Copy image → paste into another app (Notion, Slack) — image lands.
- [ ] Right-click → Copy path → paste into terminal — absolute path lands.
- [ ] Right-click → Open in default app → Preview.app opens the image.
- [ ] Right-click → Reveal in Finder → Finder window pops with file selected.

BUG-108 — table cell copy:
- [ ] Intra-cell partial text selection → exact selected substring lands on clipboard.
- [ ] Whole-cell selection (triple-click) → cell text lands.
- [ ] Multi-cell same-row selection → cells joined by `\t`.
- [ ] Multi-row selection → rows joined by `\n`, cells by `\t`.
- [ ] Whole-table selection (drag from above the table down through it) → markdown table form.

ENH-115 — terminal-tab Reveal in navigator:
- [ ] Right-click a terminal tab whose CWD differs from the current navigator root — context menu shows "Reveal in navigator".
- [ ] Click → navigator jumps to that CWD; reveal chip appears at the top of the navigator and dismisses after 4s.
- [ ] Right-click on a tab whose CWD matches the navigator root — same behavior (chip still surfaces; safe no-op visually).
- [ ] Confirm label reads correctly; flag for relabeling if "Reveal in navigator" feels wrong.

⚠️ **I couldn't verify the app's render state in this environment** — the dev session can't run here (node-pty rebuild needs network access for Electron headers). Geoff: please open DevTools (Cmd+Opt+I) for any error overlay before walking, and restart the dev session if it's been running while the IPC contract changed. The new IPCs (`files.stat`, `clipboard.writeImage`) require an Electron restart, not just a renderer HMR.

Typecheck passes cleanly on both `tsconfig.node.json` and `tsconfig.web.json`.

https://claude.ai/code/session_01Eaj9uoTFbL3oSRTe6NwCv5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eaj9uoTFbL3oSRTe6NwCv5)_