### PR TITLE
feat(ENH-160): scripts/build-pkg.sh — Path-1 .pkg installer for distro packs

### DIFF
--- a/distro-pack-builder/playground.md
+++ b/distro-pack-builder/playground.md
@@ -286,13 +286,30 @@ Three artifact shapes (pick one or build several):
 ### `.pkg` installer (path 1 — IT mass-deploy)
 
 Best for: corporate platform teams shipping to a Mac fleet via
-Jamf / Munki / Kandji. Users don't unzip; the pkg writes the
-pack to `~/.claude/duo/extra-packs/<name>/` directly.
+Jamf / Munki / Kandji. Users don't unzip; the `.pkg` bundles
+`Duo.app` + your pack and the postinstall script writes the pack
+to `~/.claude/duo/extra-packs/<name>/` directly.
 
-In Claude Code with `/pack-builder` open, walk the **build-pkg**
-step. Output is a signed `.pkg` (you supply the Developer ID
-Installer cert; or unsigned `.pkg` if your IT tool is configured
-to trust unsigned).
+```bash
+# From the Duo repo root, with the canonical signed Duo.app already
+# installed at /Applications/Duo.app on this build machine:
+bash scripts/build-pkg.sh --pack ~/Documents/<your-pack-dir>/
+# → dist/<pack-name>-<pack-version>-installer.pkg
+```
+
+The wrapper script handles `pkgbuild` + `productbuild` and bakes a
+postinstall script that drops the pack into the installing user's
+`~/.claude/duo/extra-packs/<pack-name>/`. The inner `Duo.app`'s
+signature + notarization travel intact inside the payload, so once
+installed Gatekeeper is satisfied at every app launch.
+
+If your org has a Developer ID **Installer** cert, pass
+`--sign-identity "Developer ID Installer: ..."` to produce a signed
+`.pkg`. Without that flag the `.pkg` itself is unsigned —
+Gatekeeper warns at install time but right-click → Open bypasses
+on a personal Mac and MDM-managed installs typically bypass
+Gatekeeper anyway. See `bash scripts/build-pkg.sh --help` and
+`skill/pack-builder/SKILL.md § Path 2` for the full flag list.
 
 ### Drop-in zip (path 2 — manual install)
 

--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -18,6 +18,20 @@
 | [`2d868a6`](https://github.com/dudgeon/duo/commit/2d868a6) | **BUG-123 v1 fix** — Root cause: Duo never imported `prosemirror-tables/style/tables.css`; the `.selectedCell` decoration was rendering invisibly. Empirical grounding (after owner correction) found the missing import; 9-line CSS fix in `globals.css` paints the overlay with Duo accent at 18% opacity + position:relative on td/th. Cross-boundary drag-to-outside-table deferred behind v1 owner walk | Ship — owner AUQ pick (CSS only + Duo orange) |
 | _(pending sha)_ | **ENH-156** — HTML verb-split: `duo open <html>` → browser pane (interactive default); `duo edit <html>` → canvas mode (source-editable). Renderer's `openFileSmart` strips the `<meta duo-open-in>` consultation; CLI adds `--canvas` override for open + `--browser` override for edit; server passes mode through nav.edit. ENH-157 filed as the prioritized follow-up (browser-pane comment support — `duo html comment` currently canvas-only, surfaced by the new default). Doc sweep across CLAUDE.md / vocabulary.md / make-page.md / make-playground.md / SKILL.md / agents/duo.md / CLI-COVERAGE.md | Ship — owner pick (option 2 from the verb-split AUQ: ship now, file browser-comments ENH for Sprint 18) |
 
+## Side branch — Enterprise-setup (`claude/enterprise-github-setup-ldT7t`)
+
+**Status:** Parallel branch, NOT on main. Opened 2026-05-15 from owner question "I got at-work DMG approval — can we bundle Duo + a distro pack as a `.pkg` for internal distribution?" Branch surfaced two prior-art gaps: cut-version + DMG-bundling don't quite fit the at-work zip-only Git workflow (see chat for the tradeoffs), but the Path-1 `.pkg` automation that Stage 21d-ii scoped + then deferred IS the natural shape. Built it.
+
+| ID | Title | Shape |
+|---|---|---|
+| **ENH-160** | `scripts/build-pkg.sh` Path-1 `.pkg` installer wrapper | Closes the Stage 21d-ii deferral. Bundles `/Applications/Duo.app` (signature intact via `ditto`) + the pack folder, bakes a postinstall that drops the pack into the installing user's `~/.claude/duo/extra-packs/<name>/`. Default produces an unsigned `.pkg` — the normal path for shops without a Developer ID Installer cert. `--sign-identity` flag for shops that have one. SKILL.md § Path 2 + playground.md § Step 9 § Path 1 updated to point at the script. |
+
+**Smoke-walk gate.** Owner walks the build-pkg flow on a Mac (can't run `pkgbuild` on the Linux dev environment that built this); 6-step procedure in the ENH-160 tasks.md entry. Until that walk lands the branch stays draft.
+
+**Branch disposition.** Side branch from main (NOT a Sprint 17 commit since the work is orthogonal to Sprint 17's A+C+D theme). Merge candidate post-walk; no v0.6.16 cut blocker because the artifact lives outside the Duo runtime (it's a build-tool wrapper).
+
+---
+
 ## Side branch — GitHub-integration planning (`claude/github-integration-planning-rPdVY`)
 
 **Status:** Parallel planning thread, NOT on main. Opened 2026-05-13 after ENH-149 closed + ENH-150 was filed. Owner answered a 4-feature AUQ (status overlay / clone / right-click GitHub menu + bounce-list / link folder to repo) picking all four; said "playground it first" for the link-folder-to-repo decision.

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# ENH-160 — build a macOS Installer .pkg for a Duo distro pack (Path 1).
+# (Renumbered from ENH-156 after collision with main's verb-split.)
+#
+# Produces a .pkg that bundles:
+#   1. The canonical signed Duo.app (copied verbatim from /Applications/Duo.app
+#      on this build machine; the inner code signature + notarization travel
+#      intact inside the .pkg payload).
+#   2. The distro pack folder.
+#   3. A postinstall script that drops the pack into
+#      $HOME/.claude/duo/extra-packs/<distro-name>/ for the installing user,
+#      where Duo's install service discovers it on next launch.
+#
+# Usage (run from repo root):
+#
+#   bash scripts/build-pkg.sh --pack <pack-dir> [options]
+#
+# Options:
+#   --pack <dir>            Path to the distro pack folder (required).
+#   --output <pkg-path>     Output .pkg path.
+#                           Default: dist/<pack-name>-<pack-version>-installer.pkg
+#   --identifier <rdns>     Reverse-DNS package identifier.
+#                           Default: com.duo.distro.<pack-name>.installer
+#   --sign-identity <name>  Developer ID Installer cert common name.
+#                           Omit for an unsigned .pkg (Gatekeeper warns at
+#                           install; right-click → Open bypasses on a
+#                           personal Mac; MDM-managed installs typically
+#                           bypass anyway).
+#   --duo-app <path>        Source Duo.app path. Default: /Applications/Duo.app.
+#                           Useful for forks that ship a renamed bundle.
+#   --help / -h             Show this message.
+#
+# Signing notes
+# -------------
+# The .pkg's own signature is independent of the inner Duo.app's signature.
+# Without --sign-identity the resulting .pkg is unsigned; the Duo.app inside
+# remains signed + notarized regardless (so once installed, Gatekeeper is
+# happy with the .app every launch). Producing an unsigned .pkg is the
+# normal path for shops that can't get a Developer ID Installer cert on
+# the build machine.
+#
+# Requirements
+# ------------
+# - macOS (pkgbuild + productbuild + codesign are macOS-only).
+# - jq (brew install jq) for reading plugin.json.
+# - /Applications/Duo.app present (or pass --duo-app explicitly).
+#
+# Exit codes
+# ----------
+#   0   success
+#   1   usage / argument error
+#   2   missing dependency or missing input file
+#   3   pkgbuild / productbuild / productsign failure (propagated)
+
+set -euo pipefail
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "ERROR: build-pkg.sh runs on macOS only (uses pkgbuild + productbuild + codesign)." >&2
+  exit 2
+fi
+
+SCRIPT_NAME="$(basename "$0")"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+usage() {
+  cat <<USAGE
+Usage: $SCRIPT_NAME --pack <pack-dir> [options]
+
+Options:
+  --pack <dir>             Path to the distro pack folder (required).
+  --output <pkg-path>      Output .pkg path.
+                           Default: dist/<pack-name>-<pack-version>-installer.pkg
+  --identifier <rdns>      Package identifier (reverse-DNS).
+                           Default: com.duo.distro.<pack-name>.installer
+  --sign-identity <name>   Developer ID Installer cert common name.
+                           Omit for an unsigned .pkg.
+  --duo-app <path>         Source Duo.app path. Default: /Applications/Duo.app
+  --help / -h              Show this message.
+
+Examples:
+  $SCRIPT_NAME --pack ~/Documents/my-team-pack/
+  $SCRIPT_NAME --pack ./my-pack --output dist/special.pkg
+  $SCRIPT_NAME --pack ./my-pack \\
+      --sign-identity "Developer ID Installer: ACME Corp (TEAM123)"
+USAGE
+}
+
+PACK_DIR=""
+OUTPUT_PKG=""
+IDENTIFIER=""
+SIGN_IDENTITY=""
+DUO_APP="/Applications/Duo.app"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pack)           PACK_DIR="${2:-}"; shift 2 ;;
+    --output)         OUTPUT_PKG="${2:-}"; shift 2 ;;
+    --identifier)     IDENTIFIER="${2:-}"; shift 2 ;;
+    --sign-identity)  SIGN_IDENTITY="${2:-}"; shift 2 ;;
+    --duo-app)        DUO_APP="${2:-}"; shift 2 ;;
+    --help|-h)        usage; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$PACK_DIR" ]; then
+  echo "ERROR: --pack <pack-dir> is required." >&2
+  usage
+  exit 1
+fi
+
+if [ ! -d "$PACK_DIR" ]; then
+  echo "ERROR: pack dir not found: $PACK_DIR" >&2
+  exit 2
+fi
+PACK_DIR="$(cd "$PACK_DIR" && pwd)"
+
+PLUGIN_JSON="$PACK_DIR/.claude-plugin/plugin.json"
+if [ ! -f "$PLUGIN_JSON" ]; then
+  echo "ERROR: $PLUGIN_JSON not found. Is this a Duo distro pack?" >&2
+  echo "  Expected layout: <pack-dir>/.claude-plugin/plugin.json" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required. brew install jq" >&2
+  exit 2
+fi
+
+PACK_NAME=$(jq -r '.name' "$PLUGIN_JSON")
+PACK_VERSION=$(jq -r '.version' "$PLUGIN_JSON")
+
+if [ -z "$PACK_NAME" ] || [ "$PACK_NAME" = "null" ]; then
+  echo "ERROR: plugin.json § name missing or null." >&2
+  exit 2
+fi
+if [ -z "$PACK_VERSION" ] || [ "$PACK_VERSION" = "null" ]; then
+  echo "ERROR: plugin.json § version missing or null." >&2
+  exit 2
+fi
+
+# Defense-in-depth: pack name is interpolated into the postinstall's `rm -rf`
+# target path. Restrict to lowercase alphanumeric + hyphen (the pack-naming
+# convention already enforced elsewhere) so a malformed name can't break out
+# into adjacent dirs.
+if ! [[ "$PACK_NAME" =~ ^[a-z0-9-]+$ ]]; then
+  echo "ERROR: pack name '$PACK_NAME' must match [a-z0-9-]+ (lowercase alphanumeric + hyphen)." >&2
+  exit 2
+fi
+
+if [ ! -d "$DUO_APP" ]; then
+  echo "ERROR: $DUO_APP not found." >&2
+  echo "  build-pkg bundles whatever Duo.app is currently installed at the path" >&2
+  echo "  given by --duo-app (default: /Applications/Duo.app). Install the" >&2
+  echo "  canonical signed Duo DMG first, or pass --duo-app <path>." >&2
+  exit 2
+fi
+
+for cmd in pkgbuild productbuild codesign; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: $cmd not found. build-pkg requires macOS." >&2
+    exit 2
+  fi
+done
+
+if [ -z "$OUTPUT_PKG" ]; then
+  OUTPUT_PKG="$REPO_ROOT/dist/${PACK_NAME}-${PACK_VERSION}-installer.pkg"
+fi
+if [ -z "$IDENTIFIER" ]; then
+  IDENTIFIER="com.duo.distro.${PACK_NAME}.installer"
+fi
+
+mkdir -p "$(dirname "$OUTPUT_PKG")"
+
+DUO_APP_VERSION=$(defaults read "$DUO_APP/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "unknown")
+
+echo "[build-pkg] Pack name:       $PACK_NAME"
+echo "[build-pkg] Pack version:    $PACK_VERSION"
+echo "[build-pkg] Identifier:      $IDENTIFIER"
+echo "[build-pkg] Duo.app source:  $DUO_APP (version $DUO_APP_VERSION)"
+echo "[build-pkg] Output:          $OUTPUT_PKG"
+if [ -n "$SIGN_IDENTITY" ]; then
+  echo "[build-pkg] Signing:         $SIGN_IDENTITY"
+else
+  echo "[build-pkg] Signing:         (unsigned)"
+fi
+echo
+
+STAGING_ROOT="$(mktemp -d -t duo-build-pkg)"
+trap 'rm -rf "$STAGING_ROOT"' EXIT
+
+PAYLOAD_ROOT="$STAGING_ROOT/payload"
+SCRIPTS_DIR="$STAGING_ROOT/scripts"
+
+# Payload tree: every file under PAYLOAD_ROOT will land at its corresponding
+# absolute path on the target system, because we pass --install-location "/"
+# to pkgbuild.
+#
+# 1. Duo.app → /Applications/Duo.app
+#    ditto preserves resource forks, xattrs, and the code signature.
+mkdir -p "$PAYLOAD_ROOT/Applications"
+echo "[build-pkg] Staging Duo.app (ditto preserves signature)..."
+ditto "$DUO_APP" "$PAYLOAD_ROOT/Applications/Duo.app"
+
+# Sanity check: confirm the staged copy still verifies. If ditto dropped a
+# metadata bit, fail loudly here rather than silently shipping a broken pkg.
+echo "[build-pkg] Verifying staged Duo.app signature..."
+if codesign --verify --deep --strict "$PAYLOAD_ROOT/Applications/Duo.app" 2>/dev/null; then
+  echo "[build-pkg]   ✓ signature intact in staging"
+else
+  echo "[build-pkg]   ⚠ signature did not verify in staging." >&2
+  echo "[build-pkg]     Possible causes:" >&2
+  echo "[build-pkg]       - Source Duo.app at $DUO_APP is itself unsigned (dev build)." >&2
+  echo "[build-pkg]       - ditto failed to preserve metadata (rare)." >&2
+  echo "[build-pkg]     Continuing build, but verify the produced .pkg before distributing." >&2
+fi
+
+# 2. Pack content → /private/var/tmp/duo-pack-staging/<pack-name>/
+#    Postinstall moves it from here into the installing user's home.
+#    /private/var/tmp/ is world-readable (mode 1777) — the staging directory
+#    is intentionally public during the brief install window. Distro packs
+#    must not contain secrets; pack content is assumed to be cohort-public
+#    material (skills, agents, canvases, CLAUDE.md guidance).
+STAGE_PARENT="$PAYLOAD_ROOT/private/var/tmp/duo-pack-staging"
+mkdir -p "$STAGE_PARENT"
+echo "[build-pkg] Staging pack content..."
+ditto "$PACK_DIR" "$STAGE_PARENT/$PACK_NAME"
+
+# 3. Postinstall script. Uses a quoted heredoc so $-refs stay literal until
+#    install-time; pack-name is substituted via sed afterwards.
+mkdir -p "$SCRIPTS_DIR"
+cat > "$SCRIPTS_DIR/postinstall" <<'POSTINSTALL'
+#!/bin/bash
+# Postinstall for the Duo distro pack.
+# Relocates the staged pack into the installing user's
+# ~/.claude/duo/extra-packs/<pack-name>/ directory. Duo's install
+# service picks up the pack on next launch.
+set -euo pipefail
+
+PACK_NAME="__PACK_NAME__"
+STAGE="/private/var/tmp/duo-pack-staging/$PACK_NAME"
+
+if [ ! -d "$STAGE" ]; then
+  echo "ERROR: staged pack not found at $STAGE" >&2
+  exit 1
+fi
+
+# Identify the user who initiated the install. macOS Installer runs
+# postinstall as root; the console user (whoever is logged in at the
+# GUI) is the right placement target.
+CONSOLE_USER=$(stat -f "%Su" /dev/console 2>/dev/null || true)
+if [ -z "$CONSOLE_USER" ] || [ "$CONSOLE_USER" = "root" ]; then
+  CONSOLE_USER="${USER:-$(logname 2>/dev/null || true)}"
+fi
+if [ -z "$CONSOLE_USER" ] || [ "$CONSOLE_USER" = "root" ]; then
+  echo "ERROR: cannot determine the installing user; pack placement aborted." >&2
+  echo "  Manually copy $STAGE to ~/.claude/duo/extra-packs/$PACK_NAME/" >&2
+  echo "  as the target user." >&2
+  exit 1
+fi
+
+USER_HOME=$(dscl . -read "/Users/$CONSOLE_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+if [ -z "$USER_HOME" ] || [ ! -d "$USER_HOME" ]; then
+  echo "ERROR: cannot resolve home directory for $CONSOLE_USER" >&2
+  exit 1
+fi
+
+DEST="$USER_HOME/.claude/duo/extra-packs/$PACK_NAME"
+DEST_PARENT="$(dirname "$DEST")"
+
+sudo -u "$CONSOLE_USER" mkdir -p "$DEST_PARENT"
+
+# Atomic-replace: clear any prior install of the same pack name. Duo's
+# install service does its own atomic-replace on the next launch's
+# detection of a name+version change, but clearing here keeps the
+# extra-packs/ surface clean.
+if [ -d "$DEST" ]; then
+  rm -rf "$DEST"
+fi
+
+cp -R "$STAGE" "$DEST"
+chown -R "$CONSOLE_USER:staff" "$DEST"
+
+rm -rf "$STAGE"
+rmdir /private/var/tmp/duo-pack-staging 2>/dev/null || true
+
+echo "[$PACK_NAME] installed to $DEST"
+echo "[$PACK_NAME] Duo will discover the pack on next launch."
+
+exit 0
+POSTINSTALL
+
+# Substitute the pack name into the postinstall (build-time bake).
+sed -i.bak "s/__PACK_NAME__/$PACK_NAME/g" "$SCRIPTS_DIR/postinstall"
+rm "$SCRIPTS_DIR/postinstall.bak"
+chmod +x "$SCRIPTS_DIR/postinstall"
+
+# Component pkg (raw payload + scripts).
+COMPONENT_PKG="$STAGING_ROOT/component.pkg"
+echo "[build-pkg] Running pkgbuild..."
+pkgbuild \
+  --root "$PAYLOAD_ROOT" \
+  --scripts "$SCRIPTS_DIR" \
+  --identifier "$IDENTIFIER" \
+  --version "$PACK_VERSION" \
+  --install-location "/" \
+  "$COMPONENT_PKG"
+
+# Distribution pkg (productbuild wraps for a friendlier installer UI and is
+# required as the input shape for productsign).
+DIST_PKG="$STAGING_ROOT/distribution.pkg"
+echo "[build-pkg] Running productbuild..."
+productbuild \
+  --package "$COMPONENT_PKG" \
+  "$DIST_PKG"
+
+if [ -n "$SIGN_IDENTITY" ]; then
+  echo "[build-pkg] Signing with $SIGN_IDENTITY..."
+  productsign --sign "$SIGN_IDENTITY" "$DIST_PKG" "$OUTPUT_PKG"
+else
+  cp "$DIST_PKG" "$OUTPUT_PKG"
+fi
+
+PKG_SIZE=$(du -sh "$OUTPUT_PKG" | awk '{print $1}')
+echo
+echo "[build-pkg] Done."
+echo "[build-pkg]   Output: $OUTPUT_PKG ($PKG_SIZE)"
+if [ -z "$SIGN_IDENTITY" ]; then
+  echo
+  echo "[build-pkg] Note: unsigned .pkg."
+  echo "  - End users may need to right-click → Open the first time to bypass Gatekeeper."
+  echo "  - MDM-managed installs (Jamf / Munki / Kandji) typically bypass Gatekeeper anyway."
+  echo "  - The inner Duo.app remains signed + notarized; Gatekeeper is satisfied at app launch."
+fi

--- a/skill/pack-builder/SKILL.md
+++ b/skill/pack-builder/SKILL.md
@@ -170,17 +170,51 @@ no signing.
 
 ### Path 2 — `.pkg` installer (corporate IT, polished UX)
 
+Build a macOS Installer `.pkg` that bundles the canonical signed
+`Duo.app` (copied from `/Applications/Duo.app` on the build machine —
+the inner code signature + notarization travel intact inside the
+payload) plus the pack folder. A postinstall script in the `.pkg`
+drops the pack into the installing user's
+`~/.claude/duo/extra-packs/<pack-name>/`, and Duo's install service
+picks it up on next launch.
+
+The `scripts/build-pkg.sh` wrapper handles `pkgbuild` + `productbuild`:
+
 ```bash
-# (deferred — pack-builder pkg flow lands in a follow-up sprint.)
-# Manual recipe meanwhile:
-#   1. Download canonical Duo.app from upstream releases (unmodified,
-#      signature intact).
-#   2. Bundle Duo.app + your pack folder into a .pkg with productbuild.
-#   3. Sign the .pkg with your distro's Developer ID Installer cert.
-#   4. (Optional) Notarize with notarytool.
-# .pkg postinstall script copies Duo.app to /Applications + drops
-# the pack into ~/.claude/duo/extra-packs/<distro-name>/.
+# 1. Install the canonical signed Duo DMG on the build machine so
+#    /Applications/Duo.app is what you want to bundle.
+# 2. From the Duo repo root:
+bash scripts/build-pkg.sh --pack ~/Documents/<pack-name>/
+# 3. Output lands in dist/<pack-name>-<pack-version>-installer.pkg.
 ```
+
+Flags (see `bash scripts/build-pkg.sh --help`):
+
+- `--pack <dir>` (required) — pack folder; reads name + version from
+  `.claude-plugin/plugin.json`.
+- `--output <path>` — override default output location.
+- `--identifier <rdns>` — package identifier; default
+  `com.duo.distro.<pack-name>.installer`.
+- `--sign-identity <name>` — Developer ID **Installer** cert common
+  name. Omit for an unsigned `.pkg`.
+- `--duo-app <path>` — source `Duo.app` if not at the default
+  `/Applications/Duo.app` (e.g. forks with a renamed bundle).
+
+**Signed vs. unsigned `.pkg`.** The `.pkg`'s own signature is
+independent of the inner `Duo.app`'s signature. Without
+`--sign-identity` the produced `.pkg` is unsigned: Gatekeeper will
+warn at install (`"unidentified developer"`), but right-click → Open
+bypasses on a personal Mac and MDM-managed installs (Jamf / Munki /
+Kandji) typically bypass Gatekeeper anyway. The inner `Duo.app`
+remains signed + notarized regardless, so Gatekeeper is happy at app
+launch every time. Producing an unsigned `.pkg` is the normal path
+when the build machine can't get a Developer ID Installer cert.
+
+**Notarization.** Not supported by an unsigned `.pkg`. If you have
+the Installer cert, sign with `--sign-identity` then notarize
+manually with `xcrun notarytool submit <pkg> --apple-id ... --wait`
+followed by `xcrun stapler staple <pkg>`. Not wrapped by this script
+because notarization credential management is org-specific.
 
 ### Path 3 — Fork + compile (early-adopter / pre-DMG-approval)
 

--- a/tasks.md
+++ b/tasks.md
@@ -5842,6 +5842,51 @@ Verified the gap empirically:
 
 ---
 
+### ENH-160: `scripts/build-pkg.sh` — Path-1 `.pkg` installer wrapper (closes Stage 21d-ii deferral)
+
+**Status:** ✅ Shipped on branch `claude/enterprise-github-setup-ldT7t` (2026-05-15). Closes the deferral at `skill/pack-builder/SKILL.md:174` ("deferred — pack-builder pkg flow lands in a follow-up sprint.") scoped originally in `docs/prd/stage-21d-distro-packs.md:479-484`.
+**Priority:** P1 — unblocks Geoff's at-work enterprise distribution (signed DMG-approved environment where pack distribution via `.pkg` is the natural fit; no Developer ID Installer cert available, so unsigned `.pkg` is the target shape).
+**Filed:** 2026-05-15.
+
+**Origin.** Geoff got at-work approval to run the signed Duo DMG and asked: "how do I bundle Duo + our pack content for internal distribution?" — recalled that Path 1 (`.pkg` installer) was the preferred shape from the Stage 21d PRD but couldn't remember if the build-pkg automation shipped (it hadn't). Decided to build it now on the enterprise-setup branch.
+
+**What ships.**
+- New shell script at [`scripts/build-pkg.sh`](scripts/build-pkg.sh) — wraps `pkgbuild` + `productbuild` (+ optional `productsign`) into a single command.
+- Bundles canonical signed `Duo.app` from `/Applications/Duo.app` on the build machine (the inner code signature + notarization travel intact inside the payload via `ditto`).
+- Bakes a postinstall script that resolves the installing user via `stat -f "%Su" /dev/console` + `dscl . -read /Users/<u> NFSHomeDirectory`, then `cp -R` + `chown` the pack into `$HOME/.claude/duo/extra-packs/<pack-name>/` where Duo's install service discovers it on next launch.
+- Pre-build sanity check via `codesign --verify --deep --strict` on the staged `Duo.app` — fails-soft (warns, continues) if signature didn't survive ditto (rare) or source is a dev build (intentional).
+- Atomic-replace semantics: postinstall `rm -rf` any prior `<pack-name>/` directory before placing the new one (Duo's install service does its own atomic-replace too on name+version change, but clearing here keeps `extra-packs/` clean).
+- Default output `dist/<pack-name>-<pack-version>-installer.pkg`; overridable via `--output`.
+
+**Flags.**
+- `--pack <dir>` (required) — reads `name` + `version` from `<pack-dir>/.claude-plugin/plugin.json`.
+- `--output <pkg-path>` — override default location.
+- `--identifier <rdns>` — override default `com.duo.distro.<pack-name>.installer`.
+- `--sign-identity <name>` — Developer ID **Installer** cert common name; omit for unsigned `.pkg` (the normal path for shops without an Installer cert).
+- `--duo-app <path>` — override `/Applications/Duo.app` source (forks with renamed bundles).
+
+**Signing semantics.** The `.pkg`'s own signature is independent of the inner `Duo.app`'s. Without `--sign-identity` the `.pkg` is unsigned: Gatekeeper warns at install time but (a) right-click → Open bypasses on a personal Mac, (b) MDM-managed installs typically bypass Gatekeeper anyway, (c) the inner signed+notarized `Duo.app` keeps Gatekeeper happy at every app launch post-install. **Notarization** of the `.pkg` is not wrapped (requires `xcrun notarytool` + org-specific Apple ID credentials); doc points users at the manual `notarytool submit … && stapler staple` recipe if their org has the Installer cert.
+
+**Doc updates.**
+- [`skill/pack-builder/SKILL.md`](skill/pack-builder/SKILL.md) § Path 2 — replaced the "deferred" stub with concrete `scripts/build-pkg.sh` instructions + signing semantics + notarization handoff.
+- [`distro-pack-builder/playground.md`](distro-pack-builder/playground.md) § Step 9 § Path 1 — made the aspirational `walk the build-pkg step` reference real, points at the script.
+
+**Plumbing checklist (CLAUDE.md § 4).** No `duo` CLI verb added — pack-building is a developer-tool workflow exposed via the pack-builder skill, not an end-user feature. Pattern matches the existing `pack-builder` skill (validate / build-zip / version-bump are all skill-driven, no `duo` counterparts). If owner-feedback wants CLI parity later, the natural verb would be `duo pack build <pack-dir> --kind pkg`. Sketched below as a future filing.
+
+**Smoke-walk owed (Mac-only — can't run pkgbuild on the dev environment).**
+1. On Mac with signed Duo.app at `/Applications/Duo.app`: `bash scripts/build-pkg.sh --pack examples/distro-pack-template/`. Expect `dist/duo-distro-pack-template-1.0.0-installer.pkg` to land (~150MB — most of that is Duo.app).
+2. Double-click the produced `.pkg`. Expect Gatekeeper "unidentified developer" warning. Right-click → Open. Walk the Installer flow.
+3. Verify `/Applications/Duo.app` is installed (or replaced if pre-existing).
+4. Verify `~/.claude/duo/extra-packs/duo-distro-pack-template/` exists + is owned by the installing user.
+5. Launch Duo. Verify the template's example skill + agent show up in the discovery sweep (or in `duo pack list`).
+6. Test atomic-replace: bump the template's plugin.json version to 1.0.1, rebuild, reinstall. Verify `extra-packs/duo-distro-pack-template/` is replaced (not duplicated).
+
+**Cross-ref.** Stage 21d-ii (`docs/prd/stage-21d-distro-packs.md`) — original scope. `electron/distro-pack-service.ts` — the install-service that consumes the dropped pack. CLAUDE.md "Locked decisions" → Distribution / cert row → Stage 21d ✅ → now plumbing-complete for Path 1.
+
+**Followup if surfaced.** Sketched CLI verb (not filed): `duo pack build <pack-dir> --kind pkg|zip` wrapping `scripts/build-pkg.sh` + the existing zip recipe. File only if a real builder requests it; for now the skill is the canonical entry point.
+
+---
+
 ### ENH-155: Right-click GitHub menu on FileTree + bounce-list update — "Open on GitHub" + "Copy GitHub URL"
 
 **Status:** 🆕 Filed Sprint 17 (2026-05-13) on branch `claude/github-integration-planning-rPdVY`. Picked by owner as candidate "C+D" in the GitHub-integration cluster AUQ. Independent of ENH-150 (no Doctor / probe dependency). Ships in parallel with ENH-151 / ENH-152 / ENH-154.


### PR DESCRIPTION
## Summary

Closes the Stage 21d-ii `.pkg`-build deferral that was scoped in `docs/prd/stage-21d-distro-packs.md` lines 479-484 and stubbed in `skill/pack-builder/SKILL.md:174`. Triggered by Geoff asking whether he could bundle Duo + a distro pack for at-work distribution now that the signed DMG has enterprise approval — `.pkg` (Path 1 from the Stage 21d PRD) is the natural shape for that, and the automation had never been built.

## What ships

- **New script: `scripts/build-pkg.sh`** — wraps `pkgbuild` + `productbuild` (+ optional `productsign`). Bundles the canonical signed `Duo.app` from `/Applications/Duo.app` on the build machine (inner code signature + notarization travel intact inside the payload via `ditto`) plus the distro pack folder. Bakes a postinstall script that resolves the installing user (via `stat -f "%Su" /dev/console` + `dscl . -read NFSHomeDirectory`) and drops the pack into `$HOME/.claude/duo/extra-packs/<pack-name>/` where Duo's install service discovers it on next launch.
- **Default → unsigned `.pkg`** — the normal path for shops without a Developer ID **Installer** cert. Gatekeeper warns at install but right-click → Open bypasses on a personal Mac, and MDM-managed installs typically bypass Gatekeeper anyway. The inner signed+notarized `Duo.app` keeps Gatekeeper happy at every app launch post-install regardless.
- **`--sign-identity` flag** — produces a signed `.pkg` for shops that have the Installer cert. Notarization not wrapped (org-specific Apple ID credential management); the SKILL.md doc points users at the manual `xcrun notarytool submit && stapler staple` recipe.
- **Pre-build sanity check** via `codesign --verify --deep --strict` on the staged Duo.app — fails-soft (warns, continues) if signature didn't survive ditto (rare) or source is a dev build.
- **Atomic-replace** semantics: postinstall `rm -rf` any prior `<pack-name>/` directory before placing the new one.

## Flags

```
--pack <dir>             (required) reads name + version from .claude-plugin/plugin.json
--output <path>          default: dist/<pack-name>-<pack-version>-installer.pkg
--identifier <rdns>      default: com.duo.distro.<pack-name>.installer
--sign-identity <name>   omit for unsigned
--duo-app <path>         default: /Applications/Duo.app (override for forks with renamed bundle)
```

## Doc updates

- `skill/pack-builder/SKILL.md` § Path 2 — replaced the "deferred" stub with the concrete recipe.
- `distro-pack-builder/playground.md` § Step 9 § Path 1 — made the aspirational `walk the build-pkg step` reference real.
- `tasks.md` — ENH-156 entry with full smoke-walk gate.
- `docs/dev/active-sprint.md` — side-branch log entry under "Side branch — Enterprise-setup."

## Test plan

`pkgbuild` is macOS-only so smoke-walk has to happen on a Mac with a signed Duo.app installed:

- [ ] **Build:** From repo root with `/Applications/Duo.app` present → `bash scripts/build-pkg.sh --pack examples/distro-pack-template/`. Expect `dist/duo-distro-pack-template-<version>-installer.pkg` (~150MB).
- [ ] **Pre-build verify:** Script logs `✓ signature intact in staging` (not the warn variant).
- [ ] **Install:** Double-click the produced `.pkg`. Gatekeeper warns "unidentified developer" — right-click → Open. Walk the Installer flow.
- [ ] **App placement:** `/Applications/Duo.app` is installed (or replaced if pre-existing) with signature intact: `codesign --verify --deep --strict /Applications/Duo.app` passes.
- [ ] **Pack placement:** `~/.claude/duo/extra-packs/duo-distro-pack-template/` exists + is owned by the installing user (not root).
- [ ] **Pack discovery:** Launch Duo. Verify the template's example skill + agent appear in the discovery sweep (or `duo pack list`).
- [ ] **Atomic-replace:** Bump template's `plugin.json` version to 1.0.1, rebuild, reinstall. Verify `extra-packs/duo-distro-pack-template/` is replaced (not duplicated, no stale files from prior version).
- [ ] **Cleanup verify:** Staging dir `/private/var/tmp/duo-pack-staging/` is removed post-install.

## Followup if surfaced

FOLLOWUP-021 (sketched only, not filed): `duo pack build <pack-dir> --kind pkg|zip` CLI verb wrapping this script + the existing zip recipe. File only if a real pack builder requests CLI parity; for now the pack-builder skill is the canonical entry point (matches the existing skill-only pattern for validate / build-zip / version-bump).

https://claude.ai/code/session_01Q9rv6uJxV2vPyqjwv2nYu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9rv6uJxV2vPyqjwv2nYu5)_