### PR TITLE
Add ENH-182 to Sprint carry-forward backlog (ready to build)

### DIFF
--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -79,6 +79,7 @@ Cherry-pick procedure: `git cherry-pick -n f351719`. Resolve any conflicts (the 
 - **BUG-024 follow-up** combined Send + Comment pill
 - **17a.5** template gallery
 - **Backlinks / graph view** (Obsidian cluster)
+- **ENH-182** Project-centric UX (project-as-filter-layer rail) — **decisions locked 2026-05-25 + PRD/build plan ready** → [`docs/prd/enh-182-project-centric-ux.md`](../prd/enh-182-project-centric-ux.md) (start at §6 Phase 0; §4 names the design assets, §9 has the file:line hook points). Spec-complete — not blocked on a repro/walk, just needs a sprint slot. Playgrounds: `docs/research/project-centric-ux.html` + `project-rail-style-study.html`.
 
 (FOLLOWUP-027 shipped this session — moved out of carry-forward into "Shipped this sprint" above.)
 


### PR DESCRIPTION
## Summary

One-line follow-up to the merged ENH-182 spec ([#53](https://github.com/dudgeon/duo/pull/53)). Adds **ENH-182** to the carry-forward backlog in `docs/dev/active-sprint.md` so it surfaces in the next `/sprint-plan` harvest, flagged as **spec-complete / ready to build** (not blocked on a repro or walk).

The entry points at:
- the PRD + build plan (`docs/prd/enh-182-project-centric-ux.md`) — start at §6 Phase 0,
- §4 (design-asset references) and §9 (file:line code map),
- the decision playgrounds.

Docs-only, single line added.

## Test plan
- [ ] Confirm the carry-forward bullet reads correctly and the PRD link resolves.

https://claude.ai/code/session_01P5huBHCUq7pFhpJsigcxU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5huBHCUq7pFhpJsigcxU9)_