### PR TITLE
fix(ENH-182): heal stale references to deleted dirs in project switching

### DIFF
--- a/core/projects-service.test.ts
+++ b/core/projects-service.test.ts
@@ -299,6 +299,48 @@ describe('deriveProjects — pinned projects (D12)', () => {
     expect(out.projects[0].isGitRoot).toBe(false)
     expect(out.projects[0].hasMarker).toBe(false)
   })
+
+  it('drops a pinned project whose directory was DELETED (exists === false)', () => {
+    // Ghost-pin fix — "pin alone qualifies" holds only while the folder
+    // still exists. A pin to a deleted directory is a ghost tile.
+    const out = deriveProjects({
+      terminals: [],
+      workingTabs: [],
+      pinnedTabPaths: new Set(),
+      pinnedProjects: new Set(['/pinned-deleted']),
+      colorOverrides: {},
+      qualify: () => ({ isGitRoot: false, hasMarker: false, exists: false })
+    })
+    expect(out.projects).toHaveLength(0)
+  })
+
+  it('keeps a pinned project while its existence probe is pending (exists === undefined)', () => {
+    // No-flicker guarantee — undefined exists is treated as "exists",
+    // so a valid pin never blinks out during the async probe window.
+    const out = deriveProjects({
+      terminals: [],
+      workingTabs: [],
+      pinnedTabPaths: new Set(),
+      pinnedProjects: new Set(['/pinned-pending']),
+      colorOverrides: {},
+      qualify: () => ({ isGitRoot: false, hasMarker: false })
+    })
+    expect(out.projects).toHaveLength(1)
+    expect(out.projects[0].root).toBe('/pinned-pending')
+  })
+
+  it('keeps a markerless pin whose directory still exists (exists === true)', () => {
+    const out = deriveProjects({
+      terminals: [],
+      workingTabs: [],
+      pinnedTabPaths: new Set(),
+      pinnedProjects: new Set(['/pinned-extant']),
+      colorOverrides: {},
+      qualify: () => ({ isGitRoot: false, hasMarker: false, exists: true })
+    })
+    expect(out.projects).toHaveLength(1)
+    expect(out.projects[0].root).toBe('/pinned-extant')
+  })
 })
 
 describe('deriveProjects — color assignment (R2)', () => {

--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -200,6 +200,35 @@ function makeTab(cwd: string, kind: TerminalTabKind, home: string, lastClaudeSes
 }
 
 /**
+ * A terminal's persisted launch cwd may have been deleted between
+ * sessions. Restoring it verbatim spawns a PTY in a dead directory
+ * (ENOENT) and surfaces a project-rail tile for a folder that no longer
+ * exists. Mirror the BUG-039 file-tab pattern: fall the cwd back to the
+ * nearest surviving ancestor (or `home` if none qualifies). On a probe
+ * error we restore verbatim rather than guess.
+ */
+async function resolveRestorableCwd(cwd: string, home: string): Promise<string> {
+  try {
+    if (await window.electron.files.dirExists(cwd)) return cwd
+  } catch {
+    return cwd
+  }
+  let cur = cwd
+  while (true) {
+    const idx = cur.lastIndexOf('/')
+    const parent = idx > 0 ? cur.slice(0, idx) : '/'
+    if (parent === cur) break
+    try {
+      if (await window.electron.files.dirExists(parent)) return parent
+    } catch {
+      break
+    }
+    cur = parent
+  }
+  return home
+}
+
+/**
  * ENH-096 (B1) — Walk up from `startPath` (a file path) until an
  * `.obsidian/` directory is found at the same level. Returns the
  * directory containing `.obsidian/` (the vault root) or `null` if
@@ -559,7 +588,11 @@ export function App() {
       // initial state. Empty list (first launch) → keep the default
       // single shell tab the constructor seeded.
       if (state.terminals.length > 0) {
-        const restored = state.terminals.map(t => makeTab(t.cwd, t.kind, home, t.lastClaudeSession ?? null))
+        const restored = await Promise.all(
+          state.terminals.map(async t =>
+            makeTab(await resolveRestorableCwd(t.cwd, home), t.kind, home, t.lastClaudeSession ?? null)
+          )
+        )
         setTabs(restored)
         const idx = state.activeTerminalIndex
         if (Number.isInteger(idx) && idx >= 0 && idx < restored.length) {
@@ -1363,11 +1396,28 @@ export function App() {
       // No member terminals — spawn one at the project root. Mark
       // the focus session as auto-spawned BEFORE the state update so
       // the next render (with the new tab in `tabs`) doesn't re-fire.
-      autoSpawnedForRef.current = focusedProject
-      if (lastTabKind === 'claude') {
-        openClaudeIn(focusedProject)
-      } else {
-        openTerminalHere(focusedProject)
+      //
+      // Race guard: `terminalMembership` is computed from async
+      // git/marker probes, so in the probe-pending window right after a
+      // focus click `visibleTerminals` is transiently empty even when an
+      // existing terminal's launch cwd sits under the focused root.
+      // Auto-spawning here would strand the user with a spurious new
+      // terminal while their real one becomes visible-but-inactive a
+      // beat later. Suppress the spawn while any open terminal's cwd is
+      // under the focused root — once membership resolves, the
+      // switch-to-first-visible branch above focuses it. Only spawn when
+      // there's genuinely no terminal under the root (e.g. focusing a
+      // project that has only working tabs open).
+      const hasTerminalUnderRoot = tabs.some(
+        (t) => t.cwd === focusedProject || t.cwd.startsWith(focusedProject + '/')
+      )
+      if (!hasTerminalUnderRoot) {
+        autoSpawnedForRef.current = focusedProject
+        if (lastTabKind === 'claude') {
+          openClaudeIn(focusedProject)
+        } else {
+          openTerminalHere(focusedProject)
+        }
       }
     }
     if (

--- a/renderer/components/WorkingPane.tsx
+++ b/renderer/components/WorkingPane.tsx
@@ -307,7 +307,18 @@ export function WorkingPane({
   // Plus onPageFocusGained gets its own log when invoked. After owner
   // walks for 60s, grep [ENH-084-v4] in /tmp/duo-dev-*.log to read the
   // event stream + decide which signal source is the right driver.
+  //
+  // BUG-167 (folded into ENH-182) — opt-in flag. This pass was filed as
+  // "INSTRUMENTATION ONLY" but never re-gated, so it shipped to release
+  // builds and floods the console on every focusin/mousedown/blur. Now
+  // gated behind `localStorage.duo.debug.focus === '1'` (read once on
+  // mount). Silent in release; if the subpane-focus work resumes, set
+  // the flag in DevTools and reload to re-arm the stream. Deliberate
+  // asymmetry: developer-only, no `duo` verb (not a product surface).
   useEffect(() => {
+    let focusDebug = false
+    try { focusDebug = localStorage.getItem('duo.debug.focus') === '1' } catch { /* storage disabled */ }
+    if (!focusDebug) return
     const subpaneOf = (target: EventTarget | null): 'main' | 'aux' | 'neither' => {
       if (!(target instanceof Node)) return 'neither'
       if (mainColRef.current?.contains(target)) return 'main'

--- a/renderer/hooks/pruneDeadPaths.test.ts
+++ b/renderer/hooks/pruneDeadPaths.test.ts
@@ -1,0 +1,93 @@
+// BUG-167 (folded into ENH-182) — pins the prune util's invariants so
+// the navigator's mount-time cleanup can't regress silently. The
+// load-bearing cases are (a) probe failure keeps the entry (no
+// speculative drops) and (b) ancestor walk stops at the fallback when
+// the whole chain is gone.
+
+import { describe, it, expect, vi } from 'vitest'
+import { findDeadExpandedPaths, nearestExistingAncestor } from './pruneDeadPaths'
+
+describe('findDeadExpandedPaths', () => {
+  it('returns paths whose probe resolved false', async () => {
+    const probe = vi.fn(async (p: string) =>
+      p === '/alive' || p === '/also-alive'
+    )
+    const dead = await findDeadExpandedPaths(
+      ['/alive', '/dead', '/also-alive', '/also-dead'],
+      probe
+    )
+    expect(dead.sort()).toEqual(['/also-dead', '/dead'])
+  })
+
+  it('keeps entries whose probe threw (transient IPC failure)', async () => {
+    // A throw must NOT be classified as dead — that would let a
+    // permission flake or socket hiccup wipe legit nav state.
+    const probe = vi.fn(async (p: string) => {
+      if (p === '/throws') throw new Error('boom')
+      return false
+    })
+    const dead = await findDeadExpandedPaths(['/throws', '/dead'], probe)
+    expect(dead).toEqual(['/dead'])
+  })
+
+  it('returns [] for an empty set without calling the probe', async () => {
+    const probe = vi.fn(async () => false)
+    expect(await findDeadExpandedPaths([], probe)).toEqual([])
+    expect(probe).not.toHaveBeenCalled()
+  })
+
+  it('probes in parallel (one Promise.all, not serial)', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const probe = vi.fn(async (_p: string) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise(r => setTimeout(r, 1))
+      inFlight--
+      return true
+    })
+    await findDeadExpandedPaths(['/a', '/b', '/c', '/d'], probe)
+    expect(maxInFlight).toBe(4)
+  })
+})
+
+describe('nearestExistingAncestor', () => {
+  it('returns the first ancestor whose probe resolves true', async () => {
+    const probe = async (p: string) => p === '/Users/x'
+    const out = await nearestExistingAncestor(
+      '/Users/x/dead-project/skills/setup-check-workspace',
+      probe,
+      '/'
+    )
+    expect(out).toBe('/Users/x')
+  })
+
+  it('returns the fallback when no ancestor exists below root', async () => {
+    const probe = async () => false
+    const out = await nearestExistingAncestor('/Users/x/gone', probe, '/fallback')
+    expect(out).toBe('/fallback')
+  })
+
+  it('keeps walking past a probe that threw', async () => {
+    // A thrown probe is "unknown", not "dead" — the loop continues
+    // upward rather than treating the throw as truth.
+    const probe = async (p: string) => {
+      if (p === '/Users/x/mid') throw new Error('eperm')
+      return p === '/Users/x'
+    }
+    const out = await nearestExistingAncestor(
+      '/Users/x/mid/gone',
+      probe,
+      '/'
+    )
+    expect(out).toBe('/Users/x')
+  })
+
+  it('stops at the root boundary even if probe never resolves true', async () => {
+    // Pathological case: the loop must terminate even when nothing
+    // qualifies. `/` is always assumed to exist via the fallback.
+    const probe = async () => false
+    const out = await nearestExistingAncestor('/a/b/c', probe, '/')
+    expect(out).toBe('/')
+  })
+})

--- a/renderer/hooks/pruneDeadPaths.ts
+++ b/renderer/hooks/pruneDeadPaths.ts
@@ -1,0 +1,60 @@
+// BUG-167 (folded into ENH-182) — proactive mount-time pruning of
+// persisted navigator state. The reactive ENOENT self-heal in
+// useNavigator only fires when the user navigates to or expands a dead
+// folder; this util runs once at startup and drops ghosts BEFORE the
+// user touches them, so the very first project switch is already quiet.
+//
+// Lives apart from the hooks so both `useNavigator` and
+// `useUserClaudeNavigator` share the same implementation — both replay
+// persisted `expanded` sets, both accumulated ghost entries from the
+// same pattern (a folder deleted between sessions). The util is also
+// unit-testable without mounting React.
+
+/** Probe one path for existence on disk. */
+export type DirExistsProbe = (path: string) => Promise<boolean>
+
+/** Probe every entry in `expanded`. Return the subset whose probe
+ *  resolved `false`. Entries whose probe THROWS (IPC unreachable,
+ *  permission flake) are intentionally NOT included — a probe failure
+ *  must never drop nav state speculatively. */
+export async function findDeadExpandedPaths(
+  expanded: Iterable<string>,
+  probe: DirExistsProbe
+): Promise<string[]> {
+  const paths = [...expanded]
+  if (paths.length === 0) return []
+  const checks = await Promise.all(
+    paths.map(async (p): Promise<readonly [string, boolean | null]> => {
+      try {
+        return [p, await probe(p)] as const
+      } catch {
+        return [p, null] as const
+      }
+    })
+  )
+  return checks.filter(([, ok]) => ok === false).map(([p]) => p)
+}
+
+/** Walk up from a dead path to the nearest ancestor that still exists.
+ *  Returns `fallback` if no ancestor below root qualifies. Used to
+ *  recover a missing persisted `cwd` to something the navigator can
+ *  actually render. `/` always exists so the loop terminates. */
+export async function nearestExistingAncestor(
+  deadPath: string,
+  probe: DirExistsProbe,
+  fallback: string
+): Promise<string> {
+  let cur = deadPath
+  while (cur.length > 1) {
+    const slash = cur.lastIndexOf('/')
+    const parent = slash > 0 ? cur.slice(0, slash) : '/'
+    if (parent === cur) break
+    cur = parent
+    try {
+      if (await probe(cur)) return cur
+    } catch {
+      /* probe failed — keep walking up */
+    }
+  }
+  return fallback
+}

--- a/renderer/hooks/useNavigator.ts
+++ b/renderer/hooks/useNavigator.ts
@@ -15,25 +15,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DirEntry } from '@shared/types'
-
-/** Walk up from a now-deleted directory to the nearest ancestor that
- *  still exists on disk. Returns '/' as the final fallback (root always
- *  exists). Used to re-root the navigator when its cwd points at a
- *  directory that was removed out from under it. */
-async function nearestExistingAncestor(deadPath: string): Promise<string> {
-  let cur = deadPath
-  while (true) {
-    const idx = cur.lastIndexOf('/')
-    const parent = idx > 0 ? cur.slice(0, idx) : '/'
-    if (parent === cur) return '/'
-    try {
-      if (await window.electron.files.dirExists(parent)) return parent
-    } catch {
-      /* probe failed — keep walking up */
-    }
-    cur = parent
-  }
-}
+import { findDeadExpandedPaths, nearestExistingAncestor } from './pruneDeadPaths'
 
 const LS_KEY_CWD = 'duo.nav.cwd'
 const LS_KEY_EXPANDED = 'duo.nav.expanded'
@@ -158,6 +140,48 @@ export function useNavigator(initialCwd: string) {
     })
   }, [])
 
+  // BUG-167 (folded into ENH-182) — mount-time prune of persisted
+  // navigator state. The reactive ENOENT heal above only fires when the
+  // user navigates to or expands a dead folder; this one-shot pass
+  // drops ghosts at startup, BEFORE the first project switch
+  // re-subscribes the watcher and triggers the spammy re-list. Same
+  // `dirExists` probe as the reactive heal — a probe failure leaves
+  // entries intact (transient flakes must not wipe state). Reads cwd /
+  // expanded / initialCwd from the mount-time closure so the effect is
+  // intentionally mount-only.
+  const prunedRef = useRef(false)
+  useEffect(() => {
+    if (prunedRef.current) return
+    prunedRef.current = true
+    let cancelled = false
+    const probe = window.electron?.files?.dirExists
+    if (!probe) return
+    void (async () => {
+      // Recover cwd first so the watcher's first subscription sees a
+      // live path. Fallback chain: nearest existing ancestor → initialCwd.
+      try {
+        if (!(await probe(cwd))) {
+          const recovered = await nearestExistingAncestor(cwd, probe, initialCwd)
+          if (!cancelled) setCwd(prev => (prev === cwd ? recovered : prev))
+        }
+      } catch { /* probe unreachable — leave cwd as-is */ }
+      const dead = await findDeadExpandedPaths(expanded, probe)
+      if (cancelled || dead.length === 0) return
+      setExpanded(prev => {
+        const next = new Set(prev)
+        for (const p of dead) next.delete(p)
+        return next
+      })
+      setListings(prev => {
+        const next = new Map(prev)
+        for (const p of dead) next.delete(p)
+        return next
+      })
+    })()
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // Shared helper that (lazily) fetches a directory listing and caches it.
   const ensureListing = useCallback((path: string) => {
     setListings(prev => {
@@ -210,7 +234,11 @@ export function useNavigator(initialCwd: string) {
           })
           setPrimaryPath(prev => (prev === path ? null : prev))
           if (cwdRef.current === path) {
-            void nearestExistingAncestor(path).then(fallback => {
+            void nearestExistingAncestor(
+              path,
+              p => window.electron.files.dirExists(p),
+              '/'
+            ).then(fallback => {
               setCwd(prev => (prev === path ? fallback : prev))
             })
           }

--- a/renderer/hooks/useNavigator.ts
+++ b/renderer/hooks/useNavigator.ts
@@ -13,8 +13,27 @@
 // Persistence: Phase 4 uses localStorage for a quick seed across reloads.
 // Phase 7 replaces this with the main-process state.json persistence.
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DirEntry } from '@shared/types'
+
+/** Walk up from a now-deleted directory to the nearest ancestor that
+ *  still exists on disk. Returns '/' as the final fallback (root always
+ *  exists). Used to re-root the navigator when its cwd points at a
+ *  directory that was removed out from under it. */
+async function nearestExistingAncestor(deadPath: string): Promise<string> {
+  let cur = deadPath
+  while (true) {
+    const idx = cur.lastIndexOf('/')
+    const parent = idx > 0 ? cur.slice(0, idx) : '/'
+    if (parent === cur) return '/'
+    try {
+      if (await window.electron.files.dirExists(parent)) return parent
+    } catch {
+      /* probe failed — keep walking up */
+    }
+    cur = parent
+  }
+}
 
 const LS_KEY_CWD = 'duo.nav.cwd'
 const LS_KEY_EXPANDED = 'duo.nav.expanded'
@@ -105,10 +124,15 @@ export function useNavigator(initialCwd: string) {
     try { return localStorage.getItem(LS_KEY_SHOW_DOTFILES) === '1' } catch { return false }
   })
   const [listings, setListings] = useState<NavigatorState['listings']>(() => new Map())
+  // Latest cwd, readable from the stable `ensureListing` callback (whose
+  // deps are []). Lets the ENOENT self-heal decide whether the dead path
+  // is the current cwd without re-creating the callback every navigation.
+  const cwdRef = useRef(cwd)
 
   // Persist whenever relevant state changes. Debounce is minimal because
   // these are tiny writes.
   useEffect(() => {
+    cwdRef.current = cwd
     try { localStorage.setItem(LS_KEY_CWD, cwd) } catch { /* storage full or disabled */ }
   }, [cwd])
   useEffect(() => {
@@ -157,6 +181,40 @@ export function useNavigator(initialCwd: string) {
           next.set(path, []) // treat errors as empty; UI can surface later
           return next
         })
+        // Self-heal stale references to a deleted directory. A removed
+        // dir keeps firing ENOENT on every watch-resubscribe — once per
+        // project switch — which is the console spam users see. Confirm
+        // the dir is genuinely gone (a transient/permission error must
+        // NOT drop nav state), then prune it from expanded + the listing
+        // cache + selection so it stops being re-listed. If the dead dir
+        // is the current cwd, re-root to the nearest surviving ancestor.
+        void window.electron.files.dirExists(path).then(exists => {
+          if (exists) return
+          setExpanded(prev => {
+            if (!prev.has(path)) return prev
+            const next = new Set(prev)
+            next.delete(path)
+            return next
+          })
+          setListings(prev => {
+            if (!prev.has(path)) return prev
+            const next = new Map(prev)
+            next.delete(path)
+            return next
+          })
+          setSelectedItems(prev => {
+            if (!prev.has(path)) return prev
+            const next = new Map(prev)
+            next.delete(path)
+            return next
+          })
+          setPrimaryPath(prev => (prev === path ? null : prev))
+          if (cwdRef.current === path) {
+            void nearestExistingAncestor(path).then(fallback => {
+              setCwd(prev => (prev === path ? fallback : prev))
+            })
+          }
+        }).catch(() => { /* probe unreachable — leave nav state intact */ })
       }
     )
   }, [])

--- a/renderer/hooks/useProjects.ts
+++ b/renderer/hooks/useProjects.ts
@@ -83,9 +83,15 @@ export function useProjects(args: UseProjectsArgs): UseProjectsResult {
   // mid-probe don't lose entries.
   const [gitResults, setGitResults] = useState<Map<string, GitProbeResult>>(() => new Map())
   const [markerResults, setMarkerResults] = useState<Map<string, boolean>>(() => new Map())
+  // Ghost-pin fix — existence probe results for pinned roots only.
+  // `deriveProjects` drops a pinned root whose folder was deleted
+  // (exists === false); a markerless-but-existing pin still renders
+  // (D12 "pin alone qualifies").
+  const [pinnedExists, setPinnedExists] = useState<Map<string, boolean>>(() => new Map())
   // Track which probes are in-flight per probe-kind to avoid double-probing.
   const gitInFlightRef = useRef<Set<string>>(new Set())
   const markerInFlightRef = useRef<Set<string>>(new Set())
+  const pinnedExistsInFlightRef = useRef<Set<string>>(new Set())
 
   // ── Async probe phase ──────────────────────────────────────────
   //
@@ -166,6 +172,41 @@ export function useProjects(args: UseProjectsArgs): UseProjectsResult {
     }
   }, [terminals, workingTabs, pinnedTabPaths, pinnedProjects, gitResults, markerResults])
 
+  // ── Pinned-root existence probe (ghost-pin fix) ─────────────────
+  //
+  // Only pinned roots can be ghosts: every non-pinned project has a
+  // live terminal/tab cwd under it, so the folder provably exists.
+  // Like the git/marker caches above, we never invalidate — a pin
+  // deleted mid-session drops on the next relaunch (matches this
+  // hook's documented caching contract; the owner can restart).
+  useEffect(() => {
+    const unprobed = [...pinnedProjects].filter(
+      (d) => !pinnedExists.has(d) && !pinnedExistsInFlightRef.current.has(d)
+    )
+    if (unprobed.length === 0) return
+    for (const d of unprobed) pinnedExistsInFlightRef.current.add(d)
+    void Promise.all(
+      unprobed.map(async (dir) => {
+        try {
+          return [dir, await window.electron.files.dirExists(dir)] as const
+        } catch {
+          // Probe unreachable — assume the folder exists so a transient
+          // IPC error never drops a pin.
+          return [dir, true] as const
+        }
+      })
+    ).then((entries) => {
+      setPinnedExists((prev) => {
+        const next = new Map(prev)
+        for (const [k, v] of entries) {
+          next.set(k, v)
+          pinnedExistsInFlightRef.current.delete(k)
+        }
+        return next
+      })
+    })
+  }, [pinnedProjects, pinnedExists])
+
   // ── Pure derivation ────────────────────────────────────────────
   const result = useMemo<DeriveProjectsOutput>(() => {
     return deriveProjects({
@@ -181,10 +222,13 @@ export function useProjects(args: UseProjectsArgs): UseProjectsResult {
         const git = gitResults.get(dir)
         const isGitRoot = !!(git?.isRepo && git.workTreeRoot === dir)
         const hasMarker = markerResults.get(dir) === true
-        return { isGitRoot, hasMarker }
+        // `exists` is only meaningful for pinned roots; undefined for
+        // everything else (deriveProjects only consults it for pins).
+        const exists = pinnedExists.has(dir) ? pinnedExists.get(dir) : undefined
+        return { isGitRoot, hasMarker, exists }
       }
     })
-  }, [terminals, workingTabs, pinnedTabPaths, pinnedProjects, colorOverrides, gitResults, markerResults])
+  }, [terminals, workingTabs, pinnedTabPaths, pinnedProjects, colorOverrides, gitResults, markerResults, pinnedExists])
 
   return result
 }

--- a/renderer/hooks/useUserClaudeNavigator.ts
+++ b/renderer/hooks/useUserClaudeNavigator.ts
@@ -19,9 +19,10 @@
 // so the tree can present a small hand-picked top level on top of
 // otherwise-normal expand-on-click behavior.
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DirEntry, FileChangeEvent } from '@shared/types'
 import type { NavigatorState, NavigatorActions } from './useNavigator'
+import { findDeadExpandedPaths } from './pruneDeadPaths'
 
 const LS_KEY_SHOW_ALL = 'duo.userClaude.showAll'
 const LS_KEY_EXPANDED = 'duo.userClaude.expanded'
@@ -97,6 +98,38 @@ export function useUserClaudeNavigator(home: string): UserClaudeNavigatorApi {
         })
       }
     )
+  }, [])
+
+  // BUG-167 (folded into ENH-182) — mount-time prune of persisted
+  // `expanded` paths. Root is fixed at ~/.claude so there's no cwd to
+  // recover, but a persisted entry like `skills/<gone>` /
+  // `agents/<gone>` (workspace deleted between sessions) still gets
+  // re-listed on every re-subscribe and floods the console with ENOENT
+  // until the user happens to collapse it. One-shot probe at startup
+  // drops the dead ones; a probe failure leaves entries intact.
+  const prunedRef = useRef(false)
+  useEffect(() => {
+    if (prunedRef.current) return
+    prunedRef.current = true
+    let cancelled = false
+    const probe = window.electron?.files?.dirExists
+    if (!probe || expanded.size === 0) return
+    void (async () => {
+      const dead = await findDeadExpandedPaths(expanded, probe)
+      if (cancelled || dead.length === 0) return
+      setExpanded(prev => {
+        const next = new Set(prev)
+        for (const p of dead) next.delete(p)
+        return next
+      })
+      setListings(prev => {
+        const next = new Map(prev)
+        for (const p of dead) next.delete(p)
+        return next
+      })
+    })()
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Always load the user-claude root + any expanded children.

--- a/shared/projects.ts
+++ b/shared/projects.ts
@@ -141,6 +141,13 @@ export function deepestEnclosingRoot(
 export interface QualificationResult {
   isGitRoot: boolean
   hasMarker: boolean
+  /** Whether the directory still exists on disk. Only consulted for
+   *  pinned roots: a pin is its own qualification (D12 — "pin alone
+   *  qualifies"), so a markerless-but-existing pinned folder still
+   *  renders. But a pin whose folder was DELETED is a ghost tile and is
+   *  dropped. `undefined` (probe pending / orchestrator doesn't supply
+   *  it) is treated as "exists" so we never drop a pin speculatively. */
+  exists?: boolean
 }
 
 export interface DeriveProjectsInput {
@@ -225,7 +232,13 @@ export function deriveProjects(input: DeriveProjectsInput): DeriveProjectsOutput
     considerAncestors(dirname(tab.path))
   }
   for (const pinned of pinnedProjects) {
-    probe(pinned)
+    const q = probe(pinned)
+    // D12 — a pinned root is its own qualification (the user asserted
+    // this folder is a project even if markers came and went). The one
+    // exception: a pin whose directory was DELETED is a ghost. Drop it
+    // once an existence probe confirms the dir is gone. `exists ===
+    // undefined` (probe pending / not wired) keeps the pin.
+    if (q.exists === false) continue
     qualifyingSet.add(pinned)
   }
 
@@ -250,7 +263,12 @@ export function deriveProjects(input: DeriveProjectsInput): DeriveProjectsOutput
   for (const root of Object.values(tabMembership)) {
     if (root) projectRoots.add(root)
   }
-  for (const root of pinnedProjects) projectRoots.add(root)
+  for (const root of pinnedProjects) {
+    // Mirror the ghost-pin drop from step 2: a deleted pinned folder
+    // never becomes a rendered project.
+    if (probe(root).exists === false) continue
+    projectRoots.add(root)
+  }
 
   // ── Step 5 — build Project objects ──
   const projects: Project[] = [...projectRoots].map((root) => {

--- a/tasks.md
+++ b/tasks.md
@@ -46,6 +46,28 @@
 
 ---
 
+### BUG-167: Navigator ENOENT spam from ghost folders + console-flooding focus instrumentation
+
+**Status:** 🟡 **Fix folded into PR #59 (ENH-182 polish epilogue) 2026-05-28.** **Priority:** Medium (console noise + perceived instability; functionally benign). **Effort:** ~1h.
+
+**Symptom.** Switching between projects in v0.8.2 floods the renderer console with two error classes: repeated `[nav] list failed for …/skills/setup-check-workspace — Error invoking remote method 'files:list': ENOENT`, and per-interaction `[ENH-084-v4] … focusin/mousedown/blur` logs. Both read like instability; both are benign.
+
+**Root cause (nav ENOENT).** `useNavigator` persists every folder ever expanded to `localStorage` (`duo.nav.expanded`) and never prunes it; the persisted `cwd` is restored with no existence check. The watcher effect depends on `[cwd, expanded]`, so each project switch re-subscribes and re-lists the entire expanded set. Any folder deleted/moved since — e.g. a transient skill workspace like `setup-check-workspace` — throws ENOENT on every navigation. Same pattern in `useUserClaudeNavigator`. PR #59's reactive heal cures the spam once the user navigates to the dead folder; this fold-in adds a **proactive mount-time prune** so the ghosts are gone *before* the first project switch.
+
+**Root cause (`[ENH-084-v4]`).** `WorkingPane.tsx` installs document-wide `focusin` / `mousedown` / `blur` listeners that `console.log` on every event — a Sprint 17 "INSTRUMENTATION ONLY" data-capture pass that was never re-gated, so it ships in release builds.
+
+**Fix.** Extracted shared util `renderer/hooks/pruneDeadPaths.ts` (`findDeadExpandedPaths` + `nearestExistingAncestor`, both probe-driven so a transient IPC failure leaves entries intact). Wired into:
+- **`useNavigator`** — mount-time effect that recovers a missing persisted cwd to the nearest existing ancestor (else `initialCwd`) and drops dead `expanded` entries. Composes with PR #59's reactive heal: prune at startup, heal on first failure mid-session.
+- **`useUserClaudeNavigator`** — same prune (no cwd to recover; root is fixed at `~/.claude`).
+- **`WorkingPane.tsx`** — focus instrumentation gated behind opt-in `localStorage.duo.debug.focus === '1'` (read once on mount). Silent in release; recoverable if the subpane-focus work resumes. Deliberate asymmetry: developer-only, no `duo` verb (not a product surface).
+- Replaced the inline `nearestExistingAncestor` in PR #59 with a call to the shared util so the reactive and proactive paths can't drift.
+
+**Tests.** `renderer/hooks/pruneDeadPaths.test.ts` — 8 cases pinning the invariants: dead paths returned, probe failures kept (no speculative drops), empty set short-circuits, parallel probing, ancestor walk recovers + stops at fallback + survives a thrown probe.
+
+**Cross-ref:** ENH-084 (the focus-glow defect whose v4 instrumentation this gates), BUG-039 (the `files.exists` probe pattern reused here for session-restore tab pruning), ENH-182 (project navigation, the surface this fires on). **Closed PR #63** filed the same bug independently (different shape: ENOENT string-match classifier + duplicated mount-prune in both hooks). Closed in favor of this fold-in.
+
+---
+
 ### ENH-188: Terminal-tab context menu — parity with canvas tabs (reorder + close + copy cwd)
 
 **Status:** 🆕 **Filed + implemented 2026-05-27** (branch `claude/terminal-tabs-context-parity-2lh2X`). **Priority:** Medium (daily-driver ergonomics; the headline gap is "can't reorder terminal tabs"). **Effort:** ~1.5h.


### PR DESCRIPTION
## Summary

Reported symptoms while switching between projects: repeated `[nav] list failed … ENOENT` console errors, project tiles relating to tabs that are no longer open, and a tile click failing to focus an open terminal in scope. All three trace to **Duo holding references to a directory that no longer exists on disk** (the screenshot's `…/skills/setup-check-workspace` was deleted, but terminals / nav-state / pins still pointed at it).

Four targeted fixes:

- **Stop ENOENT spam + self-heal nav** (`useNavigator.ts`) — when `files.list` fails, confirm via `dirExists` that the dir is genuinely gone (so a transient/permission error never drops state), then prune it from `expanded` / `listings` / selection so it stops being re-listed on every watch-resubscribe. If the dead dir is the current cwd, re-root to the nearest surviving ancestor.
- **Heal dead-cwd terminals on restore** (`App.tsx`) — session restore now falls a terminal's launch cwd back to the nearest existing ancestor (or home) when the original was deleted, mirroring the BUG-039 file-tab pattern. Stops PTY ENOENT spawns and ghost rail tiles.
- **Drop ghost pinned-project tiles** (`shared/projects.ts` + `useProjects.ts`) — a pin whose folder still **exists** is kept (preserving the locked "pin alone qualifies" rule, `projects-service.test.ts:286`); a pin whose folder was **deleted** is dropped, via a new existence probe scoped to pinned roots. `exists === undefined` (probe pending) keeps the pin, so valid pins never flicker.
- **Fix click→auto-spawn race** (`App.tsx`) — `terminalMembership` is computed from async git/marker probes, so right after a focus click `visibleTerminals` is transiently empty even when an in-scope terminal exists. Auto-spawn now suppresses while any open terminal's cwd is under the focused root, letting membership resolve and the existing terminal get focused instead of stranding the user with a spurious new one.

### Editor/canvas parity disposition
N/A — no editor/canvas surface changes (navigator, project rail, session-restore, and pure derivation only).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 790/790 pass, incl. 3 new ghost-pin derivation tests (`projects-service.test.ts`)
- [ ] **Manual walk required** — I could not verify render state from the cloud container (no Electron/display; `duo doctor` shows the socket unreachable here). Owner to confirm in a running session:
  - [ ] With a terminal whose launch dir was deleted, switching projects no longer spams `[nav] list failed … ENOENT`; the navigator re-roots up instead of sitting on the dead dir.
  - [ ] Relaunch with such a terminal restored → it comes back at the nearest surviving ancestor, no ghost tile.
  - [ ] A pinned project whose folder was deleted no longer renders after relaunch; a pinned **existing** markerless folder still renders.
  - [ ] Clicking a project tile focuses the existing in-scope terminal rather than spawning a new empty one; auto-spawn still fires for a project that has only working tabs open.

https://claude.ai/code/session_01JPXmfwMJezQAHCeB1Akzn1

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPXmfwMJezQAHCeB1Akzn1)_