### PR TITLE
feat(ENH-188): terminal-tab context menu parity with canvas tabs

### DIFF
--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -36,6 +36,7 @@ import { htmlBoilerplate } from './components/Page/htmlBoilerplate'
 import { encodeUtf8 } from './components/editor/markdown-io'
 import { findVaultRoot, resolveWikilinkInVault } from './components/editor/wikilinkResolver'
 import type { TabSession, DirEntry, TerminalTabKind, NewTabResult, PinEntry, SessionState, BrowserTab, ActiveWorkspace } from '@shared/types'
+import { reorderVisible } from '@shared/reorderTabs'
 
 // Stage 10 § D32: auto-collapse the Files column on windows narrower than
 // this. The user can manually re-expand; we don't re-collapse again unless
@@ -1559,41 +1560,23 @@ export function App() {
     })
   }, [activeTabId])
 
-  // ENH-187 — reorder terminal tabs (drag + move-left/right menu).
+  // ENH-188 — reorder terminal tabs (drag + move-left/right menu).
   // Mirrors WorkingPane's `reorderTab` insert-before/after semantics but
   // operates directly on the `tabs` array (no pinned zones, no separate
   // order state — array order IS the strip order, and it persists for
   // free via workspace-save). Both ids are members of the VISIBLE strip
   // (TabBar only ever hands us visible-tab ids). Under ENH-182 project
-  // focus the strip is a subset, so we reorder within the visible
-  // subsequence and rebuild the full array in place — hidden tabs keep
-  // their absolute slots, so a reorder while focused never disturbs
-  // other projects' tab order.
+  // focus the strip is a subset, so `reorderVisible` reorders within the
+  // visible subsequence and rebuilds in place — hidden tabs keep their
+  // absolute slots, so a reorder while focused never disturbs another
+  // project's tab order. The transform (+ its hidden-slot invariant) is
+  // unit-tested in `shared/reorderTabs.test.ts`.
   const reorderTerminalTab = useCallback((sourceId: string, targetId: string) => {
-    if (sourceId === targetId) return
-    setTabs(prev => {
-      const isVisible = (t: TabSession) =>
-        focusedProject === null || terminalMembership[t.id] === focusedProject
-      const visible = prev.filter(isVisible)
-      const srcIdx = visible.findIndex(t => t.id === sourceId)
-      const tgtIdx = visible.findIndex(t => t.id === targetId)
-      if (srcIdx < 0 || tgtIdx < 0) return prev
-      const without = visible.filter(t => t.id !== sourceId)
-      const newTgtIdx = without.findIndex(t => t.id === targetId)
-      if (newTgtIdx < 0) return prev
-      // Drag-rightward (source was left of target) → insert AFTER target;
-      // drag-leftward → insert BEFORE. Matches WorkingPane.reorderTab.
-      const insertAt = srcIdx < tgtIdx ? newTgtIdx + 1 : newTgtIdx
-      const newVisible = [...without.slice(0, insertAt), visible[srcIdx], ...without.slice(insertAt)]
-      // Re-thread the reordered visible tabs back into the slots the
-      // visible tabs originally occupied; hidden tabs pass through.
-      const visibleIds = new Set(visible.map(t => t.id))
-      let vi = 0
-      return prev.map(t => (visibleIds.has(t.id) ? newVisible[vi++] : t))
-    })
+    setTabs(prev => reorderVisible(prev, sourceId, targetId, (t) =>
+      focusedProject === null || terminalMembership[t.id] === focusedProject))
   }, [focusedProject, terminalMembership])
 
-  // ENH-187 — "Close other tabs" context-menu verb. Closes every VISIBLE
+  // ENH-188 — "Close other tabs" context-menu verb. Closes every VISIBLE
   // terminal tab except the kept one (under project focus, other
   // projects' tabs are untouched). Each closed tab is pushed onto the
   // ENH-179 closed-tab ring so ⌘Z restores them (re-spawns at the same
@@ -4037,7 +4020,7 @@ export function App() {
                     nav.actions.navigateTo(cwd)
                     setRevealChip(cwd)
                   }}
-                  // ENH-187 — terminal-tab reorder (drag + move-left/right
+                  // ENH-188 — terminal-tab reorder (drag + move-left/right
                   // menu) and "Close other tabs", parity with canvas tabs.
                   onReorderTab={reorderTerminalTab}
                   onCloseOthers={closeOtherTabs}

--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -1559,6 +1559,62 @@ export function App() {
     })
   }, [activeTabId])
 
+  // ENH-187 — reorder terminal tabs (drag + move-left/right menu).
+  // Mirrors WorkingPane's `reorderTab` insert-before/after semantics but
+  // operates directly on the `tabs` array (no pinned zones, no separate
+  // order state — array order IS the strip order, and it persists for
+  // free via workspace-save). Both ids are members of the VISIBLE strip
+  // (TabBar only ever hands us visible-tab ids). Under ENH-182 project
+  // focus the strip is a subset, so we reorder within the visible
+  // subsequence and rebuild the full array in place — hidden tabs keep
+  // their absolute slots, so a reorder while focused never disturbs
+  // other projects' tab order.
+  const reorderTerminalTab = useCallback((sourceId: string, targetId: string) => {
+    if (sourceId === targetId) return
+    setTabs(prev => {
+      const isVisible = (t: TabSession) =>
+        focusedProject === null || terminalMembership[t.id] === focusedProject
+      const visible = prev.filter(isVisible)
+      const srcIdx = visible.findIndex(t => t.id === sourceId)
+      const tgtIdx = visible.findIndex(t => t.id === targetId)
+      if (srcIdx < 0 || tgtIdx < 0) return prev
+      const without = visible.filter(t => t.id !== sourceId)
+      const newTgtIdx = without.findIndex(t => t.id === targetId)
+      if (newTgtIdx < 0) return prev
+      // Drag-rightward (source was left of target) → insert AFTER target;
+      // drag-leftward → insert BEFORE. Matches WorkingPane.reorderTab.
+      const insertAt = srcIdx < tgtIdx ? newTgtIdx + 1 : newTgtIdx
+      const newVisible = [...without.slice(0, insertAt), visible[srcIdx], ...without.slice(insertAt)]
+      // Re-thread the reordered visible tabs back into the slots the
+      // visible tabs originally occupied; hidden tabs pass through.
+      const visibleIds = new Set(visible.map(t => t.id))
+      let vi = 0
+      return prev.map(t => (visibleIds.has(t.id) ? newVisible[vi++] : t))
+    })
+  }, [focusedProject, terminalMembership])
+
+  // ENH-187 — "Close other tabs" context-menu verb. Closes every VISIBLE
+  // terminal tab except the kept one (under project focus, other
+  // projects' tabs are untouched). Each closed tab is pushed onto the
+  // ENH-179 closed-tab ring so ⌘Z restores them (re-spawns at the same
+  // cwd/kind — PTY state isn't preserved, matching single-tab close).
+  const closeOtherTabs = useCallback((keepId: string) => {
+    setTabs(prev => {
+      const isVisible = (t: TabSession) =>
+        focusedProject === null || terminalMembership[t.id] === focusedProject
+      const toClose = prev.filter(t => isVisible(t) && t.id !== keepId)
+      if (toClose.length === 0) return prev
+      const closeIds = new Set(toClose.map(t => t.id))
+      const ring = closedTabsRef.current
+      for (const closed of toClose) {
+        ring.push({ kind: 'terminal', cwd: closed.cwd, ptyKind: closed.kind, closedAt: Date.now() })
+        if (ring.length > CLOSED_TABS_MAX) ring.shift()
+      }
+      return prev.filter(t => !closeIds.has(t.id))
+    })
+    setActiveTabId(keepId)
+  }, [focusedProject, terminalMembership])
+
   const updateTabTitle = useCallback((id: string, title: string) => {
     setTabs(prev => prev.map(t => t.id === id ? { ...t, title } : t))
   }, [])
@@ -3981,6 +4037,10 @@ export function App() {
                     nav.actions.navigateTo(cwd)
                     setRevealChip(cwd)
                   }}
+                  // ENH-187 — terminal-tab reorder (drag + move-left/right
+                  // menu) and "Close other tabs", parity with canvas tabs.
+                  onReorderTab={reorderTerminalTab}
+                  onCloseOthers={closeOtherTabs}
                 />
                 <div className="flex-1 overflow-hidden">
                   <TerminalPane

--- a/renderer/components/TabBar.tsx
+++ b/renderer/components/TabBar.tsx
@@ -28,12 +28,12 @@ interface TabBarProps {
    *  tab fires this with the tab's `cwd`. Parent points the navigator
    *  at the path (same code path as the CLI's `duo reveal`). */
   onRevealCwd?: (cwd: string) => void
-  /** ENH-187 — reorder terminal tabs (move-left/right menu + HTML5
+  /** ENH-188 — reorder terminal tabs (move-left/right menu + HTML5
    *  drag-and-drop). Both ids are members of the visible strip; the
    *  parent reorders the underlying `tabs` array. Mirrors
    *  WorkingTabStrip's `onReorderTab`. */
   onReorderTab?: (sourceId: string, targetId: string) => void
-  /** ENH-187 — right-click → "Close other tabs": close every visible
+  /** ENH-188 — right-click → "Close other tabs": close every visible
    *  terminal tab except the right-clicked one. */
   onCloseOthers?: (id: string) => void
 }
@@ -69,12 +69,12 @@ export function TabBar({
   onReorderTab,
   onCloseOthers
 }: TabBarProps) {
-  // ENH-187 — drag-reorder visual state. The hovered tab paints an
+  // ENH-188 — drag-reorder visual state. The hovered tab paints an
   // accent insertion cue while a drag is in flight; cleared on drop /
   // dragend. Mirrors WorkingTabStrip's dropTargetId.
   const [dropTargetId, setDropTargetId] = useState<string | null>(null)
 
-  // ENH-187 — move a tab one slot left/right within the visible strip.
+  // ENH-188 — move a tab one slot left/right within the visible strip.
   // `tabs` here is already the visible (project-filtered) set, so its
   // index order IS the strip order. Mirrors WorkingTabStrip.moveTabBy
   // minus the pinned-zone logic (terminals don't pin).
@@ -124,7 +124,7 @@ export function TabBar({
             // ENH-024 — only the active tab gets the ref; previous
             // active tab loses the assignment naturally on re-render.
             buttonRef={tab.id === activeTabId ? activeTabRef : undefined}
-            // ENH-187 — reorder context: position within the visible
+            // ENH-188 — reorder context: position within the visible
             // strip gates the move-left/right items; the bound mover +
             // close-others wire the menu actions.
             index={index}
@@ -132,7 +132,7 @@ export function TabBar({
             canReorder={!!onReorderTab}
             onMoveTab={(delta) => moveTabBy(tab.id, delta)}
             onCloseOthers={onCloseOthers ? () => onCloseOthers(tab.id) : undefined}
-            // ENH-187 — HTML5 drag-and-drop reorder. Distinct mime from
+            // ENH-188 — HTML5 drag-and-drop reorder. Distinct mime from
             // the canvas strip so terminal/canvas drags never cross.
             isDropTarget={dropTargetId === tab.id}
             onDragStart={onReorderTab ? (e) => {
@@ -222,7 +222,7 @@ interface TabProps {
   tab: TabSession
   isActive: boolean
   onSelect: () => void
-  /** ENH-187 — close this tab (menu "Close tab" + the × button). */
+  /** ENH-188 — close this tab (menu "Close tab" + the × button). */
   onCloseSelf: () => void
   canClose: boolean
   /** ENH-024 — passed by the parent on the active tab so it can
@@ -230,16 +230,16 @@ interface TabProps {
   buttonRef?: React.Ref<HTMLButtonElement>
   /** ENH-115 — right-click → Reveal in navigator. */
   onRevealCwd?: (cwd: string) => void
-  /** ENH-187 — position within the visible strip; gates move-left/right. */
+  /** ENH-188 — position within the visible strip; gates move-left/right. */
   index: number
   total: number
-  /** ENH-187 — whether reorder is wired (drag + move items). */
+  /** ENH-188 — whether reorder is wired (drag + move items). */
   canReorder: boolean
-  /** ENH-187 — move this tab one slot left (-1) / right (1). */
+  /** ENH-188 — move this tab one slot left (-1) / right (1). */
   onMoveTab: (delta: -1 | 1) => void
-  /** ENH-187 — "Close other tabs" (undefined hides the item). */
+  /** ENH-188 — "Close other tabs" (undefined hides the item). */
   onCloseOthers?: () => void
-  /** ENH-187 — drag-reorder wiring. Undefined handlers ⇒ non-draggable. */
+  /** ENH-188 — drag-reorder wiring. Undefined handlers ⇒ non-draggable. */
   isDropTarget?: boolean
   onDragStart?: (e: React.DragEvent) => void
   onDragOver?: (e: React.DragEvent) => void
@@ -253,7 +253,7 @@ function Tab({
   index, total, canReorder, onMoveTab, onCloseOthers,
   isDropTarget, onDragStart, onDragOver, onDragLeave, onDrop, onDragEnd
 }: TabProps) {
-  // ENH-187 — right-click → native context menu, approaching parity
+  // ENH-188 — right-click → native context menu, approaching parity
   // with the canvas-tab menu (WorkingTabStrip). Items are grouped:
   // reveal / copy-cwd, then move-left/right, then close verbs — each
   // group separated by a rule (same builder shape as the canvas side).
@@ -317,7 +317,7 @@ function Tab({
       aria-selected={isActive}
       onClick={onClick}
       onContextMenu={onContextMenu}
-      // ENH-187 — HTML5 drag-reorder. Draggable only when the parent
+      // ENH-188 — HTML5 drag-reorder. Draggable only when the parent
       // wired reorder handlers.
       draggable={canReorder}
       onDragStart={onDragStart}
@@ -333,7 +333,7 @@ function Tab({
           // at the top renders as an absolute child below.
           ? 'bg-surface-0 text-ink shadow-[inset_0_1px_0_var(--duo-paper-rule),inset_1px_0_var(--duo-paper-rule),inset_-1px_0_var(--duo-paper-rule)] font-serif italic text-[13px] font-medium'
           : 'text-ink-mute hover:text-ink-soft hover:bg-surface-3 text-xs',
-        // ENH-187 — drop-target insertion cue. Same accent ring the
+        // ENH-188 — drop-target insertion cue. Same accent ring the
         // canvas strip (WorkingTabItem) uses for its drag affordance.
         isDropTarget ? 'ring-2 ring-accent ring-inset' : ''
       ].join(' ')}

--- a/renderer/components/TabBar.tsx
+++ b/renderer/components/TabBar.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react'
-import type { TabSession } from '@shared/types'
+import { useEffect, useRef, useState } from 'react'
+import type { MenuTemplateItem, TabSession } from '@shared/types'
 
 interface TabBarProps {
   tabs: TabSession[]
@@ -28,6 +28,14 @@ interface TabBarProps {
    *  tab fires this with the tab's `cwd`. Parent points the navigator
    *  at the path (same code path as the CLI's `duo reveal`). */
   onRevealCwd?: (cwd: string) => void
+  /** ENH-187 — reorder terminal tabs (move-left/right menu + HTML5
+   *  drag-and-drop). Both ids are members of the visible strip; the
+   *  parent reorders the underlying `tabs` array. Mirrors
+   *  WorkingTabStrip's `onReorderTab`. */
+  onReorderTab?: (sourceId: string, targetId: string) => void
+  /** ENH-187 — right-click → "Close other tabs": close every visible
+   *  terminal tab except the right-clicked one. */
+  onCloseOthers?: (id: string) => void
 }
 
 // Stage 12 Phase 3 — tab-strip rhyme.
@@ -57,8 +65,28 @@ export function TabBar({
   focused = false,
   isTerminalCollapsed = false,
   onToggleTerminalCollapsed,
-  onRevealCwd
+  onRevealCwd,
+  onReorderTab,
+  onCloseOthers
 }: TabBarProps) {
+  // ENH-187 — drag-reorder visual state. The hovered tab paints an
+  // accent insertion cue while a drag is in flight; cleared on drop /
+  // dragend. Mirrors WorkingTabStrip's dropTargetId.
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null)
+
+  // ENH-187 — move a tab one slot left/right within the visible strip.
+  // `tabs` here is already the visible (project-filtered) set, so its
+  // index order IS the strip order. Mirrors WorkingTabStrip.moveTabBy
+  // minus the pinned-zone logic (terminals don't pin).
+  const moveTabBy = (id: string, delta: -1 | 1) => {
+    if (!onReorderTab) return
+    const idx = tabs.findIndex(t => t.id === id)
+    if (idx < 0) return
+    const targetIdx = idx + delta
+    if (targetIdx < 0 || targetIdx >= tabs.length) return
+    onReorderTab(id, tabs[targetIdx].id)
+  }
+
   const cwdSuffix = pendingCwd ? ` in ${pendingCwd}` : ''
   const claudeTip = `New Claude session (⌘T from terminal focus)${cwdSuffix}`
   const shellTip = `New shell tab (⌘⇧T)${cwdSuffix}`
@@ -84,21 +112,47 @@ export function TabBar({
     >
       {/* ENH-132 (Sprint 14, 2026-05-10) — ARIA tablist for screen readers. */}
       <div role="tablist" aria-label="Terminal tabs" className="flex items-end flex-1 overflow-x-auto scrollbar-none gap-0.5">
-        {tabs.map(tab => (
+        {tabs.map((tab, index) => (
           <Tab
             key={tab.id}
             tab={tab}
             isActive={tab.id === activeTabId}
             onSelect={() => onSelect(tab.id)}
-            onClose={(e) => {
-              e.stopPropagation()
-              onClose(tab.id)
-            }}
+            onCloseSelf={() => onClose(tab.id)}
             canClose={tabs.length > 1}
             onRevealCwd={onRevealCwd}
             // ENH-024 — only the active tab gets the ref; previous
             // active tab loses the assignment naturally on re-render.
             buttonRef={tab.id === activeTabId ? activeTabRef : undefined}
+            // ENH-187 — reorder context: position within the visible
+            // strip gates the move-left/right items; the bound mover +
+            // close-others wire the menu actions.
+            index={index}
+            total={tabs.length}
+            canReorder={!!onReorderTab}
+            onMoveTab={(delta) => moveTabBy(tab.id, delta)}
+            onCloseOthers={onCloseOthers ? () => onCloseOthers(tab.id) : undefined}
+            // ENH-187 — HTML5 drag-and-drop reorder. Distinct mime from
+            // the canvas strip so terminal/canvas drags never cross.
+            isDropTarget={dropTargetId === tab.id}
+            onDragStart={onReorderTab ? (e) => {
+              e.dataTransfer.effectAllowed = 'move'
+              e.dataTransfer.setData('application/x-duo-terminal-tab-id', tab.id)
+            } : undefined}
+            onDragOver={onReorderTab ? (e) => {
+              if (e.dataTransfer.types.includes('application/x-duo-terminal-tab-id')) {
+                e.preventDefault()
+                setDropTargetId(tab.id)
+              }
+            } : undefined}
+            onDragLeave={() => setDropTargetId(prev => (prev === tab.id ? null : prev))}
+            onDrop={onReorderTab ? (e) => {
+              e.preventDefault()
+              const sourceId = e.dataTransfer.getData('application/x-duo-terminal-tab-id')
+              setDropTargetId(null)
+              if (sourceId && sourceId !== tab.id) onReorderTab(sourceId, tab.id)
+            } : undefined}
+            onDragEnd={() => setDropTargetId(null)}
           />
         ))}
       </div>
@@ -168,28 +222,87 @@ interface TabProps {
   tab: TabSession
   isActive: boolean
   onSelect: () => void
-  onClose: (e: React.MouseEvent) => void
+  /** ENH-187 — close this tab (menu "Close tab" + the × button). */
+  onCloseSelf: () => void
   canClose: boolean
   /** ENH-024 — passed by the parent on the active tab so it can
    *  `scrollIntoView` whenever the active tab changes. */
   buttonRef?: React.Ref<HTMLButtonElement>
   /** ENH-115 — right-click → Reveal in navigator. */
   onRevealCwd?: (cwd: string) => void
+  /** ENH-187 — position within the visible strip; gates move-left/right. */
+  index: number
+  total: number
+  /** ENH-187 — whether reorder is wired (drag + move items). */
+  canReorder: boolean
+  /** ENH-187 — move this tab one slot left (-1) / right (1). */
+  onMoveTab: (delta: -1 | 1) => void
+  /** ENH-187 — "Close other tabs" (undefined hides the item). */
+  onCloseOthers?: () => void
+  /** ENH-187 — drag-reorder wiring. Undefined handlers ⇒ non-draggable. */
+  isDropTarget?: boolean
+  onDragStart?: (e: React.DragEvent) => void
+  onDragOver?: (e: React.DragEvent) => void
+  onDragLeave?: (e: React.DragEvent) => void
+  onDrop?: (e: React.DragEvent) => void
+  onDragEnd?: (e: React.DragEvent) => void
 }
 
-function Tab({ tab, isActive, onSelect, onClose, canClose, buttonRef, onRevealCwd }: TabProps) {
-  // ENH-115 — right-click → native context menu. Single verb today
-  // ("Reveal in navigator"); leaves room for additional terminal-tab
-  // verbs (Duplicate / Close others) without restructuring.
+function Tab({
+  tab, isActive, onSelect, onCloseSelf, canClose, buttonRef, onRevealCwd,
+  index, total, canReorder, onMoveTab, onCloseOthers,
+  isDropTarget, onDragStart, onDragOver, onDragLeave, onDrop, onDragEnd
+}: TabProps) {
+  // ENH-187 — right-click → native context menu, approaching parity
+  // with the canvas-tab menu (WorkingTabStrip). Items are grouped:
+  // reveal / copy-cwd, then move-left/right, then close verbs — each
+  // group separated by a rule (same builder shape as the canvas side).
   const onContextMenu = async (e: React.MouseEvent) => {
     e.preventDefault()
-    if (!onRevealCwd || !tab.cwd) return
-    const res = await window.electron.menu.popup({
-      items: [{ id: 'reveal-cwd', label: 'Reveal in navigator' }],
-      x: e.clientX,
-      y: e.clientY
-    })
-    if (res.chosenId === 'reveal-cwd') onRevealCwd(tab.cwd)
+    const items: MenuTemplateItem[] = []
+    if (onRevealCwd && tab.cwd) items.push({ id: 'reveal-cwd', label: 'Reveal in navigator' })
+    if (tab.cwd) items.push({ id: 'copy-cwd', label: 'Copy cwd' })
+
+    const moveItems: MenuTemplateItem[] = []
+    if (canReorder && index > 0) moveItems.push({ id: 'move-left', label: 'Move tab left' })
+    if (canReorder && index < total - 1) moveItems.push({ id: 'move-right', label: 'Move tab right' })
+    if (moveItems.length) {
+      if (items.length) items.push({ type: 'separator' })
+      items.push(...moveItems)
+    }
+
+    const closeItems: MenuTemplateItem[] = []
+    if (canClose) closeItems.push({ id: 'close', label: 'Close tab' })
+    if (onCloseOthers && total > 1) closeItems.push({ id: 'close-others', label: 'Close other tabs' })
+    if (closeItems.length) {
+      if (items.length) items.push({ type: 'separator' })
+      items.push(...closeItems)
+    }
+
+    if (items.length === 0) return
+    const res = await window.electron.menu.popup({ items, x: e.clientX, y: e.clientY })
+    switch (res.chosenId) {
+      case 'reveal-cwd':
+        if (tab.cwd) onRevealCwd?.(tab.cwd)
+        return
+      case 'copy-cwd':
+        // BUG-105 pattern — main-process clipboard write (no gesture
+        // requirement inside a native NSMenu handler).
+        if (tab.cwd) { try { await window.electron.clipboard.writeText(tab.cwd) } catch { /* denied */ } }
+        return
+      case 'move-left':
+        onMoveTab(-1)
+        return
+      case 'move-right':
+        onMoveTab(1)
+        return
+      case 'close':
+        onCloseSelf()
+        return
+      case 'close-others':
+        onCloseOthers?.()
+        return
+    }
   }
 
   const onClick = () => {
@@ -204,6 +317,14 @@ function Tab({ tab, isActive, onSelect, onClose, canClose, buttonRef, onRevealCw
       aria-selected={isActive}
       onClick={onClick}
       onContextMenu={onContextMenu}
+      // ENH-187 — HTML5 drag-reorder. Draggable only when the parent
+      // wired reorder handlers.
+      draggable={canReorder}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
       className={[
         'group relative flex items-center gap-1.5 px-2.5 h-7 max-w-[200px] rounded-t-lg shrink-0 transition-colors',
         isActive
@@ -211,7 +332,10 @@ function Tab({ tab, isActive, onSelect, onClose, canClose, buttonRef, onRevealCw
           // top + sides via inset shadows (paper-rule). 2px accent stripe
           // at the top renders as an absolute child below.
           ? 'bg-surface-0 text-ink shadow-[inset_0_1px_0_var(--duo-paper-rule),inset_1px_0_var(--duo-paper-rule),inset_-1px_0_var(--duo-paper-rule)] font-serif italic text-[13px] font-medium'
-          : 'text-ink-mute hover:text-ink-soft hover:bg-surface-3 text-xs'
+          : 'text-ink-mute hover:text-ink-soft hover:bg-surface-3 text-xs',
+        // ENH-187 — drop-target insertion cue. Same accent ring the
+        // canvas strip (WorkingTabItem) uses for its drag affordance.
+        isDropTarget ? 'ring-2 ring-accent ring-inset' : ''
       ].join(' ')}
       title={tab.title}
     >
@@ -229,11 +353,11 @@ function Tab({ tab, isActive, onSelect, onClose, canClose, buttonRef, onRevealCw
 
       {canClose && (
         <span
-          onClick={onClose}
+          onClick={(e) => { e.stopPropagation(); onCloseSelf() }}
           role="button"
           tabIndex={0}
           aria-label={`Close ${tab.title}`}
-          onKeyDown={(e) => e.key === 'Enter' && onClose(e as unknown as React.MouseEvent)}
+          onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onCloseSelf() } }}
           className={[
             'flex items-center justify-center w-3.5 h-3.5 rounded shrink-0 transition-opacity transition-colors',
             isActive

--- a/shared/reorderTabs.test.ts
+++ b/shared/reorderTabs.test.ts
@@ -1,0 +1,78 @@
+// ENH-188 — terminal-tab reorder transform tests.
+//
+// Pins the insert-before/after semantics + the hidden-slot re-threading
+// invariant (the bit that's more subtle than the canvas WorkingPane
+// version: under ENH-182 project focus the visible strip is a subset,
+// and reordering it must not disturb hidden tabs' absolute positions).
+
+import { describe, expect, it } from 'vitest'
+import { reorderVisible } from './reorderTabs'
+
+type Tab = { id: string }
+const tabs = (...ids: string[]): Tab[] => ids.map(id => ({ id }))
+const ids = (list: Tab[]) => list.map(t => t.id)
+const allVisible = () => true
+
+describe('reorderVisible — no focus (all visible)', () => {
+  it('drag rightward inserts AFTER the target (A→C)', () => {
+    expect(ids(reorderVisible(tabs('A', 'B', 'C', 'D'), 'A', 'C', allVisible)))
+      .toEqual(['B', 'C', 'A', 'D'])
+  })
+
+  it('drag leftward inserts BEFORE the target (D→B)', () => {
+    expect(ids(reorderVisible(tabs('A', 'B', 'C', 'D'), 'D', 'B', allVisible)))
+      .toEqual(['A', 'D', 'B', 'C'])
+  })
+
+  it('adjacent move-left (B→A) swaps the pair', () => {
+    expect(ids(reorderVisible(tabs('A', 'B', 'C', 'D'), 'B', 'A', allVisible)))
+      .toEqual(['B', 'A', 'C', 'D'])
+  })
+
+  it('adjacent move-right (B→C) swaps the pair', () => {
+    expect(ids(reorderVisible(tabs('A', 'B', 'C', 'D'), 'B', 'C', allVisible)))
+      .toEqual(['A', 'C', 'B', 'D'])
+  })
+})
+
+describe('reorderVisible — under project focus (hidden tabs preserved)', () => {
+  // A and D belong to other projects (hidden); only B and C are in the
+  // focused strip.
+  const visibleSet = new Set(['B', 'C'])
+  const isVisible = (t: Tab) => visibleSet.has(t.id)
+
+  it('reordering visible tabs keeps hidden tabs in their absolute slots', () => {
+    expect(ids(reorderVisible(tabs('A', 'B', 'C', 'D'), 'B', 'C', isVisible)))
+      .toEqual(['A', 'C', 'B', 'D'])
+  })
+
+  it('a hidden tab interleaved between visible tabs keeps its absolute slot', () => {
+    // Full array [A, B, C, D, E]; visible strip is B, C, E. Note D is
+    // HIDDEN but sits at absolute slot 3 — between visible C (slot 2)
+    // and visible E (slot 4). Drag E→B reorders the visible subsequence
+    // to [E, B, C], which threads back into the visible slots (1, 2, 4);
+    // hidden A (slot 0) and D (slot 3) stay exactly where they were.
+    const visible2 = new Set(['B', 'C', 'E'])
+    const vis2 = (t: Tab) => visible2.has(t.id)
+    expect(ids(reorderVisible(tabs('A', 'B', 'C', 'D', 'E'), 'E', 'B', vis2)))
+      .toEqual(['A', 'E', 'B', 'D', 'C'])
+  })
+})
+
+describe('reorderVisible — no-ops return the original reference', () => {
+  it('self-drop is a no-op', () => {
+    const input = tabs('A', 'B', 'C')
+    expect(reorderVisible(input, 'B', 'B', allVisible)).toBe(input)
+  })
+
+  it('unknown source id is a no-op', () => {
+    const input = tabs('A', 'B', 'C')
+    expect(reorderVisible(input, 'Z', 'B', allVisible)).toBe(input)
+  })
+
+  it('target not visible is a no-op', () => {
+    const input = tabs('A', 'B', 'C')
+    const isVisible = (t: Tab) => t.id !== 'C'
+    expect(reorderVisible(input, 'A', 'C', isVisible)).toBe(input)
+  })
+})

--- a/shared/reorderTabs.ts
+++ b/shared/reorderTabs.ts
@@ -1,0 +1,47 @@
+// ENH-188 — pure tab-reorder transform shared by the terminal strip
+// (App.tsx § reorderTerminalTab) and extractable by any future reorder
+// surface. Mirrors WorkingPane.reorderTab's insert-before/after
+// semantics, with one added subtlety: when only a SUBSEQUENCE of the
+// array is visible (ENH-182 project focus), the reorder happens within
+// the visible subsequence and the result is re-threaded back into the
+// slots the visible items originally occupied — so hidden items keep
+// their absolute positions and a reorder while focused never disturbs
+// another project's tab order.
+
+/**
+ * Reorder `sourceId` relative to `targetId` within the visible
+ * subsequence of `items` (those for which `isVisible` is true), then
+ * splice the reordered visible items back into their original absolute
+ * slots. Hidden items are untouched.
+ *
+ * Direction-aware (matches WorkingPane.reorderTab): if the source was
+ * originally LEFT of the target, it lands AFTER the target
+ * (drag-rightward intent); if RIGHT, it lands BEFORE (drag-leftward).
+ *
+ * Returns the original array reference unchanged on any no-op (self-drop,
+ * unknown id, or either id not visible) so callers can rely on identity
+ * for change detection.
+ */
+export function reorderVisible<T extends { id: string }>(
+  items: T[],
+  sourceId: string,
+  targetId: string,
+  isVisible: (item: T) => boolean
+): T[] {
+  if (sourceId === targetId) return items
+  const visible = items.filter(isVisible)
+  const srcIdx = visible.findIndex(t => t.id === sourceId)
+  const tgtIdx = visible.findIndex(t => t.id === targetId)
+  if (srcIdx < 0 || tgtIdx < 0) return items
+  const without = visible.filter(t => t.id !== sourceId)
+  const newTgtIdx = without.findIndex(t => t.id === targetId)
+  if (newTgtIdx < 0) return items
+  const insertAt = srcIdx < tgtIdx ? newTgtIdx + 1 : newTgtIdx
+  const newVisible = [...without.slice(0, insertAt), visible[srcIdx], ...without.slice(insertAt)]
+  // Re-thread: walk the full array; each slot that held a visible item
+  // receives the next item from the reordered visible list, hidden items
+  // pass through in place.
+  const visibleIds = new Set(visible.map(t => t.id))
+  let vi = 0
+  return items.map(t => (visibleIds.has(t.id) ? newVisible[vi++] : t))
+}

--- a/tasks.md
+++ b/tasks.md
@@ -8,9 +8,11 @@
 
 > Sprint 24 anchor: close the v0.8.0 audit's deferred follow-ups (FOLLOWUP-031 through 040) before any new feature work. ENH-182 was the marquee chapter; Sprint 24 is its polish epilogue. Definition of done: all 10 FOLLOWUPs closed or explicitly deferred-with-reason. Expected cut shape: v0.8.1 PATCH (polish-only) OR v0.9.0 MINOR if a carry-forward capability lands alongside.
 
-### ENH-187: Terminal-tab context menu — parity with canvas tabs (reorder + close + copy cwd)
+### ENH-188: Terminal-tab context menu — parity with canvas tabs (reorder + close + copy cwd)
 
 **Status:** 🆕 **Filed + implemented 2026-05-27** (branch `claude/terminal-tabs-context-parity-2lh2X`). **Priority:** Medium (daily-driver ergonomics; the headline gap is "can't reorder terminal tabs"). **Effort:** ~1.5h.
+
+> **Renumbered ENH-187 → ENH-188 (PR #60 review).** The branch was cut from pre-v0.8.1 main; ENH-187 was meanwhile taken by the shipped `⌘T`/`duo new-tab` live-cwd-inheritance feature (v0.8.1, commit `0d303e1`). Different surface, so this work moved to the next free id, ENH-188.
 
 **Symptom.** The terminal-tab right-click menu (`TabBar.tsx`) offered a single verb — "Reveal in navigator" (ENH-115) — while the canvas-tab menu (`WorkingTabStrip.tsx`) is rich: reveal, rename, copy path, **move left/right**, pin, move-to-split, edit-in-canvas, open-in-browser, view-source, trash. Terminal tabs couldn't be reordered at all (no drag, no menu), so a mis-ordered strip was permanent until close + reopen.
 
@@ -20,7 +22,7 @@
 - **Skipped — no terminal analog:** Pin/Unpin (terminals have no pin concept), Move to Split View (working-pane-only), Edit-in-canvas / Open-in-browser (HTML modality flip), View source (file-content concept), Move to Trash (terminals aren't files — Close is the analog).
 - **Skipped — not true parity:** Rename… (canvas renames the *file*; terminal titles come from the process/OSC — a manual override would be a new concept, declined for v1).
 
-**Implementation.** `renderer/components/TabBar.tsx` — context-menu builder expanded (position-aware move items, separators between groups), HTML5 drag handlers + `dropTargetId` accent insertion cue, new `onReorderTab` / `onCloseOthers` props. `renderer/App.tsx` — `reorderTerminalTab(sourceId, targetId)` reorders the full `tabs` array with insert-before/after semantics (mirrors WorkingPane's `reorderTab`) while **preserving hidden tabs' absolute slots** under ENH-182 project focus (reorders only within the visible subsequence, rebuilds in place); `closeOtherTabs(keepId)` closes every *visible* terminal tab except the kept one and pushes each onto the ENH-179 closed-tab ring (⌘Z-restorable). Reorder persists for free via the existing workspace-save (`terminals: tabs.map(...)`).
+**Implementation.** `renderer/components/TabBar.tsx` — context-menu builder expanded (position-aware move items, separators between groups), HTML5 drag handlers + `dropTargetId` accent insertion cue, new `onReorderTab` / `onCloseOthers` props. `renderer/App.tsx` — `reorderTerminalTab(sourceId, targetId)` reorders the full `tabs` array with insert-before/after semantics (mirrors WorkingPane's `reorderTab`) while **preserving hidden tabs' absolute slots** under ENH-182 project focus (reorders only within the visible subsequence, rebuilds in place); `closeOtherTabs(keepId)` closes every *visible* terminal tab except the kept one and pushes each onto the ENH-179 closed-tab ring (⌘Z-restorable). Reorder persists for free via the existing workspace-save (`terminals: tabs.map(...)`). The reorder transform is extracted as the pure `shared/reorderTabs.ts § reorderVisible(items, sourceId, targetId, isVisible)` with **9 unit tests** (`shared/reorderTabs.test.ts`) pinning the insert-before/after + hidden-slot-preservation invariants (PR #60 review ask).
 
 **Deliberate asymmetry (CLI parity).** Canvas "move left/right" is itself UI-only — there is **no** `duo` verb for canvas reorder either (only `BROWSER_MOVE_TAB_TO_AUX`). So terminal reorder shipping UI-only *faithfully* approaches canvas parity rather than introducing a new gap. The CLI verb is deferred, not skipped → FOLLOWUP-042.
 
@@ -30,9 +32,9 @@
 
 ### FOLLOWUP-042: `duo move-terminal-tab` (and arguably `duo move-tab` for canvas) CLI verb
 
-**Status:** 🆕 **Filed 2026-05-27** (ENH-187 scoping, owner chose "defer CLI verb as follow-up"). **Priority:** Low. **Effort:** ~45 min (full new-CLI-verb plumbing checklist).
+**Status:** 🆕 **Filed 2026-05-27** (ENH-188 scoping, owner chose "defer CLI verb as follow-up"). **Priority:** Low. **Effort:** ~45 min (full new-CLI-verb plumbing checklist).
 
-**Gap.** ENH-187 added human-facing terminal-tab reorder (menu + drag) but no CLI verb — matching the canvas side, which is *also* UI-only. CLAUDE.md §4 wants every human action mirrored in the CLI; this is a known, deliberate asymmetry pending this follow-up.
+**Gap.** ENH-188 added human-facing terminal-tab reorder (menu + drag) but no CLI verb — matching the canvas side, which is *also* UI-only. CLAUDE.md §4 wants every human action mirrored in the CLI; this is a known, deliberate asymmetry pending this follow-up.
 
 **Fix path.** Add `duo move-terminal-tab <n> <left|right>` (1-indexed against the visible strip). Probably pairs with a `duo move-tab <n> <left|right>` for the canvas WorkingPane so both reorder surfaces gain CLI parity in one pass. Full plumbing checklist applies (`shared/types.ts` → `electron/preload.ts` → `electron/main.ts` → `electron/socket-server.ts` → `cli/duo.ts` + `npm run build:cli` → `skill/SKILL.md` + `npm run sync:claude` → `agents/duo.md` → `docs/CLI-COVERAGE.md`). The renderer reorder primitives (`reorderTerminalTab`, WorkingPane's `reorderTab`) already exist — this is pure plumbing to reach them from the socket.
 

--- a/tasks.md
+++ b/tasks.md
@@ -8,6 +8,36 @@
 
 > Sprint 24 anchor: close the v0.8.0 audit's deferred follow-ups (FOLLOWUP-031 through 040) before any new feature work. ENH-182 was the marquee chapter; Sprint 24 is its polish epilogue. Definition of done: all 10 FOLLOWUPs closed or explicitly deferred-with-reason. Expected cut shape: v0.8.1 PATCH (polish-only) OR v0.9.0 MINOR if a carry-forward capability lands alongside.
 
+### ENH-187: Terminal-tab context menu — parity with canvas tabs (reorder + close + copy cwd)
+
+**Status:** 🆕 **Filed + implemented 2026-05-27** (branch `claude/terminal-tabs-context-parity-2lh2X`). **Priority:** Medium (daily-driver ergonomics; the headline gap is "can't reorder terminal tabs"). **Effort:** ~1.5h.
+
+**Symptom.** The terminal-tab right-click menu (`TabBar.tsx`) offered a single verb — "Reveal in navigator" (ENH-115) — while the canvas-tab menu (`WorkingTabStrip.tsx`) is rich: reveal, rename, copy path, **move left/right**, pin, move-to-split, edit-in-canvas, open-in-browser, view-source, trash. Terminal tabs couldn't be reordered at all (no drag, no menu), so a mis-ordered strip was permanent until close + reopen.
+
+**Scope (owner-confirmed via AskUserQuestion 2026-05-27).** Reviewed every canvas-tab action for terminal fit:
+- **Brought over:** **Move tab left / right** (the headline ask), **Copy cwd** (analog of canvas "Copy path" — tabs carry a `cwd`), **Close tab** (menu mirror of the × button), **Close other tabs** (no canvas analog, but a standard tab-strip verb). Plus the pre-existing **Reveal in navigator**.
+- **Reorder gesture:** menu **+ HTML5 drag-and-drop** (mirrors canvas ENH-042), per owner pick. Distinct dataTransfer type `application/x-duo-terminal-tab-id` so terminal/canvas drags never cross-contaminate.
+- **Skipped — no terminal analog:** Pin/Unpin (terminals have no pin concept), Move to Split View (working-pane-only), Edit-in-canvas / Open-in-browser (HTML modality flip), View source (file-content concept), Move to Trash (terminals aren't files — Close is the analog).
+- **Skipped — not true parity:** Rename… (canvas renames the *file*; terminal titles come from the process/OSC — a manual override would be a new concept, declined for v1).
+
+**Implementation.** `renderer/components/TabBar.tsx` — context-menu builder expanded (position-aware move items, separators between groups), HTML5 drag handlers + `dropTargetId` accent insertion cue, new `onReorderTab` / `onCloseOthers` props. `renderer/App.tsx` — `reorderTerminalTab(sourceId, targetId)` reorders the full `tabs` array with insert-before/after semantics (mirrors WorkingPane's `reorderTab`) while **preserving hidden tabs' absolute slots** under ENH-182 project focus (reorders only within the visible subsequence, rebuilds in place); `closeOtherTabs(keepId)` closes every *visible* terminal tab except the kept one and pushes each onto the ENH-179 closed-tab ring (⌘Z-restorable). Reorder persists for free via the existing workspace-save (`terminals: tabs.map(...)`).
+
+**Deliberate asymmetry (CLI parity).** Canvas "move left/right" is itself UI-only — there is **no** `duo` verb for canvas reorder either (only `BROWSER_MOVE_TAB_TO_AUX`). So terminal reorder shipping UI-only *faithfully* approaches canvas parity rather than introducing a new gap. The CLI verb is deferred, not skipped → FOLLOWUP-042.
+
+**Cross-ref:** ENH-115 (the original single-verb terminal menu), ENH-042 (canvas drag-reorder this mirrors), ENH-050 (native NSMenu popup pattern both strips share), ENH-179 (closed-tab ring), ENH-182 (project-focus visibility filter the reorder respects).
+
+---
+
+### FOLLOWUP-042: `duo move-terminal-tab` (and arguably `duo move-tab` for canvas) CLI verb
+
+**Status:** 🆕 **Filed 2026-05-27** (ENH-187 scoping, owner chose "defer CLI verb as follow-up"). **Priority:** Low. **Effort:** ~45 min (full new-CLI-verb plumbing checklist).
+
+**Gap.** ENH-187 added human-facing terminal-tab reorder (menu + drag) but no CLI verb — matching the canvas side, which is *also* UI-only. CLAUDE.md §4 wants every human action mirrored in the CLI; this is a known, deliberate asymmetry pending this follow-up.
+
+**Fix path.** Add `duo move-terminal-tab <n> <left|right>` (1-indexed against the visible strip). Probably pairs with a `duo move-tab <n> <left|right>` for the canvas WorkingPane so both reorder surfaces gain CLI parity in one pass. Full plumbing checklist applies (`shared/types.ts` → `electron/preload.ts` → `electron/main.ts` → `electron/socket-server.ts` → `cli/duo.ts` + `npm run build:cli` → `skill/SKILL.md` + `npm run sync:claude` → `agents/duo.md` → `docs/CLI-COVERAGE.md`). The renderer reorder primitives (`reorderTerminalTab`, WorkingPane's `reorderTab`) already exist — this is pure plumbing to reach them from the socket.
+
+---
+
 ### BUG-165: Terminal stuck on "[process exited]" when its cwd was deleted
 
 **Status:** 🟡 **Fix pushed `claude/terminal-process-exit-DFgEw` 2026-05-26.** **Priority:** High (terminal unusable, no recovery even on restart). **Effort:** ~45 min.


### PR DESCRIPTION
## Summary

Brings the terminal-tab right-click menu (`TabBar.tsx`) toward parity with the canvas-tab menu (`WorkingTabStrip.tsx`). Before this, terminal tabs only offered **Reveal in navigator** and couldn't be reordered at all.

**Brought over (owner-confirmed via AskUserQuestion):**
- **Move tab left / right** — the headline ask — via context menu **and** HTML5 drag-and-drop (mirrors canvas ENH-042; distinct dataTransfer mime so terminal/canvas drags never cross).
- **Copy cwd** — analog of canvas "Copy path".
- **Close tab** — menu mirror of the × button.
- **Close other tabs** — no canvas analog, but a standard tab-strip verb.

**Skipped — no terminal analog:** Pin/Unpin, Move to Split View, Edit-in-canvas / Open-in-browser, View source, Move to Trash.
**Skipped — not true parity:** Rename… (canvas renames the *file*; terminal titles come from the process — a manual override would be a new concept).

## Implementation

- `renderer/components/TabBar.tsx` — expanded context-menu builder (position-aware move items, grouped with separators), HTML5 drag handlers + `dropTargetId` accent-ring cue, new `onReorderTab` / `onCloseOthers` props. The × close handler now routes through a clean `onCloseSelf` callback.
- `renderer/App.tsx` — `reorderTerminalTab(sourceId, targetId)` reorders the `tabs` array with insert-before/after semantics (mirrors `WorkingPane.reorderTab`) while **preserving hidden tabs' absolute slots** under ENH-182 project focus. `closeOtherTabs(keepId)` closes every *visible* terminal tab except the kept one, pushing each onto the ENH-179 closed-tab ring (⌘Z-restorable). Order persists for free via the existing workspace-save.

## Deliberate asymmetry (CLI parity)

Canvas "move left/right" is itself **UI-only** — there's no `duo` verb for canvas reorder either. So this faithfully *approaches* canvas parity rather than introducing a new gap. CLI verb deferred → **FOLLOWUP-042** (`duo move-terminal-tab`, likely paired with `duo move-tab` for the canvas).

## Verification

- ✅ `npm run typecheck` clean.
- ⚠️ **Live UI not verified in this environment** — this is a Linux cloud container; Duo is a macOS Electron app (`node-pty` native rebuild can't run here). Per CLAUDE.md §7, a live smoke-walk on the owner's Mac is still owed before this is "done".

## Test plan
- [ ] Right-click a terminal tab → menu shows Reveal / Copy cwd / Move left+right (position-gated) / Close tab / Close other tabs.
- [ ] "Move tab left/right" reorders the strip; edges hide the unavailable direction.
- [ ] Drag a terminal tab onto another → reorders, accent-ring cue shows on hover target.
- [ ] "Copy cwd" puts the tab's cwd on the clipboard.
- [ ] "Close other tabs" leaves only the right-clicked tab (and other-project tabs under focus); ⌘Z restores closed ones.
- [ ] Under project focus, reordering visible tabs leaves other projects' tab order untouched.
- [ ] Reorder survives workspace save/restore.

https://claude.ai/code/session_0189F2MNAzHKufaeR5rEbg58

---
_Generated by [Claude Code](https://claude.ai/code/session_0189F2MNAzHKufaeR5rEbg58)_