### PR TITLE
fix(BUG-190): stop quit-loop crash from webContents.send on destroyed window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ notarized distribution (Stage 21).
 
 ## [Unreleased]
 
-> Empty — v0.8.2 cut 2026-05-27.
+### Fixed
+- **BUG-189** Quitting Duo no longer pops a looping "A JavaScript error occurred in the main process" dialog (`TypeError: Object has been destroyed`). A node-pty data burst during shutdown was hitting `webContents.send` on an already-destroyed window; every async main→renderer send now routes through a guard that no-ops once the window is torn down.
 
 ## [0.8.2] — 2026-05-27 — Terminal-tab context menu parity
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ notarized distribution (Stage 21).
 ## [Unreleased]
 
 ### Fixed
-- **BUG-189** Quitting Duo no longer pops a looping "A JavaScript error occurred in the main process" dialog (`TypeError: Object has been destroyed`). A node-pty data burst during shutdown was hitting `webContents.send` on an already-destroyed window; every async main→renderer send now routes through a guard that no-ops once the window is torn down.
+- **BUG-190** Quitting Duo no longer pops a looping "A JavaScript error occurred in the main process" dialog (`TypeError: Object has been destroyed`). A node-pty data burst during shutdown was hitting `webContents.send` on an already-destroyed window; every async main→renderer send now routes through a guard that no-ops once the window is torn down.
 
 ## [0.8.2] — 2026-05-27 — Terminal-tab context menu parity
 

--- a/electron/browser-manager.ts
+++ b/electron/browser-manager.ts
@@ -1265,6 +1265,10 @@ export class BrowserManager {
   private wireKeyForwarding(view: WebContentsView): void {
     view.webContents.on('before-input-event', (event, input) => {
       if (input.type !== 'keyDown') return
+      // BUG-189 follow-up — bail if the main window is gone (quit/teardown).
+      // Guards the focus() + both sends below: webContents.send on a
+      // destroyed window throws "Object has been destroyed".
+      if (this.window.isDestroyed() || this.window.webContents.isDestroyed()) return
       const key = input.key.toLowerCase()
 
       // ⌃Tab / ⌃⇧Tab cycle browser tabs. Handled in the renderer, but
@@ -1426,6 +1430,8 @@ export class BrowserManager {
     // focusedColumn = 'working'. Symmetric to the canvas iframe's
     // mousedown forwarder (BUG-037 fix on the renderer side).
     view.webContents.on('focus', () => {
+      // BUG-189 follow-up — bail if the main window is gone (quit/teardown).
+      if (this.window.isDestroyed() || this.window.webContents.isDestroyed()) return
       // Phase 3c BUG-095 fix — forward the tab id + slot so the
       // renderer can distinguish a focus event on the AUX-pinned tab
       // from one on a main-strip tab. Pre-fix the renderer

--- a/electron/browser-manager.ts
+++ b/electron/browser-manager.ts
@@ -1265,7 +1265,7 @@ export class BrowserManager {
   private wireKeyForwarding(view: WebContentsView): void {
     view.webContents.on('before-input-event', (event, input) => {
       if (input.type !== 'keyDown') return
-      // BUG-189 follow-up — bail if the main window is gone (quit/teardown).
+      // BUG-190 follow-up — bail if the main window is gone (quit/teardown).
       // Guards the focus() + both sends below: webContents.send on a
       // destroyed window throws "Object has been destroyed".
       if (this.window.isDestroyed() || this.window.webContents.isDestroyed()) return
@@ -1430,7 +1430,7 @@ export class BrowserManager {
     // focusedColumn = 'working'. Symmetric to the canvas iframe's
     // mousedown forwarder (BUG-037 fix on the renderer side).
     view.webContents.on('focus', () => {
-      // BUG-189 follow-up — bail if the main window is gone (quit/teardown).
+      // BUG-190 follow-up — bail if the main window is gone (quit/teardown).
       if (this.window.isDestroyed() || this.window.webContents.isDestroyed()) return
       // Phase 3c BUG-095 fix — forward the tab id + slot so the
       // renderer can distinguish a focus event on the AUX-pinned tab

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,6 +55,7 @@ import { expandTilde } from '../core/path-utils'
 import { PtyManager } from '../core/pty-manager'
 import { BrowserManager } from './browser-manager'
 import { CdpBridge } from './cdp-bridge'
+import { makeSafeSend } from './safe-send'
 import { SocketServer, ensureSocketDir } from '../core/socket-server'
 import { FilesService } from './files-service'
 import { PinsService } from '../core/pins-service'
@@ -255,12 +256,9 @@ let mainWindow: BrowserWindow | null = null
 // PTYs, which flush a final burst of onData — each throwing send was an
 // uncaught exception, and node-pty kept emitting buffered output, so the
 // crash dialog looped until force-quit. Route every async-callback sink
-// through this guard.
-function safeSend(channel: string, payload?: unknown): void {
-  if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed()) {
-    mainWindow.webContents.send(channel, payload)
-  }
-}
+// through this guard. Pure-logic factory lives in ./safe-send so it can
+// be exercised from a vitest node env (see safe-send.test.ts).
+const safeSend = makeSafeSend(() => mainWindow)
 // ENH-081 (v0.6.4) — Finder double-click / drag-onto-Dock landing
 // strip. macOS fires `app.on('open-file')` for paths the user opened
 // via the OS shell. On cold start the event can fire before

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -246,6 +246,21 @@ const newTabPending = new Map<string, (res: NewTabResult) => void>()
 nativeTheme.themeSource = 'light'
 
 let mainWindow: BrowserWindow | null = null
+
+// BUG-189 — a webContents.send that's safe to call from async callbacks
+// (PTY data, socket events, CDP-driven browser state) that can fire
+// mid-quit. `mainWindow?.` guards only null; during teardown `mainWindow`
+// is still set but its webContents is already destroyed, so the bare send
+// throws "Object has been destroyed". On quit, `before-quit` kills the
+// PTYs, which flush a final burst of onData — each throwing send was an
+// uncaught exception, and node-pty kept emitting buffered output, so the
+// crash dialog looped until force-quit. Route every async-callback sink
+// through this guard.
+function safeSend(channel: string, payload?: unknown): void {
+  if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed()) {
+    mainWindow.webContents.send(channel, payload)
+  }
+}
 // ENH-081 (v0.6.4) — Finder double-click / drag-onto-Dock landing
 // strip. macOS fires `app.on('open-file')` for paths the user opened
 // via the OS shell. On cold start the event can fire before
@@ -532,7 +547,7 @@ async function createWindow(): Promise<void> {
   // adapter is one line in Electron (webContents.send); a future
   // extension helper would wrap a Native Messaging port write instead.
   ptyManager.setEventSink({
-    send: (channel, payload) => mainWindow?.webContents.send(channel, payload)
+    send: (channel, payload) => safeSend(channel, payload)
   })
 
   // BUG-040 — external-domains routing service. Loaded once at boot;
@@ -569,8 +584,8 @@ async function createWindow(): Promise<void> {
   browserManager = new BrowserManager(
     mainWindow,
     cdpBridge,
-    (state: BrowserState) => mainWindow?.webContents.send(IPC.BROWSER_STATE, state),
-    (tabs: BrowserTab[]) => mainWindow?.webContents.send(IPC.BROWSER_TABS, tabs),
+    (state: BrowserState) => safeSend(IPC.BROWSER_STATE, state),
+    (tabs: BrowserTab[]) => safeSend(IPC.BROWSER_TABS, tabs),
     browserHistory,
     externalDomainsService
   )
@@ -695,7 +710,7 @@ async function createWindow(): Promise<void> {
       return { ok: true, target }
     },
     pushNavPinsChanged: (pins) => {
-      mainWindow?.webContents.send(IPC.NAV_PINS_CHANGED, pins)
+      safeSend(IPC.NAV_PINS_CHANGED, pins)
     },
     // ENH-167 — workspace-as-file CLI parity.
     workspaceSave: async (opts) => saveWorkspaceFile(opts),
@@ -722,7 +737,7 @@ async function createWindow(): Promise<void> {
   // the agent calls `duo selection`). Same one-liner adapter as
   // PtyManager's setEventSink.
   socketServer.setEventSink((channel, payload) => {
-    mainWindow?.webContents.send(channel, payload)
+    safeSend(channel, payload)
   })
   socketServer.start()
 
@@ -752,9 +767,7 @@ async function createWindow(): Promise<void> {
     if ((state === 'claude' || state === 'starting') && activeTerminalId) {
       tabsThatHostedClaude.add(activeTerminalId)
     }
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(IPC.TERMINAL_CLAUDE_PRESENCE_CHANGED, state)
-    }
+    safeSend(IPC.TERMINAL_CLAUDE_PRESENCE_CHANGED, state)
     const live = state === 'claude' || state === 'starting'
     cdpBridge.setClaudeLive(live)
     // BUG-133 — also broadcast to ALL browser tabs (not just the
@@ -1704,8 +1717,7 @@ function setupIPC(): void {
       usePolling: false
     })
     const fireInvalidate = () => {
-      if (mainWindow?.webContents.isDestroyed()) return
-      mainWindow?.webContents.send(IPC.GIT_WATCH_INVALIDATE)
+      safeSend(IPC.GIT_WATCH_INVALIDATE)
     }
     const scheduleInvalidate = () => {
       if (gitWatcherTimer) clearTimeout(gitWatcherTimer)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -248,7 +248,7 @@ nativeTheme.themeSource = 'light'
 
 let mainWindow: BrowserWindow | null = null
 
-// BUG-189 — a webContents.send that's safe to call from async callbacks
+// BUG-190 — a webContents.send that's safe to call from async callbacks
 // (PTY data, socket events, CDP-driven browser state) that can fire
 // mid-quit. `mainWindow?.` guards only null; during teardown `mainWindow`
 // is still set but its webContents is already destroyed, so the bare send

--- a/electron/safe-send.test.ts
+++ b/electron/safe-send.test.ts
@@ -1,4 +1,4 @@
-// BUG-189 — pins the guarded-send invariants so the quit-loop crash
+// BUG-190 — pins the guarded-send invariants so the quit-loop crash
 // can't regress silently. Each case targets one branch the production
 // closure depends on; the destroyed-window-throws-on-webContents case
 // is the specific defensive behavior that motivated the short-circuit
@@ -23,7 +23,7 @@ function makeFakeWindow(opts?: {
   return { window, send }
 }
 
-describe('makeSafeSend — BUG-189 guard', () => {
+describe('makeSafeSend — BUG-190 guard', () => {
   it('no-ops when getWindow returns null', () => {
     const safeSend = makeSafeSend(() => null)
     expect(() => safeSend('channel', 'payload')).not.toThrow()
@@ -44,7 +44,7 @@ describe('makeSafeSend — BUG-189 guard', () => {
   })
 
   it('short-circuits BEFORE touching webContents on a destroyed window', () => {
-    // Reproduces the BUG-189 defensive shape: accessing webContents on a
+    // Reproduces the BUG-190 defensive shape: accessing webContents on a
     // torn-down BrowserWindow can itself throw. The guard must check
     // isDestroyed() first so the getter never fires.
     const send = vi.fn()

--- a/electron/safe-send.test.ts
+++ b/electron/safe-send.test.ts
@@ -1,0 +1,94 @@
+// BUG-189 — pins the guarded-send invariants so the quit-loop crash
+// can't regress silently. Each case targets one branch the production
+// closure depends on; the destroyed-window-throws-on-webContents case
+// is the specific defensive behavior that motivated the short-circuit
+// (a naive `w.webContents.isDestroyed()` after a destroyed window
+// would itself throw).
+
+import { describe, it, expect, vi } from 'vitest'
+import { makeSafeSend, type WindowLike } from './safe-send'
+
+function makeFakeWindow(opts?: {
+  destroyed?: boolean
+  webContentsDestroyed?: boolean
+}): { window: WindowLike; send: ReturnType<typeof vi.fn> } {
+  const send = vi.fn()
+  const window: WindowLike = {
+    isDestroyed: () => opts?.destroyed ?? false,
+    webContents: {
+      isDestroyed: () => opts?.webContentsDestroyed ?? false,
+      send
+    }
+  }
+  return { window, send }
+}
+
+describe('makeSafeSend — BUG-189 guard', () => {
+  it('no-ops when getWindow returns null', () => {
+    const safeSend = makeSafeSend(() => null)
+    expect(() => safeSend('channel', 'payload')).not.toThrow()
+  })
+
+  it('no-ops when window.isDestroyed() is true', () => {
+    const { window, send } = makeFakeWindow({ destroyed: true })
+    const safeSend = makeSafeSend(() => window)
+    safeSend('channel', 'payload')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when webContents.isDestroyed() is true (window still alive)', () => {
+    const { window, send } = makeFakeWindow({ webContentsDestroyed: true })
+    const safeSend = makeSafeSend(() => window)
+    safeSend('channel', 'payload')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('short-circuits BEFORE touching webContents on a destroyed window', () => {
+    // Reproduces the BUG-189 defensive shape: accessing webContents on a
+    // torn-down BrowserWindow can itself throw. The guard must check
+    // isDestroyed() first so the getter never fires.
+    const send = vi.fn()
+    const window: WindowLike = {
+      isDestroyed: () => true,
+      get webContents(): WindowLike['webContents'] {
+        throw new Error('Object has been destroyed')
+      }
+    }
+    const safeSend = makeSafeSend(() => window)
+    expect(() => safeSend('channel', 'payload')).not.toThrow()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('sends through to webContents.send on a live window', () => {
+    const { window, send } = makeFakeWindow()
+    const safeSend = makeSafeSend(() => window)
+    safeSend('channel', { foo: 1 })
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('channel', { foo: 1 })
+  })
+
+  it('passes undefined payload when caller omits it', () => {
+    const { window, send } = makeFakeWindow()
+    const safeSend = makeSafeSend(() => window)
+    safeSend('channel')
+    expect(send).toHaveBeenCalledWith('channel', undefined)
+  })
+
+  it('re-reads the window on each call (so a window swap is reflected)', () => {
+    // Production wiring is `makeSafeSend(() => mainWindow)`; if the
+    // closure cached the window at construction, sends after a
+    // workspace-driven window swap would target the dead handle.
+    const live = makeFakeWindow()
+    const dead = makeFakeWindow({ destroyed: true })
+    let current: WindowLike = live.window
+    const safeSend = makeSafeSend(() => current)
+
+    safeSend('a', 1)
+    expect(live.send).toHaveBeenCalledWith('a', 1)
+
+    current = dead.window
+    safeSend('b', 2)
+    expect(dead.send).not.toHaveBeenCalled()
+    expect(live.send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/electron/safe-send.ts
+++ b/electron/safe-send.ts
@@ -1,4 +1,4 @@
-// BUG-189 — guarded webContents.send factory, extracted from
+// BUG-190 — guarded webContents.send factory, extracted from
 // electron/main.ts so it's exercisable from a vitest node env without
 // mounting Electron. The production wiring closes over the main-process
 // `mainWindow` variable via the `getWindow` thunk; tests inject a fake

--- a/electron/safe-send.ts
+++ b/electron/safe-send.ts
@@ -1,0 +1,30 @@
+// BUG-189 — guarded webContents.send factory, extracted from
+// electron/main.ts so it's exercisable from a vitest node env without
+// mounting Electron. The production wiring closes over the main-process
+// `mainWindow` variable via the `getWindow` thunk; tests inject a fake
+// WindowLike to drive the destroyed/null branches.
+//
+// Why this lives apart from main.ts: a regression here re-opens the
+// quit-loop crash (PTY data after teardown → unguarded send → uncaught
+// "Object has been destroyed" → looping dialog). The owner's review on
+// PR #61 explicitly asked for the test, hence the small extraction.
+
+export interface WindowLike {
+  isDestroyed(): boolean
+  webContents: {
+    isDestroyed(): boolean
+    send(channel: string, payload?: unknown): void
+  }
+}
+
+export function makeSafeSend(
+  getWindow: () => WindowLike | null
+): (channel: string, payload?: unknown) => void {
+  return (channel, payload) => {
+    const w = getWindow()
+    // Order matters — short-circuit before touching `webContents` on a
+    // destroyed window, since accessing it then can itself throw.
+    if (!w || w.isDestroyed() || w.webContents.isDestroyed()) return
+    w.webContents.send(channel, payload)
+  }
+}

--- a/tasks.md
+++ b/tasks.md
@@ -28,9 +28,11 @@
 
 ---
 
-### BUG-189: Quit-loop crash — "Object has been destroyed" cycling dialog on app quit
+### BUG-190: Quit-loop crash — "Object has been destroyed" cycling dialog on app quit
 
 **Status:** 🟡 **Fix pushed `claude/duo-quit-loop-bug-OBZHB` 2026-05-27.** **Priority:** High (app un-quittable without force-quit). **Effort:** ~30 min.
+
+> **Renumbered BUG-189 → BUG-190 (PR #61 review).** This PR opened before [ENH-189](#enh-189) ([#62](https://github.com/dudgeon/duo/pull/62)) landed on `main`; ENH-189 claimed the next-free id while #61 sat open. Same shared BUG/ENH counter, same collision pattern as the [ENH-187 → ENH-188 rename](#enh-188) the prior sprint; moved to the next free id, BUG-190.
 
 **Symptom (owner repro 2026-05-27).** Quitting Duo popped the Electron "A JavaScript error occurred in the main process" dialog — `TypeError: Object has been destroyed` at `webContents.send` inside a node-pty `onData` handler. Clicking OK re-popped it immediately; the dialog cycled and owner had to force-quit.
 

--- a/tasks.md
+++ b/tasks.md
@@ -40,7 +40,7 @@
 
 **Verification.** Reasoning + `npm run typecheck` clean. Not run in-app: this is a macOS-only Electron quit-time path and the fix landed in a Linux cloud container (no Electron, node-pty native rebuild unavailable). Owner smoke: launch Duo with a live terminal producing output, then ⌘Q — should quit cleanly with no error dialog.
 
-**Noted follow-up (not in this fix).** `electron/browser-manager.ts` has three still-unguarded `this.window.webContents.send` calls in the key-forward (1274/1405) and focus (1440) handlers. Lower severity — they fire on keyboard/focus events (one-shot, no buffered-data burst), so they can't reproduce the *loop*, at most a single dialog if they race quit. Left for a follow-up so this fix stays scoped to the reported crash.
+**Follow-up (now folded in, same PR).** `electron/browser-manager.ts` had three still-unguarded `this.window.webContents.send` calls in the key-forward (1274/1405) and focus (1440) handlers, plus a `this.window.webContents.focus()` (1397) that would also throw on a destroyed window. Lower severity — they fire on keyboard/focus events (one-shot, no buffered-data burst), so they couldn't reproduce the *loop*, at most a single dialog if they raced quit. Hardened with an early-return guard at the top of each handler (`this.window.isDestroyed() || this.window.webContents.isDestroyed()`) — matching the file's existing inline-guard convention plus the webContents check that was this bug's root cause.
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -28,6 +28,22 @@
 
 ---
 
+### BUG-189: Quit-loop crash — "Object has been destroyed" cycling dialog on app quit
+
+**Status:** 🟡 **Fix pushed `claude/duo-quit-loop-bug-OBZHB` 2026-05-27.** **Priority:** High (app un-quittable without force-quit). **Effort:** ~30 min.
+
+**Symptom (owner repro 2026-05-27).** Quitting Duo popped the Electron "A JavaScript error occurred in the main process" dialog — `TypeError: Object has been destroyed` at `webContents.send` inside a node-pty `onData` handler. Clicking OK re-popped it immediately; the dialog cycled and owner had to force-quit.
+
+**Root cause.** PtyManager forwards terminal output to the renderer through an EventSink adapter wired in `electron/main.ts` as `(channel, payload) => mainWindow?.webContents.send(...)`. The `?.` guards a *null* `mainWindow` but not a *destroyed* one. On quit, `before-quit` calls `ptyManager.dispose()` → `pty.kill()`, which makes node-pty flush a final burst of buffered output as `onData` events. Those fire after the window's `webContents` is torn down but before the `'closed'` handler nulls `mainWindow`, so each send throws "Object has been destroyed". The throw is uncaught (→ Electron's crash dialog), and because the buffered data keeps draining, every subsequent `onData` re-throws → the dialog loops. The same unguarded closure pattern existed in the socket-server EventSink, the BrowserManager state/tabs callbacks, and the nav-pins push — all async-driven, so all could race teardown the same way (the git-watch path had already grown a bespoke `webContents.isDestroyed()` guard, evidence this class had bitten before).
+
+**Fix.** Added a single `safeSend(channel, payload?)` helper in `electron/main.ts` that checks `mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed()` before sending, and routed every async-callback sink through it (PtyManager + socket-server EventSinks, BrowserManager state/tabs, nav-pins, claude-presence, git-watch — the last two had window-only / bespoke guards now consolidated onto the canonical path). No behavior change on the live path; sends mid-teardown become silent no-ops, which stops the throw and therefore the loop.
+
+**Verification.** Reasoning + `npm run typecheck` clean. Not run in-app: this is a macOS-only Electron quit-time path and the fix landed in a Linux cloud container (no Electron, node-pty native rebuild unavailable). Owner smoke: launch Duo with a live terminal producing output, then ⌘Q — should quit cleanly with no error dialog.
+
+**Noted follow-up (not in this fix).** `electron/browser-manager.ts` has three still-unguarded `this.window.webContents.send` calls in the key-forward (1274/1405) and focus (1440) handlers. Lower severity — they fire on keyboard/focus events (one-shot, no buffered-data burst), so they can't reproduce the *loop*, at most a single dialog if they race quit. Left for a follow-up so this fix stays scoped to the reported crash.
+
+---
+
 ### ENH-188: Terminal-tab context menu — parity with canvas tabs (reorder + close + copy cwd)
 
 **Status:** 🆕 **Filed + implemented 2026-05-27** (branch `claude/terminal-tabs-context-parity-2lh2X`). **Priority:** Medium (daily-driver ergonomics; the headline gap is "can't reorder terminal tabs"). **Effort:** ~1.5h.


### PR DESCRIPTION
## Summary

Quitting Duo popped the Electron **"A JavaScript error occurred in the main process"** dialog — `TypeError: Object has been destroyed` at `webContents.send` inside a node-pty `onData` handler — and the dialog **cycled**, forcing a force-quit.

**Root cause.** PtyManager forwards terminal output through an EventSink wired in `electron/main.ts` as `(channel, payload) => mainWindow?.webContents.send(...)`. The `?.` guards a *null* `mainWindow` but not a *destroyed* one. On quit, `before-quit` → `ptyManager.dispose()` → `pty.kill()` makes node-pty flush a final burst of buffered output as `onData` events. Those fire after the window's `webContents` is torn down but before the `'closed'` handler nulls `mainWindow`, so each send throws. The throw is uncaught (→ crash dialog), and because the buffered data keeps draining, every subsequent `onData` re-throws → the dialog loops.

The same unguarded closure pattern existed in the socket-server EventSink, the BrowserManager state/tabs callbacks, and the nav-pins push — all async-driven, so all could race teardown the same way (the git-watch path had already grown a bespoke `webContents.isDestroyed()` guard, evidence this class had bitten before).

> **Renumbered BUG-189 → BUG-190 (review ask).** This PR opened before [ENH-189](https://github.com/dudgeon/duo/pull/62) landed on `main`; ENH-189 claimed the next-free id in the shared BUG/ENH counter while #61 sat open. Same collision pattern as the ENH-187 → ENH-188 rename on #60. The earlier commits keep their original `BUG-189` prefixes as historical record; the final commit on this branch sweeps every code/doc reference to `BUG-190`.

## Changes

**Commit 1 — main EventSink path (the reported crash):**
- Add a `safeSend(channel, payload?)` helper in `electron/main.ts` guarding `mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed()`.
- Route every async-callback main→renderer sink through it: PtyManager + socket-server EventSinks, BrowserManager state/tabs, nav-pins, claude-presence, git-watch (the last two had window-only / bespoke guards, now consolidated onto the canonical path).

**Commit 2 — browser-view follow-up (hardening, same class):**
- `electron/browser-manager.ts` had three unguarded `this.window.webContents.send` calls in the key-forward (1274/1405) and focus (1440) handlers, plus a `webContents.focus()` (1397) that would also throw on a destroyed window. These are one-shot (no buffered burst) so they couldn't reproduce the *loop*, but a single crash dialog was still possible if they raced quit. Added an early-return guard (`this.window.isDestroyed() || this.window.webContents.isDestroyed()`) at the top of each handler.

**Commit 3 — regression tests (per review):**
- Extracted the pure window-guard logic to `electron/safe-send.ts` (`makeSafeSend(getWindow)` factory). `main.ts` now builds `safeSend` via `makeSafeSend(() => mainWindow)` — same call-site semantics, no behavior change.
- Added `electron/safe-send.test.ts` with 7 cases pinning: null window, destroyed window, destroyed webContents, **short-circuit-before-touching-webContents** (the specific defensive shape — accessing webContents on a torn-down window would itself throw), live-window send-through, undefined-payload pass-through, and window re-read on each call (so a workspace-driven window swap is reflected).

**Commit 4 — id collision sweep (rebase ask):**
- Rebased onto current `main` (ENH-189 #62 had landed). Renumbered `BUG-189` → `BUG-190` across `tasks.md` (heading + provenance blockquote citing the ENH-188 precedent), `CHANGELOG.md`, and code/test comments.

No behavior change on the live path; sends mid-teardown become silent no-ops, which stops the throw and therefore the loop.

Ledger: `tasks.md` BUG-190 + `CHANGELOG.md` (Unreleased → Fixed).

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npx vitest run` — full suite green (42 files / 831 tests), including the new 7-case `safe-send.test.ts`.
- [ ] **Owner smoke (macOS — couldn't run in the Linux cloud container):** launch Duo with a live terminal producing output, then ⌘Q → should quit cleanly with no error dialog.

https://claude.ai/code/session_01CtGCaQMxmtkLevANGJRaGM