### PR TITLE
docs(ENH-189): agent-agnostic Duo research — Claude Code + Codex

### DIFF
--- a/docs/research/agent-agnostic-duo.html
+++ b/docs/research/agent-agnostic-duo.html
@@ -1,0 +1,647 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="duo-open-in" content="browser">
+<meta name="duo-editable" content="false">
+<title>Agent-agnostic Duo — Claude Code + Codex</title>
+<style>
+/* ============================================================
+   Atelier CSS kernel (inlined verbatim — see
+   skill/references/duo-atelier.css)
+   ============================================================ */
+:root {
+  --paper: #fbf8f1;
+  --paper-deep: #f3ede0;
+  --paper-edge: #e8e0cb;
+  --paper-rule: #d9cea8;
+  --ink: #2b2620;
+  --ink-soft: #4a4238;
+  --ink-mute: #6f6557;
+  --ink-ghost: #9a9080;
+  --accent: #c46a1c;
+  --accent-soft: #f4d9b6;
+  --pass: #4a7d3e;
+  --fail: #b13e3a;
+  --warn: #b07527;
+  --code-bg: #2b2823;
+  --code-ink: #e8e0cb;
+  --project-pine:   #2E7D74;
+  --project-harbor: #3C6E93;
+  --project-iris:   #5B57A6;
+  --project-plum:   #87508F;
+  --project-rose:   #A4506A;
+  --project-moss:   #69763A;
+}
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0;
+  background: var(--paper); color: var(--ink);
+  font-family: -apple-system, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+  font-size: 14px; line-height: 1.55;
+}
+body { padding: 32px 40px 96px; max-width: 920px; margin: 0 auto; }
+header.page-head { border-bottom: 1px solid var(--paper-rule); padding-bottom: 16px; margin-bottom: 24px; }
+header.page-head h1 { font-family: "New York", "Iowan Old Style", Georgia, serif; font-style: italic; font-weight: 500; margin: 0 0 4px; font-size: 24px; }
+header.page-head .meta { color: var(--ink-mute); font-size: 13px; }
+header.page-head .meta .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; background: var(--accent-soft); color: var(--accent); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; margin-right: 6px; }
+.intro { background: var(--paper-deep); border: 1px solid var(--paper-rule); border-radius: 6px; padding: 14px 18px; margin-bottom: 28px; font-size: 13.5px; color: var(--ink-soft); }
+.intro strong { color: var(--ink); font-weight: 600; }
+h2 { font-family: "New York", "Iowan Old Style", Georgia, serif; font-weight: 600; margin: 36px 0 12px; font-size: 19px; border-bottom: 1px solid var(--paper-rule); padding-bottom: 6px; }
+h3 { font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; font-weight: 600; margin: 22px 0 8px; font-size: 15px; }
+h4 { margin: 16px 0 6px; font-size: 13.5px; }
+p { margin: 8px 0; }
+ul, ol { margin: 8px 0; padding-left: 24px; }
+li { margin: 4px 0; }
+code { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; background: var(--paper-deep); padding: 1px 5px; border-radius: 3px; }
+pre { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; line-height: 1.5; background: var(--code-bg); color: var(--code-ink); padding: 14px 16px; border-radius: 6px; overflow-x: auto; }
+pre code { background: transparent; padding: 0; color: inherit; font-size: inherit; }
+.decision-card { background: var(--paper-deep); border: 1.5px solid var(--paper-rule); border-radius: 6px; padding: 16px 18px; margin: 18px 0; }
+.decision-card .q-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--accent); margin: 0 0 6px; }
+.decision-card .q-prompt { font-family: "New York", "Iowan Old Style", Georgia, serif; font-weight: 500; font-size: 17px; color: var(--ink); margin: 0 0 12px; line-height: 1.35; }
+.decision-card .q-context { font-size: 13px; color: var(--ink-mute); margin: 0 0 14px; }
+.q-options { display: grid; grid-template-columns: 1fr; gap: 10px; margin: 0 0 12px; }
+.q-option { display: block; background: var(--paper); border: 1.5px solid var(--paper-rule); border-radius: 5px; padding: 10px 12px; cursor: pointer; transition: border-color 0.12s, background 0.12s; }
+.q-option:hover { border-color: var(--ink-ghost); }
+.q-option input[type="radio"] { margin-right: 8px; cursor: pointer; accent-color: var(--accent); }
+.q-option:has(input[type="radio"]:checked) { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 6%, var(--paper)); }
+.q-option-body { display: inline-block; vertical-align: top; width: calc(100% - 22px); }
+.q-option-title { font-weight: 600; font-size: 13.5px; color: var(--ink); margin: 0 0 3px; }
+.q-option-title .recommend-tag { font-size: 10px; background: var(--accent-soft); color: var(--accent); text-transform: uppercase; font-weight: 700; letter-spacing: 0.04em; padding: 1px 6px; border-radius: 8px; margin-left: 6px; }
+.q-option-rationale { font-size: 12px; color: var(--ink-soft); line-height: 1.45; margin: 3px 0 0; }
+.q-notes { width: 100%; background: var(--paper); border: 1px solid var(--paper-rule); border-radius: 4px; padding: 8px 10px; font-family: inherit; font-size: 12.5px; color: var(--ink); resize: vertical; min-height: 50px; }
+.q-notes:focus { outline: 1.5px solid var(--accent); }
+details.deferred { margin: 22px 0; padding: 12px 16px; background: var(--paper-deep); border: 1px dashed var(--paper-rule); border-radius: 6px; }
+details.deferred summary { cursor: pointer; font-weight: 600; color: var(--ink-soft); font-size: 13.5px; }
+details.deferred[open] summary { color: var(--ink); }
+details.deferred .deferred-body { margin-top: 12px; font-size: 13px; color: var(--ink-soft); }
+.copy-bar { position: sticky; bottom: 0; margin: 32px -40px -96px; padding: 16px 40px; background: color-mix(in srgb, var(--paper-deep) 96%, transparent); border-top: 1.5px solid var(--paper-rule); backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); display: flex; justify-content: space-between; align-items: center; gap: 16px; z-index: 50; }
+.copy-bar .copy-meta { font-size: 12.5px; color: var(--ink-soft); }
+.copy-bar #answered-count { color: var(--accent); font-weight: 700; }
+.copy-bar button { background: var(--accent); color: white; border: none; border-radius: 5px; padding: 9px 18px; font-family: inherit; font-size: 13.5px; font-weight: 600; cursor: pointer; transition: background 0.12s; }
+.copy-bar button:hover { background: color-mix(in srgb, black 8%, var(--accent)); }
+.copy-bar button.copied { background: var(--pass); }
+
+/* ============================================================
+   Per-playground patterns (authored after the kernel)
+   ============================================================ */
+
+/* — status badges for the touchpoint matrix — */
+.badge { display: inline-block; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; padding: 2px 7px; border-radius: 8px; white-space: nowrap; }
+.badge.works   { background: color-mix(in srgb, var(--pass) 18%, var(--paper)); color: var(--pass); }
+.badge.noop    { background: color-mix(in srgb, var(--project-harbor) 18%, var(--paper)); color: var(--project-harbor); }
+.badge.breaks  { background: color-mix(in srgb, var(--fail) 16%, var(--paper)); color: var(--fail); }
+.badge.general { background: color-mix(in srgb, var(--warn) 20%, var(--paper)); color: var(--warn); }
+
+/* — legend / filter chips — */
+.filter-row { display: flex; flex-wrap: wrap; gap: 8px; margin: 14px 0 6px; }
+.filter-row button { background: var(--paper); border: 1.5px solid var(--paper-rule); border-radius: 14px; padding: 5px 13px; font-family: inherit; font-size: 12px; font-weight: 600; color: var(--ink-soft); cursor: pointer; transition: all 0.12s; }
+.filter-row button:hover { border-color: var(--ink-ghost); }
+.filter-row button.active { background: var(--ink); border-color: var(--ink); color: var(--paper); }
+
+/* — touchpoint matrix — */
+.matrix { display: grid; grid-template-columns: 1fr; gap: 8px; margin: 12px 0; }
+.tp { display: grid; grid-template-columns: 92px 1fr; gap: 12px; align-items: start; background: var(--paper-deep); border: 1px solid var(--paper-rule); border-radius: 6px; padding: 11px 14px; }
+.tp.hide { display: none; }
+.tp-status { padding-top: 1px; }
+.tp-name { font-weight: 600; font-size: 13px; margin: 0 0 2px; }
+.tp-impact { font-size: 12px; color: var(--ink-soft); margin: 0 0 4px; }
+.tp-loc { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10.5px; color: var(--ink-mute); }
+
+/* — comparison table — */
+table.cmp { width: 100%; border-collapse: collapse; margin: 14px 0; font-size: 12.5px; }
+table.cmp th, table.cmp td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--paper-rule); vertical-align: top; }
+table.cmp thead th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--ink-mute); border-bottom: 1.5px solid var(--paper-rule); }
+table.cmp td.dim { color: var(--ink-mute); }
+table.cmp .yes { color: var(--pass); font-weight: 700; }
+table.cmp .no  { color: var(--fail); font-weight: 700; }
+table.cmp .meh { color: var(--warn); font-weight: 700; }
+table.cmp tbody tr:hover { background: color-mix(in srgb, var(--accent) 4%, transparent); }
+table.cmp .feat { font-weight: 600; color: var(--ink); }
+
+/* — cost pips on each option — */
+.cost { display: inline-flex; gap: 14px; margin-top: 6px; font-size: 10.5px; color: var(--ink-mute); text-transform: uppercase; letter-spacing: 0.03em; font-weight: 600; }
+.cost .pips { letter-spacing: 1px; }
+.cost .up { color: var(--accent); }
+.cost .on { color: var(--project-iris); }
+
+/* — mockup frames — */
+.mock { background: #1d1b17; border: 1px solid var(--paper-rule); border-radius: 8px; padding: 16px; margin: 14px 0; }
+.mock-cap { font-size: 11.5px; color: var(--ink-mute); margin: 4px 0 0; font-style: italic; }
+.mockrow { display: flex; flex-wrap: wrap; gap: 18px; align-items: flex-start; }
+.mockcol { flex: 1; min-width: 220px; }
+
+/* faux Duo tab strip */
+.tabstrip { display: flex; gap: 2px; background: #26231d; border-radius: 6px 6px 0 0; padding: 6px 6px 0; font-size: 12px; }
+.ftab { display: flex; align-items: center; gap: 6px; padding: 7px 12px; border-radius: 6px 6px 0 0; color: #cabfa9; background: #322d25; }
+.ftab.active { background: var(--paper); color: var(--ink); }
+.ftab .dot { width: 7px; height: 7px; border-radius: 2px; display: inline-block; }
+.ftab .x { color: #8a8170; margin-left: 2px; }
+.tabadd { padding: 7px 10px; color: #cabfa9; background: #322d25; border-radius: 6px 6px 0 0; font-weight: 700; }
+
+/* faux new-tab dropdown */
+.ddmenu { margin-top: 6px; width: 210px; background: var(--paper); border: 1px solid var(--paper-rule); border-radius: 7px; overflow: hidden; box-shadow: 0 6px 20px rgba(0,0,0,0.25); }
+.ddmenu .item { display: flex; align-items: center; gap: 9px; padding: 9px 12px; font-size: 12.5px; color: var(--ink); border-bottom: 1px solid var(--paper-edge); }
+.ddmenu .item:last-child { border-bottom: none; }
+.ddmenu .item .kbd { margin-left: auto; font-family: ui-monospace, Menlo, monospace; font-size: 10.5px; color: var(--ink-ghost); }
+.ddmenu .item .ic { width: 16px; text-align: center; }
+.ddmenu .item.new { color: var(--accent); font-weight: 600; }
+
+/* faux send pill */
+.pillbar { display: flex; gap: 10px; align-items: center; background: #26231d; border-radius: 0 0 6px 6px; padding: 10px 12px; }
+.spill { display: inline-flex; align-items: center; gap: 7px; padding: 6px 13px; border-radius: 16px; font-size: 12px; font-weight: 600; }
+.spill.live { background: var(--accent); color: #fff; }
+.spill.off { background: #3a352c; color: #8a8170; }
+.spill.codex { background: #1f6f5c; color: #fff; }
+.spill .led { width: 7px; height: 7px; border-radius: 50%; background: currentColor; opacity: 0.9; }
+
+/* faux navigator pane */
+.navpane { background: var(--paper); border: 1px solid var(--paper-rule); border-radius: 7px; padding: 8px 0; font-size: 12.5px; min-width: 230px; }
+.navpane .nrow { display: flex; align-items: center; gap: 8px; padding: 5px 14px; }
+.navpane .nrow.head { font-weight: 700; color: var(--ink-mute); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.04em; }
+.navpane .nrow .ic { width: 14px; text-align: center; color: var(--ink-mute); }
+.navpane .nrow.child { padding-left: 30px; color: var(--ink-soft); }
+
+/* onboarding lane cards */
+.lanes { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); gap: 10px; margin: 12px 0; }
+.lane { background: var(--paper-deep); border: 1px solid var(--paper-rule); border-radius: 6px; padding: 12px 13px; }
+.lane h4 { margin: 0 0 6px; font-size: 12.5px; }
+.lane.dur { border-color: var(--pass); border-width: 1.5px; }
+.lane p { font-size: 11.5px; color: var(--ink-soft); margin: 4px 0 0; }
+.lane .tag { font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; padding: 1px 6px; border-radius: 7px; }
+.lane .tag.good { background: color-mix(in srgb, var(--pass) 18%, var(--paper)); color: var(--pass); }
+.lane .tag.warn { background: color-mix(in srgb, var(--warn) 20%, var(--paper)); color: var(--warn); }
+
+/* SVG figure wrapper */
+.fig { background: var(--paper-deep); border: 1px solid var(--paper-rule); border-radius: 8px; padding: 16px; margin: 16px 0; }
+.fig svg { display: block; width: 100%; height: auto; }
+.fig figcaption { font-size: 11.5px; color: var(--ink-mute); margin-top: 10px; font-style: italic; }
+
+/* general comments block */
+.general-comments { margin: 24px 0 8px; }
+.general-comments textarea { width: 100%; background: var(--paper); border: 1.5px solid var(--paper-rule); border-radius: 6px; padding: 10px 12px; font-family: inherit; font-size: 13px; color: var(--ink); resize: vertical; min-height: 80px; }
+.general-comments textarea:focus { outline: 1.5px solid var(--accent); }
+
+.tl-note { font-size: 12px; color: var(--ink-mute); margin: 6px 0 0; }
+.keyline { background: color-mix(in srgb, var(--accent) 8%, var(--paper-deep)); border-left: 3px solid var(--accent); border-radius: 0 6px 6px 0; padding: 12px 16px; margin: 16px 0; font-size: 13px; }
+.keyline strong { color: var(--ink); }
+</style>
+</head>
+<body>
+
+<header class="page-head">
+  <h1>Agent-agnostic Duo — Claude Code + Codex</h1>
+  <div class="meta">
+    <span class="pill">RESEARCH</span>
+    <span class="pill">ENH-189</span>
+    Max-effort research sprint · 2026-05-27 · branch <code>claude/duo-agent-agnostic-research-9y1t3</code>
+  </div>
+</header>
+
+<div class="intro">
+  <strong>What this is.</strong> A decision-bearing audit of every place Duo is wired to
+  Claude Code, scored for what would happen under OpenAI's Codex CLI —
+  <strong>works</strong>, <strong>no-ops</strong>, or <strong>breaks</strong> — with options for each,
+  weighed by <em>upfront build</em> vs <em>ongoing maintenance</em>. The headline:
+  Duo's bridge is already ~90% harness-neutral; the coupling is a thin lifecycle skin.
+  Answer the decision cards and hit <em>Copy decisions</em> at the bottom to round-trip back to Claude.
+</div>
+
+<div class="keyline">
+  <strong>The one-sentence thesis.</strong> The <code>duo</code> CLI + socket bridge are agent-neutral and
+  work with Codex <em>today</em> — what doesn't port is (1) <em>teaching</em> the agent that <code>duo</code> exists
+  and (2) a handful of <em>lifecycle</em> features that read Claude's private on-disk state or shell its private flags.
+  The cheap, durable play is to parameterize the launch/presence/marker layer and degrade the rest gracefully —
+  while treating <strong>MCP</strong> (the one extension surface both harnesses share) as the long-term, drift-proof spine.
+</div>
+
+<h2>1 · The architecture in three rings</h2>
+
+<p>Every Claude-Code touchpoint falls into one of three concentric rings. The further out, the more
+Claude-specific — and the more it breaks under Codex.</p>
+
+<div class="fig">
+<svg viewBox="0 0 700 360" role="img" aria-label="Three concentric rings: core bridge works, onboarding no-ops, lifecycle breaks">
+  <!-- rings -->
+  <ellipse cx="230" cy="180" rx="200" ry="150" fill="color-mix(in srgb, #b13e3a 8%, #fbf8f1)" stroke="#b13e3a" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <ellipse cx="230" cy="180" rx="140" ry="108" fill="color-mix(in srgb, #3C6E93 10%, #fbf8f1)" stroke="#3C6E93" stroke-width="1.5"/>
+  <ellipse cx="230" cy="180" rx="80" ry="62" fill="color-mix(in srgb, #4a7d3e 16%, #fbf8f1)" stroke="#4a7d3e" stroke-width="2"/>
+  <!-- labels in rings -->
+  <text x="230" y="172" text-anchor="middle" font-family="system-ui" font-size="13" font-weight="700" fill="#3a6330">CORE BRIDGE</text>
+  <text x="230" y="190" text-anchor="middle" font-family="system-ui" font-size="10.5" fill="#3a6330">socket + ~100 verbs</text>
+  <text x="230" y="204" text-anchor="middle" font-family="system-ui" font-size="10" font-weight="700" fill="#4a7d3e">WORKS</text>
+
+  <text x="230" y="96" text-anchor="middle" font-family="system-ui" font-size="12" font-weight="700" fill="#2f567a">ONBOARDING</text>
+  <text x="230" y="111" text-anchor="middle" font-family="system-ui" font-size="9.5" fill="#2f567a">skill · agent · hook</text>
+  <text x="230" y="124" text-anchor="middle" font-family="system-ui" font-size="9.5" font-weight="700" fill="#3C6E93">NO-OP</text>
+
+  <text x="230" y="50" text-anchor="middle" font-family="system-ui" font-size="12" font-weight="700" fill="#9c3531">LIFECYCLE</text>
+  <text x="230" y="64" text-anchor="middle" font-family="system-ui" font-size="9.5" fill="#9c3531">launch · pill · resume · panes</text>
+  <text x="230" y="77" text-anchor="middle" font-family="system-ui" font-size="9.5" font-weight="700" fill="#b13e3a">BREAKS</text>
+
+  <!-- right-side callouts -->
+  <line x1="430" y1="180" x2="478" y2="180" stroke="#4a7d3e" stroke-width="1"/>
+  <text x="484" y="176" font-family="system-ui" font-size="11" font-weight="700" fill="#3a6330">Ring 1 — Codex calls these identically</text>
+  <text x="484" y="190" font-family="system-ui" font-size="10.5" fill="#6f6557">Transport is JSON-RPC; verbs are generic.</text>
+
+  <line x1="370" y1="100" x2="478" y2="100" stroke="#3C6E93" stroke-width="1"/>
+  <text x="484" y="96" font-family="system-ui" font-size="11" font-weight="700" fill="#2f567a">Ring 2 — silent absence</text>
+  <text x="484" y="110" font-family="system-ui" font-size="10.5" fill="#6f6557">Codex never reads the skill, so it</text>
+  <text x="484" y="123" font-family="system-ui" font-size="10.5" fill="#6f6557">doesn't <tspan font-style="italic">know</tspan> duo exists. Nothing errors.</text>
+
+  <line x1="340" y1="52" x2="478" y2="52" stroke="#b13e3a" stroke-width="1"/>
+  <text x="484" y="48" font-family="system-ui" font-size="11" font-weight="700" fill="#9c3531">Ring 3 — false signals</text>
+  <text x="484" y="62" font-family="system-ui" font-size="10.5" fill="#6f6557">Pill stuck off, resume never offered,</text>
+  <text x="484" y="75" font-family="system-ui" font-size="10.5" fill="#6f6557">doctor shows red, wrong config pane.</text>
+
+  <text x="484" y="300" font-family="system-ui" font-size="10.5" font-style="italic" fill="#9a9080">Value concentrates in Ring 1 (free under Codex).</text>
+  <text x="484" y="315" font-family="system-ui" font-size="10.5" font-style="italic" fill="#9a9080">Cost concentrates in Ring 3.</text>
+</svg>
+<figcaption>Figure 1 — The coupling is a thin skin. The browser/editor/canvas value lives in the green core, which is already agent-neutral.</figcaption>
+</div>
+
+<h2>2 · Touchpoint inventory — works / no-op / breaks</h2>
+
+<p>Every Claude-specific touchpoint found in the codebase, scored for Codex. Filter by verdict:</p>
+
+<div class="filter-row" id="filters">
+  <button data-f="all" class="active">All (19)</button>
+  <button data-f="works">✓ Works (4)</button>
+  <button data-f="noop">No-op (5)</button>
+  <button data-f="breaks">Breaks (8)</button>
+  <button data-f="general">Generalizable (2)</button>
+</div>
+
+<div class="matrix" id="matrix">
+  <!-- WORKS -->
+  <div class="tp" data-cat="works"><div class="tp-status"><span class="badge works">Works</span></div><div><div class="tp-name">Socket protocol (JSON-RPC)</div><div class="tp-impact">Generic <code>{id,cmd,args}</code> → <code>{id,ok,result}</code>. No agent concept in the frame. Codex over the same socket is byte-identical.</div><div class="tp-loc">shared/types.ts · DuoRequest/DuoResponse</div></div></div>
+  <div class="tp" data-cat="works"><div class="tp-status"><span class="badge works">Works</span></div><div><div class="tp-name">~100 <code>duo</code> verbs (browser / editor / canvas / file / layout / git / project / events)</div><div class="tp-impact">navigate, click, fill, dom, ax, screenshot, doc&nbsp;read/write, html&nbsp;*, split, theme, project&nbsp;* … all pure renderer/CDP ops. No Claude check in any dispatch branch.</div><div class="tp-loc">cli/duo.ts · core/socket-server.ts (switch cmd)</div></div></div>
+  <div class="tp" data-cat="works"><div class="tp-status"><span class="badge works">Works</span></div><div><div class="tp-name">PTY environment injection</div><div class="tp-impact"><code>DUO_SESSION</code>, <code>DUO_SOCKET</code>, <code>DUO_VERSION</code>, <code>TERM_PROGRAM=Duo</code> are set by Duo's pty pool regardless of which agent runs inside. Codex inherits them.</div><div class="tp-loc">core/pty-manager.ts:44–51</div></div></div>
+  <div class="tp" data-cat="works"><div class="tp-status"><span class="badge works">Works</span></div><div><div class="tp-name">CLI transport (Unix socket + TCP fallback)</div><div class="tp-impact">Connection + retry + sandbox-tolerant fallback are agent-agnostic. The <code>duo</code> binary doesn't care who invokes it.</div><div class="tp-loc">cli/duo.ts (transport)</div></div></div>
+
+  <!-- NO-OP -->
+  <div class="tp" data-cat="noop"><div class="tp-status"><span class="badge noop">No-op</span></div><div><div class="tp-name">The skill (<code>~/.claude/skills/duo/SKILL.md</code>)</div><div class="tp-impact"><strong>The important one.</strong> Codex has no "skills" concept and never loads it → the agent never learns <code>duo</code> exists. The bridge works; nobody told the agent. Silent, not an error.</div><div class="tp-loc">skill/SKILL.md → synced via npm run sync:claude</div></div></div>
+  <div class="tp" data-cat="noop"><div class="tp-status"><span class="badge noop">No-op</span></div><div><div class="tp-name">The subagent (<code>~/.claude/agents/duo.md</code>)</div><div class="tp-impact">Codex has no subagent/delegation primitive. The "delegate Duo round-trips to Haiku" optimization simply doesn't exist; Codex would run verbs inline.</div><div class="tp-loc">agents/duo.md (model: haiku, tools: Bash)</div></div></div>
+  <div class="tp" data-cat="noop"><div class="tp-status"><span class="badge noop">No-op</span></div><div><div class="tp-name">SessionStart hook priming</div><div class="tp-impact">The settings.json SessionStart hook that <code>cat</code>s priming.md is a Claude Code feature. Codex never fires it. (It's the safety-net behind the shim — see "priming shim" under Breaks.)</div><div class="tp-loc">shared/host-api.ts (PrimingInstallStatus)</div></div></div>
+  <div class="tp" data-cat="noop"><div class="tp-status"><span class="badge noop">No-op</span></div><div><div class="tp-name"><code>duo claude-return</code> / <code>shift-return</code></div><div class="tp-impact">Toggles Claude-tab Enter-vs-newline behavior — a quirk of Claude's TUI. Inert/meaningless for a Codex tab; the verbs would just no-op against a non-Claude flavor.</div><div class="tp-loc">cli/duo.ts:680–713 · socket-server (ClaudeKeyPrefs)</div></div></div>
+  <div class="tp" data-cat="noop"><div class="tp-status"><span class="badge noop">No-op</span></div><div><div class="tp-name">Author attribution default (<code>DUO_AUTHOR</code>)</div><div class="tp-impact">CriticMarkup marks default to author <code>claude</code> when the env var is unset. Cosmetic only — a Codex edit would be mislabeled "claude," not broken. Already env-overridable today.</div><div class="tp-loc">cli/duo.ts (DUO_AUTHOR) · socket-server author</div></div></div>
+
+  <!-- BREAKS -->
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name">First-class launch — tab <code>kind:'claude'</code> auto-types <code>claude\n</code></div><div class="tp-impact">The tab-kind enum is <code>'shell' | 'claude'</code>. There's no <code>codex</code> kind, no <code>--codex</code> flag, and the launcher hard-types <code>claude</code>. You can't open Codex as a first-class tab.</div><div class="tp-loc">renderer/App.tsx ~1463 · shared/types.ts (TerminalTabKind)</div></div></div>
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name">Priming shim — <code>~/.claude/duo/bin/claude</code> → <code>--append-system-prompt</code></div><div class="tp-impact"><strong>The hardest gap.</strong> The load-bearing priming injects <code>--append-system-prompt "$(cat priming.md)"</code>. <em>Codex has no per-session system-prompt-append flag.</em> A <code>codex</code> shim has nowhere to inject. Priming doesn't port cleanly.</div><div class="tp-loc">electron/install-service.ts (shim, ~862–879)</div></div></div>
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name">Presence pill — process basename must equal <code>claude</code></div><div class="tp-impact"><code>hasClaudeDescendant()</code> BFS-matches a process named <code>claude</code>. A <code>codex</code> process never matches → pill stuck on "shell" → the "Send to Duo" gating thinks no agent is live.</div><div class="tp-loc">core/claude-presence.ts:143</div></div></div>
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name">Session capture — scans <code>~/.claude/projects/&lt;enc-cwd&gt;/*.jsonl</code></div><div class="tp-impact">Codex stores at <code>~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl</code> — <em>date-indexed, not cwd-indexed</em>, different schema. The cwd scan returns null → <code>lastClaudeSession</code> always null → resume pills never appear for a Codex tab.</div><div class="tp-loc">electron/claude-session-tracker.ts:75</div></div></div>
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name">Session resume — writes <code>claude --resume &lt;uuid&gt;</code></div><div class="tp-impact">Hard-coded binary + flag + UUID format. Codex resumes with <code>codex resume &lt;id&gt;</code> / <code>--last</code> and a different id shape. Wrong on all three axes.</div><div class="tp-loc">electron/main.ts:677</div></div></div>
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name">Banner title + message count — parse Claude JSONL schema</div><div class="tp-impact">Reads <code>custom-title</code>/<code>ai-title</code>/<code>user</code> entry types + counts <code>user</code> turns. Codex rollout events use a different schema. (Only reached if capture worked — which it doesn't.)</div><div class="tp-loc">electron/claude-session-tracker.ts:139–198</div></div></div>
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name">Binary resolution — <code>resolveClaudeBinary()</code> looks for <code>claude</code></div><div class="tp-impact">Walks well-known dirs for a file named <code>claude</code>; gates the install banner + auto-type decision. No Codex equivalent → install/launch logic misfires for a Codex-only user.</div><div class="tp-loc">core/resolve-claude.ts (~104)</div></div></div>
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name"><code>duo doctor</code> — checks skill + agent files exist</div><div class="tp-impact">Asserts <code>~/.claude/skills/duo/SKILL.md</code> and <code>~/.claude/agents/duo.md</code>. A Codex-only user sees ✗ red rows — a false failure that reads as "Duo is broken."</div><div class="tp-loc">cli/duo.ts (~1881)</div></div></div>
+  <div class="tp" data-cat="breaks"><div class="tp-status"><span class="badge breaks">Breaks</span></div><div><div class="tp-name">UserClaudePane — the <code>~/.claude</code> navigator</div><div class="tp-impact">Hard-codes <code>~/.claude/{CLAUDE.md, skills, agents}</code> as a curated config surface. A Codex user sees Claude's config (irrelevant to them) or an empty pane, never <code>~/.codex</code>.</div><div class="tp-loc">renderer/hooks/useUserClaudeNavigator.ts:57,118 · UserClaudePane.tsx</div></div></div>
+
+  <!-- GENERALIZABLE -->
+  <div class="tp" data-cat="general"><div class="tp-status"><span class="badge general">General</span></div><div><div class="tp-name">Project marker — <code>CLAUDE.md</code> or <code>.claude/</code></div><div class="tp-impact">The qualification <em>algorithm</em> (git-root OR marker) is already agent-neutral; only the marker <em>names</em> are Claude-ish. Add <code>AGENTS.md</code> / <code>.codex/</code> to the set and it generalizes for free.</div><div class="tp-loc">core/projects-service.ts:107 · shared/projects.ts:214</div></div></div>
+  <div class="tp" data-cat="general"><div class="tp-status"><span class="badge general">General</span></div><div><div class="tp-name">Author identity (<code>duo author</code> + <code>DUO_AUTHOR</code>)</div><div class="tp-impact">Already a generic string channel; just needs the default to derive from the active harness ("codex") instead of literal "claude."</div><div class="tp-loc">cli/duo.ts · socket-server (author)</div></div></div>
+</div>
+
+<h2>3 · Why it's asymmetric — Claude Code vs Codex extension surfaces</h2>
+
+<p>The cost isn't symmetric because the two harnesses give Duo very different hooks. Claude Code offers
+<em>three</em> ways to inject context (skill, hook, <code>--append-system-prompt</code>); Codex offers
+essentially one clean <em>shared</em> one (MCP), one repo-invasive one (<code>AGENTS.md</code>), and an opt-in slash prompt.</p>
+
+<table class="cmp">
+  <thead><tr><th>Concept</th><th>Claude Code</th><th>Codex CLI</th><th>Implication for Duo</th></tr></thead>
+  <tbody>
+    <tr><td class="feat">Binary</td><td><code>claude</code></td><td><code>codex</code></td><td class="dim">Parameterize launch / presence / resolve.</td></tr>
+    <tr><td class="feat">Resume</td><td><code>claude --resume &lt;uuid&gt;</code></td><td><code>codex resume &lt;id&gt;</code> · <code>--last</code></td><td class="dim">Different verb + id shape.</td></tr>
+    <tr><td class="feat">Project instructions</td><td><code>CLAUDE.md</code></td><td><code>AGENTS.md</code> (+ overrides)</td><td class="dim">Add to marker set — cheap.</td></tr>
+    <tr><td class="feat">Home config dir</td><td><code>~/.claude/</code></td><td><code>~/.codex/</code></td><td class="dim">Navigator pane + path assumptions.</td></tr>
+    <tr><td class="feat">Session storage</td><td><code>~/.claude/projects/&lt;enc-cwd&gt;/&lt;uuid&gt;.jsonl</code><br><span class="dim">cwd-indexed</span></td><td><code>~/.codex/sessions/Y/M/D/rollout-*.jsonl</code><br><span class="dim">date-indexed, NOT cwd</span></td><td class="dim"><strong>Structurally different.</strong> Can't map cwd→sessions by path; must read rollout metadata or call <code>codex resume</code>.</td></tr>
+    <tr><td class="feat">Ephemeral system-prompt inject</td><td class="yes">✓ <code>--append-system-prompt</code></td><td class="no">✗ none<br><span class="dim">(model_instructions_file <em>replaces</em>)</span></td><td class="dim"><strong>Priming's hardest gap.</strong> No per-session append channel.</td></tr>
+    <tr><td class="feat">Skills (progressive disclosure)</td><td class="yes">✓ <code>~/.claude/skills/</code></td><td class="no">✗ none</td><td class="dim">Teaching mechanism must change for Codex.</td></tr>
+    <tr><td class="feat">Subagents</td><td class="yes">✓ <code>~/.claude/agents/</code></td><td class="no">✗ none</td><td class="dim">Delegation optimization unavailable.</td></tr>
+    <tr><td class="feat">Lifecycle hooks</td><td class="yes">✓ SessionStart (settings.json)</td><td class="no">✗ none equivalent</td><td class="dim">Priming safety-net unavailable.</td></tr>
+    <tr><td class="feat">Custom prompts</td><td>skills / slash</td><td class="meh">≈ <code>~/.codex/prompts/*.md</code><br><span class="dim">slash, frontmatter, $ARGS</span></td><td class="dim">A discoverable, opt-in teaching channel.</td></tr>
+    <tr><td class="feat">MCP servers</td><td class="yes">✓ supported</td><td class="yes">✓ <code>~/.codex/config.toml</code></td><td class="dim"><strong>The one shared, self-describing, public contract.</strong></td></tr>
+  </tbody>
+</table>
+
+<div class="keyline">
+  <strong>Maintenance-burden law.</strong> Anything that reads another tool's <em>private file format</em>
+  (the rollout JSONL schema) or shells its <em>private flags</em> (<code>--append-system-prompt</code>) is a
+  standing drift liability — it breaks silently on the next upstream release. Anything that rides a
+  <em>public contract</em> (a documented subcommand like <code>codex resume --last</code>, an env var, or MCP)
+  is durable. Every option below is graded on which side of that line it sits.
+</div>
+
+<h2>4 · The cost landscape</h2>
+
+<p>Plotting each approach by <em>upfront build</em> (x) against <em>ongoing maintenance</em> (y) sorts them into
+four quadrants. The recommended near-term moves cluster in the cheap-and-durable corner; the strategic bet (MCP)
+trades upfront cost for near-zero drift; the things to <em>avoid</em> sit in the high-drift top band.</p>
+
+<div class="fig">
+<svg viewBox="0 0 700 470" role="img" aria-label="Scatter plot of approaches by upfront cost versus ongoing maintenance">
+  <!-- quadrant tints -->
+  <rect x="70" y="40" width="280" height="180" fill="color-mix(in srgb, #b07527 9%, #fbf8f1)"/>
+  <rect x="350" y="40" width="280" height="180" fill="color-mix(in srgb, #b13e3a 8%, #fbf8f1)"/>
+  <rect x="70" y="220" width="280" height="180" fill="color-mix(in srgb, #4a7d3e 12%, #fbf8f1)"/>
+  <rect x="350" y="220" width="280" height="180" fill="color-mix(in srgb, #3C6E93 9%, #fbf8f1)"/>
+  <!-- axes -->
+  <line x1="70" y1="40" x2="70" y2="400" stroke="#9a9080" stroke-width="1.5"/>
+  <line x1="70" y1="400" x2="630" y2="400" stroke="#9a9080" stroke-width="1.5"/>
+  <text x="350" y="438" text-anchor="middle" font-family="system-ui" font-size="12" font-weight="700" fill="#4a4238">UPFRONT BUILD COST →</text>
+  <text x="28" y="220" text-anchor="middle" font-family="system-ui" font-size="12" font-weight="700" fill="#4a4238" transform="rotate(-90 28 220)">ONGOING MAINTENANCE →</text>
+  <!-- quadrant labels -->
+  <text x="80" y="58" font-family="system-ui" font-size="10.5" font-weight="700" fill="#9a6a1f">CHEAP BUT DRIFTS ⚠</text>
+  <text x="620" y="58" text-anchor="end" font-family="system-ui" font-size="10.5" font-weight="700" fill="#9c3531">COSTLY &amp; DRIFTS ✗</text>
+  <text x="80" y="392" font-family="system-ui" font-size="10.5" font-weight="700" fill="#3a6330">CHEAP &amp; DURABLE ✓</text>
+  <text x="620" y="392" text-anchor="end" font-family="system-ui" font-size="10.5" font-weight="700" fill="#2f567a">INVEST ONCE, DURABLE</text>
+
+  <!-- points: cx,cy by (upfront,ongoing). x:70..630 maps 0..100; y:400(low)..40(high) -->
+  <!-- core bridge (already done) ~ (5,5) -->
+  <circle cx="98" cy="382" r="7" fill="#4a7d3e"/>
+  <text x="110" y="386" font-family="system-ui" font-size="10.5" fill="#2b2620">Core bridge (free — works today)</text>
+  <!-- graceful degrade lifecycle (15,8) -->
+  <circle cx="154" cy="371" r="7" fill="#4a7d3e"/>
+  <text x="166" y="375" font-family="system-ui" font-size="10.5" fill="#2b2620">Degrade lifecycle on Codex</text>
+  <!-- /duo slash prompt (18,12) -->
+  <circle cx="171" cy="357" r="7" fill="#4a7d3e"/>
+  <text x="183" y="361" font-family="system-ui" font-size="10.5" fill="#2b2620">Ship <tspan font-family="monospace">/duo</tspan> Codex prompt</text>
+  <!-- cheap params: kind+presence+marker (24,16) -->
+  <circle cx="204" cy="343" r="7" fill="#4a7d3e"/>
+  <text x="216" y="347" font-family="system-ui" font-size="10.5" fill="#2b2620">Add codex kind + presence + marker</text>
+  <!-- codex resume --last action (28,22) -->
+  <circle cx="227" cy="322" r="7" fill="#4a7d3e"/>
+  <text x="239" y="326" font-family="system-ui" font-size="10.5" fill="#2b2620">"Resume last" via <tspan font-family="monospace">codex resume --last</tspan></text>
+  <!-- two-adapter abstraction (52,46) -->
+  <circle cx="361" cy="234" r="7" fill="#3C6E93"/>
+  <text x="373" y="238" font-family="system-ui" font-size="10.5" fill="#2b2620">Two-adapter HarnessAdapter</text>
+  <!-- MCP server (70,24) — INVEST ONCE -->
+  <circle cx="462" cy="314" r="9" fill="#3C6E93" stroke="#2b2620" stroke-width="1.5"/>
+  <text x="475" y="312" font-family="system-ui" font-size="10.5" font-weight="700" fill="#2b2620">Duo-as-MCP-server</text>
+  <text x="475" y="325" font-family="system-ui" font-size="9.5" font-style="italic" fill="#6f6557">the durable spine</text>
+  <!-- AGENTS.md auto-inject (30,74) — drift -->
+  <circle cx="238" cy="122" r="7" fill="#b07527"/>
+  <text x="250" y="126" font-family="system-ui" font-size="10.5" fill="#2b2620">Auto-merge AGENTS.md (repo-invasive)</text>
+  <!-- codex session JSONL parser (46,80) — drift -->
+  <circle cx="328" cy="100" r="7" fill="#b07527"/>
+  <text x="200" y="90" text-anchor="end" font-family="system-ui" font-size="10.5" fill="#2b2620">Parse rollout JSONL + rebuild resume list</text>
+  <line x1="205" y1="86" x2="322" y2="98" stroke="#b07527" stroke-width="0.8"/>
+  <!-- pluggable registry (90,90) -->
+  <circle cx="574" cy="58" r="7" fill="#b13e3a"/>
+  <text x="566" y="62" text-anchor="end" font-family="system-ui" font-size="10.5" fill="#2b2620">Pluggable harness registry (community plugins)</text>
+</svg>
+<figcaption>Figure 2 — Green = recommended near-term (cheap &amp; durable). Blue = strategic (invest once, low drift). Amber/red = high ongoing tax; reach for only if parity is a hard requirement.</figcaption>
+</div>
+
+<h2>5 · Mockups — the UI decisions</h2>
+
+<h3>5a · Launching Codex as a first-class tab</h3>
+<div class="mock">
+  <div class="tabstrip">
+    <div class="ftab active"><span class="dot" style="background:var(--accent)"></span> claude · duo <span class="x">×</span></div>
+    <div class="ftab"><span class="dot" style="background:var(--project-pine)"></span> codex · api <span class="x">×</span></div>
+    <div class="ftab"><span class="dot" style="background:var(--ink-ghost)"></span> zsh <span class="x">×</span></div>
+    <div class="tabadd">+</div>
+  </div>
+  <div style="display:flex;justify-content:flex-end"><div class="ddmenu">
+    <div class="item"><span class="ic">›_</span> New shell <span class="kbd">⌘T</span></div>
+    <div class="item"><span class="ic">✶</span> New Claude tab <span class="kbd">⌘⇧T</span></div>
+    <div class="item new"><span class="ic">◆</span> New Codex tab <span class="kbd">⌥⌘T</span></div>
+  </div></div>
+  <p class="mock-cap">New-tab split menu gains a third option; tab labels read <code>codex · &lt;cwd&gt;</code> with a per-harness dot color. (Decision D4 picks whether this is a new enum value or a generalized <code>kind:'agent'</code>.)</p>
+</div>
+
+<h3>5b · The presence pill for a Codex tab</h3>
+<div class="mock">
+  <div class="mockrow">
+    <div class="mockcol">
+      <div class="pillbar"><span class="spill live"><span class="led"></span> Send to Claude</span></div>
+      <p class="mock-cap">Today — Claude tab, live.</p>
+    </div>
+    <div class="mockcol">
+      <div class="pillbar"><span class="spill off"><span class="led"></span> Send to Duo</span></div>
+      <p class="mock-cap">Codex tab <em>today</em> — pill stuck off (codex never matches the presence probe). Broken.</p>
+    </div>
+    <div class="mockcol">
+      <div class="pillbar"><span class="spill codex"><span class="led"></span> Send to Codex</span></div>
+      <p class="mock-cap">After D5 — probe matches <code>codex</code>; pill goes live and names the harness.</p>
+    </div>
+  </div>
+</div>
+
+<h3>5c · Teaching Codex that <code>duo</code> exists</h3>
+<div class="lanes">
+  <div class="lane"><span class="tag warn">No-op</span><h4>Do nothing</h4><p>User manually tells Codex about <code>duo</code> each session. Zero build, zero maintenance — but the autonomous-agent magic silently never happens.</p></div>
+  <div class="lane"><span class="tag good">Codex-native</span><h4><code>/duo</code> slash prompt</h4><p>Ship <code>~/.codex/prompts/duo.md</code>. Discoverable in Codex's slash menu, opt-in, non-invasive. Low build, low drift.</p></div>
+  <div class="lane"><span class="tag warn">Invasive</span><h4>Auto-merge AGENTS.md</h4><p>Write a <code>duo</code> block into the project's <code>AGENTS.md</code>. Automatic, but pollutes the user's repo and drifts. High ongoing tax.</p></div>
+  <div class="lane dur"><span class="tag good">Durable</span><h4>Duo as MCP server</h4><p>Expose the verbs as self-describing MCP tools. Both harnesses discover them automatically via their own config. Bigger build, near-zero drift — collapses Rings&nbsp;1&nbsp;+&nbsp;2 into one neutral mechanism.</p></div>
+</div>
+<p class="tl-note">Decision D3 chooses among these (they're not all mutually exclusive — <code>/duo</code> now + MCP later is a sequence).</p>
+
+<h3>5d · The agent-config navigator pane</h3>
+<div class="mock">
+  <div class="mockrow">
+    <div class="mockcol">
+      <div class="navpane">
+        <div class="nrow head">~/.claude</div>
+        <div class="nrow"><span class="ic">📄</span> CLAUDE.md</div>
+        <div class="nrow"><span class="ic">📁</span> skills/</div>
+        <div class="nrow"><span class="ic">📁</span> agents/</div>
+      </div>
+      <p class="mock-cap">Today — hard-coded to <code>~/.claude</code>.</p>
+    </div>
+    <div class="mockcol">
+      <div class="navpane">
+        <div class="nrow head">Agent config · ◆ codex</div>
+        <div class="nrow"><span class="ic">📄</span> AGENTS.md</div>
+        <div class="nrow"><span class="ic">📁</span> prompts/</div>
+        <div class="nrow"><span class="ic">⚙</span> config.toml</div>
+      </div>
+      <p class="mock-cap">After D7 — pane follows the active tab's harness (or shows both).</p>
+    </div>
+  </div>
+</div>
+
+<h2>6 · Decisions</h2>
+<p>Seven decisions, ordered from the spine (D1) outward. Recommended picks are pre-tagged; override freely and leave notes.</p>
+
+<section class="decision-card">
+  <div class="q-title">Decision 1 · The spine</div>
+  <h3 class="q-prompt">What target posture for harness-agnosticism?</h3>
+  <p class="q-context">Everything else inherits from this. The trade is reach vs. the standing cost of keeping two (or N) integrations honest as both tools ship weekly.</p>
+  <div class="q-options">
+    <label class="q-option"><input type="radio" name="d1" value="A"><div class="q-option-body"><div class="q-option-title">A · Claude-first, Codex-tolerant <span class="recommend-tag">Recommended</span></div><div class="q-option-rationale">Core bridge works for Codex; lifecycle features degrade/hide on Codex tabs. Cheap params only (kind, presence, marker). <span class="cost"><span class="up">Upfront ●●○○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d1" value="B"><div class="q-option-body"><div class="q-option-title">B · Agnostic core, two first-class adapters</div><div class="q-option-rationale">Claude + Codex are peers behind a <code>HarnessAdapter</code> interface; both get pill, launch, resume. <span class="cost"><span class="up">Upfront ●●●○○</span> <span class="on">Ongoing ●●●○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d1" value="C"><div class="q-option-body"><div class="q-option-title">C · Pluggable harness registry</div><div class="q-option-rationale">Data-driven adapters; community can add Gemini CLI, aider, etc. Maximum reach, you own a plugin contract + N drifting parsers. <span class="cost"><span class="up">Upfront ●●●●●</span> <span class="on">Ongoing ●●●●●</span></span></div></div></label>
+  </div>
+  <textarea class="q-notes" data-decision="d1" placeholder="Notes (optional)…"></textarea>
+</section>
+
+<section class="decision-card">
+  <div class="q-title">Decision 2 · Abstraction shape</div>
+  <h3 class="q-prompt">If we go agnostic, how do we model "a harness" in code?</h3>
+  <p class="q-context">Only bites under D1=B/C. Determines how a new harness (or an upstream change) ripples through the codebase.</p>
+  <div class="q-options">
+    <label class="q-option"><input type="radio" name="d2" value="A"><div class="q-option-body"><div class="q-option-title">A · Inline 2-way branches (<code>if kind==='codex'</code>)</div><div class="q-option-rationale">Fastest to write, but the branches sprawl across pty/presence/tracker/renderer and rot. <span class="cost"><span class="up">Upfront ●○○○○</span> <span class="on">Ongoing ●●●○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d2" value="B"><div class="q-option-body"><div class="q-option-title">B · <code>HarnessAdapter</code> interface + concrete impls <span class="recommend-tag">Recommended (if agnostic)</span></div><div class="q-option-rationale">One interface: <code>{name, binary, launchCmd, resumeCmd, presenceMatch, configDir, sessionLocator?, primingChannel}</code>. Claude + Codex implement it; call sites stay generic. <span class="cost"><span class="up">Upfront ●●●○○</span> <span class="on">Ongoing ●●○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d2" value="C"><div class="q-option-body"><div class="q-option-title">C · Declarative manifest (JSON/TOML descriptor)</div><div class="q-option-rationale">Most flexible/user-extensible, but session-JSONL parsers still need real code per harness → the descriptor leaks. <span class="cost"><span class="up">Upfront ●●●●○</span> <span class="on">Ongoing ●●●○○</span></span></div></div></label>
+  </div>
+  <textarea class="q-notes" data-decision="d2" placeholder="Notes (optional)…"></textarea>
+</section>
+
+<section class="decision-card">
+  <div class="q-title">Decision 3 · The onboarding gap</div>
+  <h3 class="q-prompt">How does Codex learn that <code>duo</code> exists?</h3>
+  <p class="q-context">The single most important question for Codex value: without this the bridge works but the agent never reaches for it. Options aren't mutually exclusive.</p>
+  <div class="q-options">
+    <label class="q-option"><input type="radio" name="d3" value="A"><div class="q-option-body"><div class="q-option-title">A · Nothing — user tells Codex manually</div><div class="q-option-rationale">Zero build/maintenance; loses the autonomous-driving experience. A valid "ship-the-bridge-only" floor. <span class="cost"><span class="up">Upfront ○○○○○</span> <span class="on">Ongoing ○○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d3" value="B"><div class="q-option-body"><div class="q-option-title">B · Ship a <code>/duo</code> Codex slash prompt <span class="recommend-tag">Recommended now</span></div><div class="q-option-rationale"><code>~/.codex/prompts/duo.md</code> — Codex-native, opt-in, non-invasive, discoverable in the slash menu. Mirrors the skill's intent without skills. <span class="cost"><span class="up">Upfront ●○○○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d3" value="C"><div class="q-option-body"><div class="q-option-title">C · Auto-merge a <code>duo</code> block into <code>AGENTS.md</code></div><div class="q-option-rationale">Automatic priming, but writes into the user's repo (commit noise, drift, surprise). Reach for only if auto-on is non-negotiable. <span class="cost"><span class="up">Upfront ●●○○○</span> <span class="on">Ongoing ●●●●○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d3" value="D"><div class="q-option-body"><div class="q-option-title">D · Expose Duo as an MCP server <span class="recommend-tag">Recommended as the spine</span></div><div class="q-option-rationale">Self-describing tools both harnesses auto-discover via their MCP config. Public protocol = near-zero drift. Biggest build; flags the "MCP not included" locked decision (which was about Duo-as-MCP-<em>client</em>, not server — worth re-opening). <span class="cost"><span class="up">Upfront ●●●●○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+  </div>
+  <textarea class="q-notes" data-decision="d3" placeholder="Notes (optional)…"></textarea>
+</section>
+
+<section class="decision-card">
+  <div class="q-title">Decision 4 · Launch</div>
+  <h3 class="q-prompt">How do we open Codex as a tab? (mockup 5a)</h3>
+  <p class="q-context">The tab-kind enum is <code>'shell' | 'claude'</code> today. This is a UI + data-model choice.</p>
+  <div class="q-options">
+    <label class="q-option"><input type="radio" name="d4" value="A"><div class="q-option-body"><div class="q-option-title">A · Add <code>kind:'codex'</code> + <code>--codex</code> flag <span class="recommend-tag">Recommended</span></div><div class="q-option-rationale">Parallel to <code>claude</code>: new menu item, <code>codex · cwd</code> label, auto-type <code>codex</code>. Smallest diff; enum grows by one. <span class="cost"><span class="up">Upfront ●●○○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d4" value="B"><div class="q-option-body"><div class="q-option-title">B · Generalize to <code>kind:'agent'</code> + <code>agentId</code></div><div class="q-option-rationale">Data-driven launch spec; no enum growth per future agent. Touches more call sites; pairs with D2=B/C. <span class="cost"><span class="up">Upfront ●●●○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d4" value="C"><div class="q-option-body"><div class="q-option-title">C · No first-class Codex tab — type <code>codex</code> in a shell</div><div class="q-option-rationale">Zero build; loses launch + pill + presence integration. The D1=A floor if we want literally no Codex-specific code. <span class="cost"><span class="up">Upfront ○○○○○</span> <span class="on">Ongoing ○○○○○</span></span></div></div></label>
+  </div>
+  <textarea class="q-notes" data-decision="d4" placeholder="Notes (optional)…"></textarea>
+</section>
+
+<section class="decision-card">
+  <div class="q-title">Decision 5 · Presence pill</div>
+  <h3 class="q-prompt">How do we detect a live Codex process, and what does the pill say? (mockup 5b)</h3>
+  <p class="q-context">The probe matches <code>comm === 'claude'</code>. The fix is small; the question is how general to make it + the pill copy.</p>
+  <div class="q-options">
+    <label class="q-option"><input type="radio" name="d5" value="A"><div class="q-option-body"><div class="q-option-title">A · Add <code>codex</code> to a static known-agent set <span class="recommend-tag">Recommended</span></div><div class="q-option-rationale">One-line matcher change; pill names the matched harness ("Send to Codex"). <span class="cost"><span class="up">Upfront ●○○○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d5" value="B"><div class="q-option-body"><div class="q-option-title">B · Per-harness matcher from the adapter (D2)</div><div class="q-option-rationale">Presence string lives on the adapter; cleanest if D1=B. Slightly more wiring. <span class="cost"><span class="up">Upfront ●●○○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d5" value="C"><div class="q-option-body"><div class="q-option-title">C · Generic "any known coding-agent descendant" + neutral copy</div><div class="q-option-rationale">Pill says "Send to agent" regardless. Future-proof but loses the harness name as a useful signal. <span class="cost"><span class="up">Upfront ●○○○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+  </div>
+  <textarea class="q-notes" data-decision="d5" placeholder="Notes (optional)…"></textarea>
+</section>
+
+<section class="decision-card">
+  <div class="q-title">Decision 6 · Session capture &amp; resume</div>
+  <h3 class="q-prompt">Do we rebuild resume pills for Codex — and how?</h3>
+  <p class="q-context">This is where the ongoing-maintenance tax is highest. Codex's session store is date-indexed (not cwd-indexed) with a different schema, so per-cwd reconstruction is both harder <em>and</em> a standing drift liability.</p>
+  <div class="q-options">
+    <label class="q-option"><input type="radio" name="d6" value="A"><div class="q-option-body"><div class="q-option-title">A · Skip rich capture — resume pills just don't show on Codex tabs <span class="recommend-tag">Recommended v1</span></div><div class="q-option-rationale">Graceful no-op. Zero drift tax. Codex users still get the full bridge; they just resume via Codex's own UI. <span class="cost"><span class="up">Upfront ●○○○○</span> <span class="on">Ongoing ○○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d6" value="B"><div class="q-option-body"><div class="q-option-title">B · Offer "Resume last Codex session" via <code>codex resume --last</code></div><div class="q-option-rationale">Public-CLI path (rule-12 aligned): Duo runs the documented subcommand, never parses rollout files. Less rich (no per-session titles) but durable. <span class="cost"><span class="up">Upfront ●●○○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d6" value="C"><div class="q-option-body"><div class="q-option-title">C · Full parity — parse <code>rollout-*.jsonl</code> + rebuild the list</div><div class="q-option-rationale">Matches Claude's resume UX exactly, but reverse-engineers a private format that drifts on every Codex release. The top-band cost in Fig.&nbsp;2. <span class="cost"><span class="up">Upfront ●●●○○</span> <span class="on">Ongoing ●●●●●</span></span></div></div></label>
+  </div>
+  <textarea class="q-notes" data-decision="d6" placeholder="Notes (optional)…"></textarea>
+</section>
+
+<section class="decision-card">
+  <div class="q-title">Decision 7 · Config pane + doctor</div>
+  <h3 class="q-prompt">What happens to the <code>~/.claude</code> navigator pane and <code>duo doctor</code>? (mockup 5d)</h3>
+  <p class="q-context">Both currently assert Claude paths. For a Codex-only user the pane shows the wrong thing and doctor shows false red.</p>
+  <div class="q-options">
+    <label class="q-option"><input type="radio" name="d7" value="A"><div class="q-option-body"><div class="q-option-title">A · Harness-aware — pane + doctor follow installed/active harness</div><div class="q-option-rationale">Pane shows <code>~/.codex</code> on a Codex tab; doctor only checks paths for harnesses that are installed. Most polished. <span class="cost"><span class="up">Upfront ●●●○○</span> <span class="on">Ongoing ●●○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d7" value="B"><div class="q-option-body"><div class="q-option-title">B · Unified "agent config" pane listing all installed agents</div><div class="q-option-rationale">One pane, both roots. Nice for mixed users; more design. <span class="cost"><span class="up">Upfront ●●●○○</span> <span class="on">Ongoing ●●○○○</span></span></div></div></label>
+    <label class="q-option"><input type="radio" name="d7" value="C"><div class="q-option-body"><div class="q-option-title">C · Minimal — hide pane + skip doctor checks when no Claude install <span class="recommend-tag">Recommended v1</span></div><div class="q-option-rationale">Stops the false-red and the irrelevant pane with near-zero work; upgrade to A later. <span class="cost"><span class="up">Upfront ●○○○○</span> <span class="on">Ongoing ●○○○○</span></span></div></div></label>
+  </div>
+  <textarea class="q-notes" data-decision="d7" placeholder="Notes (optional)…"></textarea>
+</section>
+
+<details class="deferred">
+  <summary>Recommended throughline (one coherent path)</summary>
+  <div class="deferred-body">
+    <p><strong>D1=A · D3=B+plan&nbsp;D · D4=A · D5=A · D6=A&nbsp;(then&nbsp;B) · D7=C&nbsp;(then&nbsp;A).</strong></p>
+    <p>Translation: lean on the already-neutral core; make only the <em>cheap, durable</em> parameterizations
+    (codex tab kind, presence matcher, marker set, neutral author default); teach Codex via a
+    <code>/duo</code> slash prompt now while scoping <strong>Duo-as-MCP-server</strong> as the long-term spine
+    that makes the skill/onboarding question harness-neutral for good. <em>Avoid</em> the high-drift moves —
+    parsing Codex's rollout JSONL and auto-writing AGENTS.md — until parity is a proven user need. Degrade the
+    lifecycle features (resume pills, config pane) on Codex rather than reconstructing them from reverse-engineered
+    state. Net: most of Codex's value ships in a small, low-maintenance diff; the durable bet (MCP) is sequenced, not rushed.</p>
+    <p class="tl-note">If the goal is broader than Codex (Gemini CLI, aider, …), that's the signal to escalate D1→B and D2→B —
+    but only then, since the adapter's ongoing cost is only justified by a third harness.</p>
+  </div>
+</details>
+
+<div class="general-comments">
+  <h3>General comments</h3>
+  <textarea id="general-comments" placeholder="Anything the decisions above don't capture — scope, sequencing, a harness I missed, disagreement with a recommendation…"></textarea>
+</div>
+
+<div class="copy-bar">
+  <div class="copy-meta"><span id="answered-count">0</span> / 7 decisions answered</div>
+  <button id="copy-btn" type="button">Copy decisions</button>
+</div>
+
+<script>
+(function () {
+  // ── Matrix filter ──
+  const filters = document.getElementById('filters');
+  const tps = Array.from(document.querySelectorAll('#matrix .tp'));
+  filters.addEventListener('click', function (e) {
+    const btn = e.target.closest('button');
+    if (!btn) return;
+    const f = btn.dataset.f;
+    filters.querySelectorAll('button').forEach(b => b.classList.toggle('active', b === btn));
+    tps.forEach(tp => tp.classList.toggle('hide', f !== 'all' && tp.dataset.cat !== f));
+  });
+
+  // ── Answered count ──
+  const cards = Array.from(document.querySelectorAll('.decision-card'));
+  const countEl = document.getElementById('answered-count');
+  function refreshCount() {
+    const answered = cards.filter(c => c.querySelector('input[type=radio]:checked')).length;
+    countEl.textContent = answered;
+  }
+  document.addEventListener('change', function (e) {
+    if (e.target.matches('.decision-card input[type=radio]')) refreshCount();
+  });
+
+  // ── Copy decisions payload ──
+  const btn = document.getElementById('copy-btn');
+  btn.addEventListener('click', async function () {
+    const parts = ['# Agent-agnostic Duo — decisions', ''];
+    cards.forEach(card => {
+      const title = (card.querySelector('.q-title')?.textContent || '').trim();
+      const prompt = (card.querySelector('.q-prompt')?.textContent || '').trim();
+      const checked = card.querySelector('input[type=radio]:checked');
+      const notes = (card.querySelector('.q-notes')?.value || '').trim();
+      let line;
+      if (checked) {
+        const optTitle = (checked.closest('.q-option').querySelector('.q-option-title')?.textContent || '')
+          .replace(/Recommended.*/i, '').trim();
+        line = '[' + checked.value + '] ' + title + ' — ' + optTitle;
+      } else {
+        line = '[—] ' + title + ' — (unanswered)';
+      }
+      parts.push(line);
+      parts.push('    Q: ' + prompt);
+      if (notes) parts.push('    note: ' + notes);
+      parts.push('');
+    });
+    const general = (document.getElementById('general-comments')?.value || '').trim();
+    if (general) { parts.push('## General comments'); parts.push(general); parts.push(''); }
+    const payload = parts.join('\n');
+    try {
+      await navigator.clipboard.writeText(payload);
+    } catch (_) {
+      const ta = document.createElement('textarea');
+      ta.value = payload; document.body.appendChild(ta); ta.select();
+      try { document.execCommand('copy'); } catch (e) {}
+      document.body.removeChild(ta);
+    }
+    btn.classList.add('copied');
+    const prev = btn.textContent; btn.textContent = 'Copied ✓';
+    setTimeout(() => { btn.classList.remove('copied'); btn.textContent = prev; }, 2000);
+  });
+
+  refreshCount();
+})();
+</script>
+
+</body>
+</html>

--- a/tasks.md
+++ b/tasks.md
@@ -6,6 +6,28 @@
 
 > Sprint 24 anchor: close the v0.8.0 audit's deferred follow-ups (FOLLOWUP-031 through 040) before any new feature work. ENH-182 was the marquee chapter; Sprint 24 is its polish epilogue. Definition of done: all 10 FOLLOWUPs closed or explicitly deferred-with-reason. Expected cut shape: v0.8.1 PATCH (polish-only) OR v0.9.0 MINOR if a carry-forward capability lands alongside.
 
+### ENH-189: Agent-agnostic Duo — Claude Code + Codex (research)
+
+**Status:** 🆕 **Research delivered 2026-05-27** (branch `claude/duo-agent-agnostic-research-9y1t3`). **Priority:** Strategic / owner-decision-gated. **Effort:** research only; implementation scope depends on D1.
+
+**Ask.** Explore making Duo harness-agnostic across the Claude Code and Codex CLIs: identify what works across both, what no-ops with Codex, and what outright breaks; for each, propose options weighed by upfront vs ongoing maintenance burden.
+
+**Deliverable.** Decision-bearing HTML playground at [`docs/research/agent-agnostic-duo.html`](research/agent-agnostic-duo.html) (Atelier kernel, three-rings + cost-quadrant SVGs, UI mockups, 7 decision cards + Copy-decisions footer, per rule 11).
+
+**Key findings.** The `duo` CLI + Unix-socket bridge are ~90% harness-neutral — Codex over the same socket is byte-identical, and all ~100 verbs (browser/editor/canvas/file/layout/git/project/events) are agent-generic (no Claude branch in the dispatch switch). Claude-coupling concentrates in a thin lifecycle skin, tri-categorized:
+- **Works (4):** socket protocol, ~100 verbs, PTY env injection (`DUO_SESSION`/`DUO_SOCKET`), CLI transport.
+- **No-op (5):** skill (`~/.claude/skills/duo/`), subagent (`agents/duo.md`), SessionStart hook, `claude-return`/`shift-return`, `DUO_AUTHOR` default — Codex silently never loads them. The important one is the skill: the bridge works but the agent is never *told* `duo` exists.
+- **Breaks (8):** tab `kind:'claude'` auto-launch (no `codex` kind), priming shim's `--append-system-prompt` (Codex has no per-session append flag — the hardest gap), presence probe (`comm==='claude'`, `core/claude-presence.ts:143`), session capture (`~/.claude/projects/<enc-cwd>/*.jsonl` vs Codex's date-indexed `~/.codex/sessions/Y/M/D/rollout-*.jsonl`), `claude --resume` (`electron/main.ts:677`), JSONL title/count parsing, `resolveClaudeBinary`, `duo doctor` false-red, UserClaudePane.
+- **Generalizable (2):** project marker (`CLAUDE.md`/`.claude/` → add `AGENTS.md`/`.codex/`), author identity default.
+
+**Maintenance-burden law (the throughline).** Coupling that reads a tool's *private file format* (rollout JSONL) or shells its *private flags* (`--append-system-prompt`) is a standing drift liability; coupling that rides a *public contract* (documented subcommand like `codex resume --last`, env vars, MCP) is durable. **MCP is the one extension surface both harnesses share** — flagged as the durable long-term spine (re-opens the "MCP not included" locked decision, which was about Duo-as-MCP-*client*, not *server*).
+
+**Recommended throughline (owner to confirm via the playground's decision cards):** D1=A (Claude-first, Codex-tolerant) · D3=B+plan-D (`/duo` Codex slash prompt now, scope Duo-as-MCP-server as the spine) · D4=A (add `codex` tab kind) · D5=A (add `codex` to presence matcher) · D6=A→B (skip rich resume; offer `codex resume --last`) · D7=C→A (hide pane/skip doctor checks for non-Claude now). Avoid the high-drift moves (parse rollout JSONL, auto-write AGENTS.md) until parity is a proven need. Escalate D1→B (two-adapter `HarnessAdapter`) only when a *third* harness (Gemini CLI, aider) justifies the abstraction's ongoing cost.
+
+**Next.** Owner walks the playground, picks the decision set, pastes back → that pins implementation scope. No code changes shipped in this sprint (research only).
+
+---
+
 ### ENH-188: Terminal-tab context menu — parity with canvas tabs (reorder + close + copy cwd)
 
 **Status:** 🆕 **Filed + implemented 2026-05-27** (branch `claude/terminal-tabs-context-parity-2lh2X`). **Priority:** Medium (daily-driver ergonomics; the headline gap is "can't reorder terminal tabs"). **Effort:** ~1.5h.


### PR DESCRIPTION
## Summary

Max-effort research sprint on making Duo harness-agnostic across the **Claude Code** and **Codex** CLIs. Ships a decision-bearing HTML playground (no app code changes) at `docs/research/agent-agnostic-duo.html` + a tracked ENH-189 entry in `tasks.md`.

**Headline:** the `duo` CLI + Unix-socket bridge are **~90% harness-neutral** — Codex over the same socket is byte-identical, and all ~100 verbs are agent-generic. Claude-coupling concentrates in a thin *lifecycle skin*.

### What the report covers
- **Three-rings architecture** (SVG): core bridge *works* / onboarding *no-ops* / lifecycle *breaks*.
- **19-touchpoint inventory** (filterable), tri-categorized with file:line:
  - **Works (4):** socket protocol, ~100 verbs, PTY env injection, CLI transport.
  - **No-op (5):** skill, subagent, SessionStart hook, `claude-return`, `DUO_AUTHOR` default. *The important one:* Codex never loads the skill → the bridge works but the agent is never told `duo` exists.
  - **Breaks (8):** `kind:'claude'` auto-launch, the `--append-system-prompt` priming shim (Codex has no per-session append flag — the hardest gap), presence probe (`comm==='claude'`), session capture (cwd-indexed `~/.claude/projects/` vs Codex's date-indexed `~/.codex/sessions/`), `claude --resume`, JSONL parsing, `resolveClaudeBinary`, `duo doctor` false-red, UserClaudePane.
  - **Generalizable (2):** project marker, author identity.
- **Codex-vs-Claude capability table** — the asymmetry that drives cost.
- **Cost quadrant** (SVG scatter): upfront build × ongoing maintenance.
- **UI mockups:** new-tab menu, presence pill states, onboarding lanes, agent-config pane.
- **7 decision cards** + Copy-decisions footer (round-trips picks back to Claude).

### The throughline
Coupling that reads a tool's *private format* (rollout JSONL) or shells its *private flags* (`--append-system-prompt`) is a standing drift liability; coupling that rides a *public contract* (`codex resume --last`, env vars, **MCP**) is durable. MCP is the one extension surface both harnesses share — flagged as the durable long-term spine.

### Recommended (owner to confirm via the cards)
D1=A · D3=B+plan-D · D4=A · D5=A · D6=A→B · D7=C→A. Make the cheap/durable parameterizations now; degrade lifecycle features on Codex rather than reverse-engineering its state; scope Duo-as-MCP-server as the spine. Escalate to a two-adapter abstraction only when a *third* harness justifies it.

## Test plan
- [ ] Open `docs/research/agent-agnostic-duo.html` in Duo (browser mode) — verify SVGs render, matrix filters work, decision radios highlight, Copy-decisions assembles the payload.
- [ ] Owner walks the 7 decision cards, pastes results back to pin implementation scope.

> Research only — no renderer/electron/CLI changes; nothing to smoke-walk in the app shell.

https://claude.ai/code/session_01Bd92VSjbDoVkTPwinYvG9J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bd92VSjbDoVkTPwinYvG9J)_