### PR TITLE
Fix navigator ENOENT spam from ghost folders + gate focus instrumentation

### DIFF
--- a/renderer/components/WorkingPane.tsx
+++ b/renderer/components/WorkingPane.tsx
@@ -308,6 +308,14 @@ export function WorkingPane({
   // walks for 60s, grep [ENH-084-v4] in /tmp/duo-dev-*.log to read the
   // event stream + decide which signal source is the right driver.
   useEffect(() => {
+    // BUG-167 — this v4 pass logs on EVERY focusin / mousedown / blur
+    // document-wide, which floods the release console (it was never
+    // un-gated after the Sprint 17 data capture). Now opt-in: silent by
+    // default, recoverable if the subpane-focus work resumes — set
+    // `duo.debug.focus` to '1' in DevTools and reload to re-arm the stream.
+    let focusDebug = false
+    try { focusDebug = localStorage.getItem('duo.debug.focus') === '1' } catch { /* storage disabled */ }
+    if (!focusDebug) return
     const subpaneOf = (target: EventTarget | null): 'main' | 'aux' | 'neither' => {
       if (!(target instanceof Node)) return 'neither'
       if (mainColRef.current?.contains(target)) return 'main'

--- a/renderer/hooks/useNavigator.ts
+++ b/renderer/hooks/useNavigator.ts
@@ -13,8 +13,20 @@
 // Persistence: Phase 4 uses localStorage for a quick seed across reloads.
 // Phase 7 replaces this with the main-process state.json persistence.
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DirEntry } from '@shared/types'
+
+/** BUG-167 — true for fs errors that mean "the path is simply gone"
+ *  (deleted folder, moved directory, a stale persisted path, a transient
+ *  skill workspace that came and went). These are expected, not app
+ *  errors. The renderer receives them wrapped by Electron as
+ *  `Error invoking remote method 'files:list': Error: ENOENT …`, so we
+ *  match on the embedded errno rather than the wrapper. Shared with
+ *  `useUserClaudeNavigator`. */
+export function isMissingPathError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return msg.includes('ENOENT') || msg.includes('ENOTDIR')
+}
 
 const LS_KEY_CWD = 'duo.nav.cwd'
 const LS_KEY_EXPANDED = 'duo.nav.expanded'
@@ -151,7 +163,20 @@ export function useNavigator(initialCwd: string) {
         })
       },
       err => {
-        console.warn('[nav] list failed for', path, err instanceof Error ? err.message : err)
+        if (isMissingPathError(err)) {
+          // BUG-167 — the folder is gone. Drop it from the expanded set so
+          // we stop re-listing a ghost on every project switch (the watcher
+          // effect re-lists the entire expanded set on each cwd change).
+          // No console noise: this is an expected condition, not an error.
+          setExpanded(prev => {
+            if (!prev.has(path)) return prev
+            const next = new Set(prev)
+            next.delete(path)
+            return next
+          })
+        } else {
+          console.warn('[nav] list failed for', path, err instanceof Error ? err.message : err)
+        }
         setListings(prev => {
           const next = new Map(prev)
           next.set(path, []) // treat errors as empty; UI can surface later
@@ -159,6 +184,60 @@ export function useNavigator(initialCwd: string) {
         })
       }
     )
+  }, [])
+
+  // BUG-167 — prune ghost paths from persisted nav state once on mount.
+  // `cwd` + `expanded` are restored from localStorage and can point at
+  // folders deleted/moved since last session (e.g. transient skill
+  // workspaces). The watcher effect re-lists the whole expanded set on
+  // every project switch, so a single ghost throws ENOENT on each
+  // navigation. Validate once at startup: recover a missing cwd to its
+  // nearest existing ancestor (else the initial home), and drop dead
+  // expanded entries. Reads cwd/expanded/initialCwd from the mount-time
+  // closure (their persisted values) — intentionally mount-only.
+  const prunedRef = useRef(false)
+  useEffect(() => {
+    if (prunedRef.current) return
+    prunedRef.current = true
+    let cancelled = false
+    const probe = window.electron?.files?.dirExists
+    if (!probe) return
+    void (async () => {
+      try {
+        if (!(await probe(cwd))) {
+          let dir = cwd
+          let recovered = initialCwd
+          while (dir.length > 1) {
+            const slash = dir.lastIndexOf('/')
+            const parent = slash > 0 ? dir.slice(0, slash) : '/'
+            if (parent === dir) break
+            dir = parent
+            if (await probe(dir)) { recovered = dir; break }
+          }
+          if (!cancelled) setCwd(recovered)
+        }
+      } catch { /* probe failed — leave cwd as-is */ }
+      const current = [...expanded]
+      if (current.length === 0) return
+      try {
+        const checks = await Promise.all(
+          current.map(async p => [p, await probe(p)] as const)
+        )
+        const dead = checks.filter(([, ok]) => !ok).map(([p]) => p)
+        if (cancelled || dead.length === 0) return
+        setExpanded(prev => {
+          const next = new Set(prev)
+          for (const p of dead) next.delete(p)
+          return next
+        })
+        setListings(prev => {
+          const next = new Map(prev)
+          for (const p of dead) next.delete(p)
+          return next
+        })
+      } catch { /* probe failed — leave expanded as-is */ }
+    })()
+    return () => { cancelled = true }
   }, [])
 
   // Auto-load the current cwd + any expanded children.
@@ -204,6 +283,14 @@ export function useNavigator(initialCwd: string) {
           return next
         })
         setPrimaryPath(curr => (curr === event.path ? null : curr))
+        // BUG-167 — a removed folder that was expanded must leave the
+        // expanded set too, or the next project switch re-lists a ghost.
+        setExpanded(curr => {
+          if (!curr.has(event.path)) return curr
+          const next = new Set(curr)
+          next.delete(event.path)
+          return next
+        })
       }
     }
 

--- a/renderer/hooks/useUserClaudeNavigator.ts
+++ b/renderer/hooks/useUserClaudeNavigator.ts
@@ -19,9 +19,9 @@
 // so the tree can present a small hand-picked top level on top of
 // otherwise-normal expand-on-click behavior.
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DirEntry, FileChangeEvent } from '@shared/types'
-import type { NavigatorState, NavigatorActions } from './useNavigator'
+import { isMissingPathError, type NavigatorState, type NavigatorActions } from './useNavigator'
 
 const LS_KEY_SHOW_ALL = 'duo.userClaude.showAll'
 const LS_KEY_EXPANDED = 'duo.userClaude.expanded'
@@ -89,7 +89,18 @@ export function useUserClaudeNavigator(home: string): UserClaudeNavigatorApi {
         })
       },
       err => {
-        console.warn('[user-claude-nav] list failed for', path, err instanceof Error ? err.message : err)
+        if (isMissingPathError(err)) {
+          // BUG-167 — folder gone; drop it from the expanded set so it
+          // isn't re-listed on every re-subscribe. Expected, not an error.
+          setExpanded(prev => {
+            if (!prev.has(path)) return prev
+            const next = new Set(prev)
+            next.delete(path)
+            return next
+          })
+        } else {
+          console.warn('[user-claude-nav] list failed for', path, err instanceof Error ? err.message : err)
+        }
         setListings(prev => {
           const next = new Map(prev)
           next.set(path, [])
@@ -97,6 +108,41 @@ export function useUserClaudeNavigator(home: string): UserClaudeNavigatorApi {
         })
       }
     )
+  }, [])
+
+  // BUG-167 — prune ghost expanded paths once on mount. The root is fixed
+  // at ~/.claude so there's no cwd to recover, but persisted `expanded`
+  // can still reference folders (skills/<gone>, agents/<gone>) that were
+  // deleted since last session. Validate once and drop the dead entries.
+  const prunedRef = useRef(false)
+  useEffect(() => {
+    if (prunedRef.current) return
+    prunedRef.current = true
+    let cancelled = false
+    const probe = window.electron?.files?.dirExists
+    if (!probe) return
+    const current = [...expanded]
+    if (current.length === 0) return
+    void (async () => {
+      try {
+        const checks = await Promise.all(
+          current.map(async p => [p, await probe(p)] as const)
+        )
+        const dead = checks.filter(([, ok]) => !ok).map(([p]) => p)
+        if (cancelled || dead.length === 0) return
+        setExpanded(prev => {
+          const next = new Set(prev)
+          for (const p of dead) next.delete(p)
+          return next
+        })
+        setListings(prev => {
+          const next = new Map(prev)
+          for (const p of dead) next.delete(p)
+          return next
+        })
+      } catch { /* probe failed — leave expanded as-is */ }
+    })()
+    return () => { cancelled = true }
   }, [])
 
   // Always load the user-claude root + any expanded children.
@@ -142,6 +188,16 @@ export function useUserClaudeNavigator(home: string): UserClaudeNavigatorApi {
         return next
       })
       ensureListing(parent)
+      if (event.kind === 'removed') {
+        // BUG-167 — a removed folder that was expanded must leave the
+        // expanded set, or it gets re-listed (ENOENT) on the next re-sub.
+        setExpanded(curr => {
+          if (!curr.has(event.path)) return curr
+          const next = new Set(curr)
+          next.delete(event.path)
+          return next
+        })
+      }
     }
 
     void window.electron.files.watch(paths, handleEvent).then(stop => {

--- a/tasks.md
+++ b/tasks.md
@@ -6,6 +6,22 @@
 
 > Sprint 24 anchor: close the v0.8.0 audit's deferred follow-ups (FOLLOWUP-031 through 040) before any new feature work. ENH-182 was the marquee chapter; Sprint 24 is its polish epilogue. Definition of done: all 10 FOLLOWUPs closed or explicitly deferred-with-reason. Expected cut shape: v0.8.1 PATCH (polish-only) OR v0.9.0 MINOR if a carry-forward capability lands alongside.
 
+### BUG-167: Navigator ENOENT spam from ghost folders + console-flooding focus instrumentation
+
+**Status:** 🆕 **Filed + fixed 2026-05-27** (branch `claude/project-navigation-errors-7UpEJ`). **Priority:** Medium (console noise + perceived instability; functionally benign). **Effort:** ~1h.
+
+**Symptom.** Switching between projects in v0.8.2 floods the renderer console with two error classes (owner screenshot): repeated `[nav] list failed for …/skills/setup-check-workspace — Error invoking remote method 'files:list': ENOENT`, and per-interaction `[ENH-084-v4] … focusin/mousedown/blur` logs.
+
+**Root cause (nav ENOENT).** `useNavigator` persists every folder ever expanded to `localStorage` (`duo.nav.expanded`) and never prunes it; the persisted `cwd` (`duo.nav.cwd`) is restored with no existence check. The watcher effect depends on `[cwd, expanded]`, so **each project switch re-subscribes and re-lists the entire expanded set** (the belt-and-suspenders refresh). Any folder that has since been deleted/moved — e.g. a transient Claude Code skill workspace like `setup-check-workspace` — throws ENOENT on every navigation. The renderer treated all list failures identically: a loud `console.warn` of the full Electron remote-method wrapper, so a benign condition read like a crash. Brand-new users don't hit it; anyone who deletes/moves an expanded folder accumulates it permanently. Same pattern in `useUserClaudeNavigator`.
+
+**Root cause (`[ENH-084-v4]`).** `WorkingPane.tsx` installs document-wide `focusin`/`mousedown`/`blur` listeners that `console.log` on every event — a Sprint 17 "INSTRUMENTATION ONLY" data-capture pass that was never re-gated, so it ships in release builds.
+
+**Fix.** Navigator hardening (`useNavigator.ts`, `useUserClaudeNavigator.ts`): (a) one-shot **mount-time prune** via the existing `files.dirExists` probe — drop dead `expanded` entries and recover a missing `cwd` to its nearest existing ancestor (else `$HOME`); (b) drop a removed folder from `expanded` in the watcher's `removed` handler so mid-session deletes don't re-accumulate; (c) shared `isMissingPathError()` classifier — ENOENT/ENOTDIR is pruned + logged quietly, genuine errors (EACCES etc.) still `console.warn`. `FilesService.list` is deliberately **unchanged** — it's shared with the CLI `duo ls`, where erroring on a nonexistent path is correct Unix semantics; resilience belongs in the navigator layer that replays persisted state. Focus instrumentation gated behind an opt-in `localStorage` flag (`duo.debug.focus = '1'`, read once on mount): silent in release, recoverable if the subpane-focus work resumes. **Deliberate asymmetry:** the debug flag is developer-only and has no `duo` verb (not a product surface).
+
+**Cross-ref:** ENH-084 (the focus-glow defect whose v4 instrumentation this gates), BUG-039 (the `files.exists` probe pattern reused here for session-restore tab pruning), ENH-182 (project navigation, the surface this fires on).
+
+---
+
 ### ENH-188: Terminal-tab context menu — parity with canvas tabs (reorder + close + copy cwd)
 
 **Status:** 🆕 **Filed + implemented 2026-05-27** (branch `claude/terminal-tabs-context-parity-2lh2X`). **Priority:** Medium (daily-driver ergonomics; the headline gap is "can't reorder terminal tabs"). **Effort:** ~1.5h.


### PR DESCRIPTION
## What & why

Switching between projects in v0.8.2 floods the renderer console with two error classes (from the owner's screenshot):

1. Repeated `[nav] list failed for …/skills/setup-check-workspace — Error invoking remote method 'files:list': ENOENT`
2. Per-interaction `[ENH-084-v4] … focusin/mousedown/blur` logs

Both read like instability; both are benign. This PR cures the class.

### Root cause — nav ENOENT
`useNavigator` persists **every folder ever expanded** to `localStorage` (`duo.nav.expanded`) and never prunes it; the persisted `cwd` is restored with no existence check. The watcher effect depends on `[cwd, expanded]`, so **each project switch re-subscribes and re-lists the entire expanded set**. Any folder deleted/moved since — e.g. a transient Claude Code skill workspace like `setup-check-workspace` — throws ENOENT on every navigation, logged loudly via the full Electron remote-method wrapper. Brand-new users don't hit it; anyone who deletes/moves an expanded folder accumulates it permanently. Same pattern in `useUserClaudeNavigator`.

### Root cause — `[ENH-084-v4]`
`WorkingPane.tsx` installs document-wide `focusin`/`mousedown`/`blur` listeners that `console.log` on every event — a Sprint 17 "INSTRUMENTATION ONLY" data-capture pass that was never re-gated, so it ships in release builds.

## Changes
- **Mount-time prune** (`useNavigator`, `useUserClaudeNavigator`): one-shot validation via the existing `files.dirExists` probe — drop dead `expanded` entries and recover a missing `cwd` to its nearest existing ancestor (else `$HOME`).
- **Watcher prune**: drop a removed folder from `expanded` in the `removed` handler so mid-session deletes don't re-accumulate.
- **Quiet expected misses**: shared `isMissingPathError()` — ENOENT/ENOTDIR is pruned + logged quietly; genuine errors (EACCES etc.) still `console.warn`.
- **`FilesService.list` deliberately unchanged** — it's shared with the CLI `duo ls`, where erroring on a nonexistent path is correct Unix semantics. Resilience belongs in the navigator layer that replays persisted state.
- **Focus instrumentation gated** behind an opt-in `localStorage` flag (`duo.debug.focus = '1'`, read once on mount): silent in release, recoverable if the subpane-focus work resumes. Deliberate asymmetry: developer-only, no `duo` verb.

Ledger: `tasks.md` § BUG-167.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:run` — 824 tests pass
- [ ] **Live smoke (owner):** could not launch Electron in the cloud container (no display; `node-pty` couldn't rebuild offline). Please verify in a local build:
  - [ ] Expand a folder, delete it on disk, switch projects → no `[nav] list failed` spam
  - [ ] Restart with a stale `duo.nav.expanded`/`duo.nav.cwd` pointing at deleted folders → tree recovers cleanly, console quiet
  - [ ] Default build: no `[ENH-084-v4]` logs on click/focus; set `localStorage.duo.debug.focus='1'` + reload → stream returns
  - [ ] `duo ls /nonexistent` still errors (CLI semantics preserved)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnTydccc1dPAVhxfkPBoba)_