### PR TITLE
v0.8.5 — Project rail correctness: ghost tiles · close-jitter · phantom parents · multitab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,21 @@ notarized distribution (Stage 21).
 
 ## [Unreleased]
 
-> Empty — v0.8.4 cut 2026-05-28.
+> Empty — v0.8.5 cut 2026-06-02.
+
+## [0.8.5] — 2026-06-02 — Project rail correctness: ghost tiles · close-jitter · phantom parents · multitab
+
+### Fixed
+- **BUG-191** Project rail tiles no longer linger as "ghosts" when no files or terminals from that project are open. A terminal's project membership was frozen at the shell's *launch* directory and never updated — so a shell that `cd`'d away (or whose process exited) kept its tile alive forever. Membership now follows the **live shell cwd**, polled on a visibility-gated interval via a new batched, liveness-aware `PTY_LIVE_CWDS` IPC; an exited shell drops its tile, a `cd` out clears it, a `cd` back restores it.
+- **BUG-192** Right-clicking a project tile and choosing "Close N terminals and M tabs" no longer risks a recursive jitter / force-quit. `handleCloseProject` is now re-entrancy-guarded (`inFlightCloseRef`), runs its confirm dialog *before* any state snapshot, and hoists `setActiveTabId` out of the `setTabs` updater (the nested-setState anti-pattern). The member/survivor/active-shift logic is extracted to a pure, unit-tested `planProjectClose`.
+- **BUG-193** Opening a terminal in a nested repo (e.g. a project inside a git-repo parent like `~/Documents`) no longer spawns a phantom tile for the parent, and clicking the real tile no longer has focus stolen by the parent. Pinned reference tabs now get **null** project membership, so they can't resolve up to a shallow qualifying ancestor and contaminate the project set or the D11 auto-switch.
+- **BUG-194** `cd`-ing the focused project's last terminal out of it no longer hides that terminal's tab (which had broken ⌘T / ⌃Tab multitab). When the focused project drops out of the rail, focus auto-releases to "All" so the orphaned terminal stays visible.
+
+### Notes
+- New pure module `shared/project-lifecycle.ts` (19 unit tests) isolates the membership-input, poll-churn-guard, close-plan, and focus-release logic from React. 868/868 tests pass; typecheck clean.
+- Root-caused via a 38-agent investigation workflow; decision playground at `docs/research/bug-191-192-ghost-tiles-jitter-rootcause.html`.
+
+[0.8.5]: https://github.com/dudgeon/duo/compare/v0.8.4...v0.8.5
 
 ## [0.8.4] — 2026-05-28 — Polish patch: quit-loop · source-line gutter · nav heal
 

--- a/core/projects-service.test.ts
+++ b/core/projects-service.test.ts
@@ -178,6 +178,37 @@ describe('deriveProjects — qualification (D2)', () => {
     expect(out.tabMembership.tab1).toBeNull()
   })
 
+  it('BUG-193 — a pinned tab does NOT resolve to a shallow parent seeded by another member', () => {
+    // Real repro: ~/Documents is a git repo (qualifies). A terminal sits
+    // in a sibling marker-project (.../GitHub/stoop), whose candidate walk
+    // adds BOTH stoop AND ~/Documents to the qualifying set. Two pinned
+    // reference tabs live in .../GitHub/duo — their own project, but NOT in
+    // the set (pinned tabs don't gather candidates). Pre-fix, the pinned
+    // tabs resolved up to the shallowest qualifying ancestor (~/Documents),
+    // spuriously spawning a Documents tile AND making D11 steal focus to it.
+    const out = deriveProjects({
+      terminals: [{ id: 't1', cwd: '/docs/GitHub/stoop' }],
+      workingTabs: [
+        { id: 'tabA', path: '/docs/GitHub/duo/tasks.md' },
+        { id: 'tabB', path: '/docs/GitHub/duo/idle.md' }
+      ],
+      pinnedTabPaths: new Set(['/docs/GitHub/duo/tasks.md', '/docs/GitHub/duo/idle.md']),
+      pinnedProjects: new Set(),
+      colorOverrides: {},
+      qualify: makeQualify({
+        '/docs': { isGitRoot: true }, // ~/Documents is itself a git repo
+        '/docs/GitHub/stoop': { hasMarker: true } // sibling marker-project
+        // /docs/GitHub and /docs/GitHub/duo deliberately do NOT qualify
+      })
+    })
+    // Only the deepest project the terminal is actually in — never the parent.
+    expect(out.projects.map((p) => p.root)).toEqual(['/docs/GitHub/stoop'])
+    // Pinned tabs are cross-project references → no membership.
+    expect(out.tabMembership.tabA).toBeNull()
+    expect(out.tabMembership.tabB).toBeNull()
+    expect(out.terminalMembership.t1).toBe('/docs/GitHub/stoop')
+  })
+
   it('non-pinned working tabs DO count toward working-in', () => {
     const out = deriveProjects({
       terminals: [],

--- a/core/pty-manager.ts
+++ b/core/pty-manager.ts
@@ -14,6 +14,12 @@ interface Session {
 
 export class PtyManager {
   private sessions = new Map<string, Session>()
+  // BUG-191 — ids whose shell has EXITED. `sessions` is deleted on exit
+  // (so getPid returns null), which is indistinguishable from a tab whose
+  // PTY hasn't spawned yet. Tracking exited ids lets `getLiveness` tell
+  // "dead shell" (drop its project tile) from "pending" (keep the launch
+  // cwd) — see `getLiveness`.
+  private exited = new Set<string>()
   private eventSink: EventSink | null = null
 
   constructor(private readonly appVersion: string) {}
@@ -24,6 +30,8 @@ export class PtyManager {
 
   create(id: string, shell: string = DEFAULT_SHELL, cwd: string = DEFAULT_CWD): void {
     if (this.sessions.has(id)) return
+    // A re-create for this id means it's live again, not exited.
+    this.exited.delete(id)
 
     // Stage 18 Phase 18a — env signals (D1–D3).
     // Every PTY Duo spawns is tagged so child processes (Claude Code,
@@ -72,6 +80,7 @@ export class PtyManager {
     ptyProcess.onExit(({ exitCode }) => {
       this.eventSink?.send(IPC.PTY_EXIT(id), exitCode)
       this.sessions.delete(id)
+      this.exited.add(id) // BUG-191 — remember it died (vs never-spawned)
     })
 
     this.sessions.set(id, { id, pty: ptyProcess, cwd: resolvedCwd })
@@ -141,6 +150,19 @@ export class PtyManager {
    *  live `claude` process. */
   getPid(id: string): number | null {
     return this.sessions.get(id)?.pty.pid ?? null
+  }
+
+  /** BUG-191 — liveness for the project-rail live-cwd batch.
+   *   • 'live'    — session exists; safe to lsof its pid for the cwd.
+   *   • 'exited'  — the shell process exited; the tab keeps no project
+   *                 membership (drops a ghost tile).
+   *   • 'unknown' — no session and never recorded as exited (PTY not
+   *                 spawned yet, or create failed) → caller falls back to
+   *                 the tab's launch cwd rather than dropping its tile. */
+  getLiveness(id: string): 'live' | 'exited' | 'unknown' {
+    if (this.sessions.has(id)) return 'live'
+    if (this.exited.has(id)) return 'exited'
+    return 'unknown'
   }
 
   dispose(): void {

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -21,7 +21,24 @@
 
 ## Pending — not yet cut
 
-> *(empty — v0.8.4 cut 2026-05-28)*
+> *(empty — v0.8.5 cut 2026-06-02)*
+
+---
+
+## v0.8.5 — 2026-06-02 — Project rail correctness
+
+**Why this lands here.** The project rail (ENH-182) shipped its lifecycle behavior across v0.8.x, and a day of dogfooding surfaced four correctness bugs clustered tightly around one root: *membership is derived from inputs that don't reflect reality, and churned hardest during close.* They're a coherent chapter — all rail, all membership — so they cut together rather than dribbling out as separate patches.
+
+The two headline bugs are two faces of the same design fact. **BUG-191** (ghost tiles) is the steady-state face: a terminal's `cwd` was frozen at launch, so a shell that wandered off — or died — kept its tile forever. **BUG-192** (close-jitter) is the transition face: the close handler mutated five pieces of state (one `setState` nested inside another's updater) with no re-entrancy guard, which could spin a non-converging render loop severe enough to force-quit. Fixing 191 meant making membership track the *live* shell cwd; that surfaced **BUG-194** (a focused project whose last terminal left would hide the terminal), fixed by releasing focus to "All" when the project vanishes. **BUG-193** (phantom parent tile + focus theft) was a pre-existing latent bug the dogfooding flushed out: pinned reference docs under a git-repo parent resolved their membership up to that parent.
+
+**Key design decisions.**
+
+1. **Track the live shell cwd, don't freeze it.** A new `PTY_LIVE_CWDS` batched IPC resolves each terminal's real cwd + liveness asynchronously (`lsof` off the main thread, never blocking it); the renderer polls it on a visibility-gated 5s interval into a `liveCwdInfo` map that `deriveProjects` consumes via the pure `effectiveProjectTerminals`. A `PtyManager` liveness tri-state distinguishes an *exited* shell (drop its tile) from a *not-yet-spawned* tab (keep its launch cwd) so a fresh tab never flickers.
+2. **Make the close handler atomic and idempotent.** `inFlightCloseRef` guards re-entry, the confirm moves before any snapshot, and the nested `setActiveTabId` is hoisted out of the `setTabs` updater. The pure `planProjectClose` computes members/survivors/active-shift so the React layer just applies a plan.
+3. **Pinned tabs have no home project.** A cross-project reference shouldn't qualify whatever folder it happens to sit under — so pinned tabs get null membership, killing both the phantom parent tile and the D11 focus theft at the source.
+4. **Poll without churn.** `mergeLiveCwdInfo` returns the same map reference when nothing changed, so a steady 5s poll doesn't re-derive the project set every tick.
+
+**What this is and isn't.** v0.8.5 is a correctness patch on the project rail — no new capability surface, no roadmap stage flips. BUG-192/193/194 were owner-PASSed on the smoke walk; BUG-191 (the keystone) was owner-SKIP but agent-verified live three ways (unit tests, socket cd-out/cd-in tile clear+restore, and computer-use screenshots), which the owner accepted for the cut. The investigation that found these is itself a small artifact worth keeping — a 38-agent root-cause workflow whose decision playground lives at `docs/research/bug-191-192-ghost-tiles-jitter-rootcause.html`. One process note for the record: requesting computer-use mid-session to capture the BUG-194 proof triggered a macOS TCC permission reset that temporarily blocked file access to `~/Documents` (where the repo lives) for both the agent and the running app — recovered by restarting the session; worth weighing before reaching for computer-use on a repo under a protected folder.
 
 ---
 

--- a/docs/dev/session-log.md
+++ b/docs/dev/session-log.md
@@ -18,6 +18,19 @@
 
 ---
 
+## 2026-06-02 (v0.8.5 cut — project rail correctness: ghost tiles · close-jitter · phantom parents · multitab)
+
+**v0.8.5 cut + tagged locally.** PATCH bump (0.8.4 → 0.8.5) — four project-rail correctness fixes on branch `claude/kind-goldstine-6904c1`. Root-caused via a 38-agent investigation workflow (5-reader map → ranked hypotheses → 3-lens adversarial verification); decision playground at `docs/research/bug-191-192-ghost-tiles-jitter-rootcause.html`.
+
+- **BUG-191** ([`c215226`](https://github.com/dudgeon/duo/commit/c215226)) — ghost tiles. Terminal membership was frozen at the shell's launch cwd; now tracks the **live** shell cwd via a new batched, liveness-aware `PTY_LIVE_CWDS` IPC (async `lsof` off the main thread + a `PtyManager` liveness tri-state so an exited shell drops its tile but a not-yet-spawned tab keeps its launch cwd). Renderer polls on a visibility-gated 5s interval into a `liveCwdInfo` map consumed by `deriveProjects` via the pure `effectiveProjectTerminals`; `mergeLiveCwdInfo` keeps the map reference stable to avoid re-derive churn.
+- **BUG-192** ([`c215226`](https://github.com/dudgeon/duo/commit/c215226)) — right-click close jitter/force-quit. `handleCloseProject` now has an `inFlightCloseRef` re-entrancy guard, runs the confirm before any snapshot, and hoists `setActiveTabId` out of the `setTabs` updater. Pure `planProjectClose` extracted.
+- **BUG-193** ([`10faab3`](https://github.com/dudgeon/duo/commit/10faab3)) — phantom parent tile + D11 focus theft. Pinned reference tabs (e.g. tasks.md / idle-thoughts.md under the `~/Documents` git repo) resolved their membership up to the shallow git-repo parent. Fix: pinned tabs get null `tabMembership` in `deriveProjects`. Regression test in `core/projects-service.test.ts`.
+- **BUG-194** ([`573fe3e`](https://github.com/dudgeon/duo/commit/573fe3e)) — regression from BUG-191, caught on the v0.8.5 walk: `cd`-ing the focused project's last terminal out hid the terminal (broke ⌘T/⌃Tab) because the visibility filter matched nothing while focus stayed pinned to the now-gone project. Fix: `shouldReleaseFocus` releases focus to "All" when the focused project drops from the rail.
+- **New pure module** `shared/project-lifecycle.ts` (+19 vitest cases: effectiveProjectTerminals / mergeLiveCwdInfo / planProjectClose / shouldReleaseFocus). 868/868 tests pass; typecheck clean.
+- **Process note.** Smoke walk: BUG-192/193/194 owner-PASS; BUG-191 owner-SKIP but agent-verified live three ways (unit + socket cd-out/cd-in + computer-use screenshots), owner accepted for the cut. Requesting computer-use mid-session (for the BUG-194 visual proof) triggered a macOS TCC reset that blocked `~/Documents` file access for both agent and app until a session restart — drove the rest of the verification over the Duo Unix socket directly (CLI binary was under the blocked tree). Captured a memory lesson on weighing computer-use against protected-folder repos.
+
+---
+
 ## 2026-05-28 (v0.8.4 cut — polish patch: quit-loop · source-line gutter · nav heal)
 
 **v0.8.4 cut + tagged locally.** PATCH bump (0.8.3 → 0.8.4) — four fixes shipped over the last day plus one research doc.

--- a/docs/research/bug-191-192-ghost-tiles-jitter-rootcause.html
+++ b/docs/research/bug-191-192-ghost-tiles-jitter-rootcause.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="duo-editable" content="false">
+<title>Ghost tiles + jitter loop · root cause + fix decisions</title>
+<style>
+:root {
+  --paper: #fbf8f1;
+  --paper-deep: #f3ede0;
+  --paper-edge: #e8e0cb;
+  --paper-rule: #d9cea8;
+  --ink: #2b2620;
+  --ink-soft: #4a4238;
+  --ink-mute: #6f6557;
+  --ink-ghost: #9a9080;
+  --accent: #c46a1c;
+  --accent-soft: #f4d9b6;
+  --pass: #4a7d3e;
+  --fail: #b13e3a;
+  --warn: #b07527;
+  --code-bg: #2b2823;
+  --code-ink: #e8e0cb;
+  /* project rail hues (mirror --duo-project-* tokens) */
+  --proj-pine: #4a7d3e;
+  --proj-harbor: #3a6b8a;
+  --proj-iris: #6a5acd;
+}
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0;
+  background: var(--paper); color: var(--ink);
+  font-family: -apple-system, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+  font-size: 14px; line-height: 1.55;
+}
+body { padding: 32px 40px 96px; max-width: 980px; margin: 0 auto; }
+header.page-head { border-bottom: 1px solid var(--paper-rule); padding-bottom: 16px; margin-bottom: 24px; }
+header.page-head h1 { font-family: "New York", "Iowan Old Style", Georgia, serif; font-style: italic; font-weight: 500; margin: 0 0 4px; font-size: 24px; }
+header.page-head .meta { color: var(--ink-mute); font-size: 13px; }
+header.page-head .meta .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; background: var(--accent-soft); color: var(--accent); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; margin-right: 6px; }
+.intro { background: var(--paper-deep); border: 1px solid var(--paper-rule); border-radius: 6px; padding: 14px 18px; margin-bottom: 28px; font-size: 13.5px; color: var(--ink-soft); }
+.intro strong { color: var(--ink); font-weight: 600; }
+h2 { font-family: "New York", "Iowan Old Style", Georgia, serif; font-weight: 600; margin: 36px 0 12px; font-size: 19px; border-bottom: 1px solid var(--paper-rule); padding-bottom: 6px; }
+h3 { font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; font-weight: 600; margin: 22px 0 8px; font-size: 15px; }
+h4 { margin: 16px 0 6px; font-size: 12px; color: var(--accent); text-transform: uppercase; letter-spacing: 0.04em; font-weight: 700; }
+p { margin: 8px 0; }
+code { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; background: var(--paper-deep); padding: 1px 5px; border-radius: 3px; }
+ul, ol { margin: 8px 0; padding-left: 22px; }
+li { margin: 3px 0; }
+a { color: var(--accent); }
+
+/* confidence + verdict badges */
+.badge { display: inline-block; font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; padding: 2px 8px; border-radius: 10px; vertical-align: middle; }
+.badge.conf-med { background: #f0e2c4; color: var(--warn); }
+.badge.conf-low { background: #f1d9d6; color: var(--fail); }
+.badge.conf-high { background: #d9eccf; color: var(--pass); }
+.badge.confirmed { background: #d9eccf; color: var(--pass); }
+.badge.refuted { background: #ece6d8; color: var(--ink-mute); }
+
+/* root-cause panel */
+.rc { background: var(--paper-deep); border: 1.5px solid var(--paper-rule); border-left: 4px solid var(--accent); border-radius: 6px; padding: 14px 18px; margin: 14px 0 18px; }
+.rc .rc-cause { font-size: 14.5px; color: var(--ink); }
+.rc .rc-cause strong { color: var(--accent); }
+
+/* evidence list with file refs */
+.evidence { font-size: 12.5px; color: var(--ink-soft); }
+.evidence code { font-size: 11.5px; }
+.evidence li { margin: 4px 0; }
+
+/* triage callout */
+.triage { background: #fdf6e9; border: 1.5px dashed var(--accent); border-radius: 6px; padding: 14px 18px; margin: 16px 0; }
+.triage .t-title { font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.04em; font-size: 12px; margin-bottom: 6px; }
+
+/* rejected hypotheses table */
+.rejected { font-size: 12.5px; color: var(--ink-mute); margin: 10px 0; }
+.rejected .rj { padding: 7px 0; border-bottom: 1px solid var(--paper-edge); }
+.rejected .rj:last-child { border-bottom: none; }
+.rejected .rj .name { font-family: ui-monospace, Menlo, monospace; font-size: 11.5px; color: var(--ink-soft); font-weight: 600; }
+
+/* option cards */
+.option-grid { display: grid; grid-template-columns: 1fr; gap: 12px; margin: 12px 0 4px; }
+.option-card { background: var(--paper); border: 1.5px solid var(--paper-rule); border-radius: 6px; padding: 12px 15px; }
+.option-card.rec { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 5%, var(--paper)); }
+.option-card .oc-head { font-weight: 600; font-size: 14px; color: var(--ink); margin-bottom: 4px; }
+.option-card .oc-head .letter { display: inline-block; width: 22px; height: 22px; line-height: 22px; text-align: center; border-radius: 5px; background: var(--accent); color: white; font-weight: 700; font-size: 12px; margin-right: 8px; }
+.option-card .recommend-tag { font-size: 10px; background: var(--accent-soft); color: var(--accent); text-transform: uppercase; font-weight: 700; letter-spacing: 0.04em; padding: 1px 6px; border-radius: 8px; margin-left: 6px; }
+.option-card .oc-effort { float: right; font-size: 11px; color: var(--ink-mute); font-weight: 600; }
+.option-card .oc-body { font-size: 12.5px; color: var(--ink-soft); margin: 4px 0; }
+.option-card .oc-trade { font-size: 12px; color: var(--ink-mute); margin-top: 4px; }
+.option-card .oc-trade strong { color: var(--ink-soft); }
+.option-card .oc-files { font-size: 11px; color: var(--ink-ghost); margin-top: 4px; }
+.option-card .oc-files code { font-size: 11px; }
+
+/* ── project-tile mockups (mirror the rail) ── */
+.tile-row { display: flex; gap: 24px; align-items: flex-start; margin: 14px 0; flex-wrap: wrap; }
+.tile-demo { text-align: center; }
+.tile { position: relative; width: 44px; height: 44px; border-radius: 8px; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 700; color: white; margin: 0 auto; }
+.tile .pip { position: absolute; top: 3px; right: 3px; width: 6px; height: 6px; border-radius: 50%; background: white; }
+.tile-demo .cap { font-size: 11px; color: var(--ink-mute); margin-top: 6px; max-width: 150px; }
+.tile-demo .verdict { font-size: 10.5px; font-weight: 700; margin-top: 3px; }
+.tile-demo .verdict.bug { color: var(--fail); }
+.tile-demo .verdict.ok { color: var(--pass); }
+
+/* ── flow / causal-chain diagram ── */
+.chain { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 12px 0; font-size: 12px; }
+.chain .step { background: var(--paper); border: 1.5px solid var(--paper-rule); border-radius: 5px; padding: 7px 11px; color: var(--ink-soft); max-width: 200px; }
+.chain .step.bad { border-color: var(--fail); color: var(--fail); background: #fdf0ef; font-weight: 600; }
+.chain .step code { font-size: 11px; background: var(--paper-deep); }
+.chain .arrow { color: var(--ink-ghost); font-size: 16px; }
+
+/* burst diagram */
+.burst { background: var(--code-bg); color: var(--code-ink); border-radius: 6px; padding: 14px 16px; font-family: ui-monospace, Menlo, monospace; font-size: 11.5px; line-height: 1.7; margin: 12px 0; overflow-x: auto; }
+.burst .hl { color: #f4b860; font-weight: 700; }
+.burst .dim { color: #9a9080; }
+.burst .danger { color: #e88; }
+
+/* ── decision cards (verbatim Atelier kernel) ── */
+.decision-card { background: var(--paper-deep); border: 1.5px solid var(--paper-rule); border-radius: 6px; padding: 16px 18px; margin: 18px 0; }
+.decision-card .q-title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--accent); margin: 0 0 6px; }
+.decision-card .q-prompt { font-family: "New York", "Iowan Old Style", Georgia, serif; font-weight: 500; font-size: 17px; color: var(--ink); margin: 0 0 12px; line-height: 1.35; }
+.decision-card .q-context { font-size: 13px; color: var(--ink-mute); margin: 0 0 14px; }
+.q-options { display: grid; grid-template-columns: 1fr; gap: 10px; margin: 0 0 12px; }
+.q-option { display: block; background: var(--paper); border: 1.5px solid var(--paper-rule); border-radius: 5px; padding: 10px 12px; cursor: pointer; transition: border-color 0.12s, background 0.12s; }
+.q-option:hover { border-color: var(--ink-ghost); }
+.q-option input[type="radio"] { margin-right: 8px; cursor: pointer; accent-color: var(--accent); }
+.q-option:has(input[type="radio"]:checked) { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 6%, var(--paper)); }
+.q-option-body { display: inline-block; vertical-align: top; width: calc(100% - 22px); }
+.q-option-title { font-weight: 600; font-size: 13.5px; color: var(--ink); margin: 0 0 3px; }
+.q-option-title .recommend-tag { font-size: 10px; background: var(--accent-soft); color: var(--accent); text-transform: uppercase; font-weight: 700; letter-spacing: 0.04em; padding: 1px 6px; border-radius: 8px; margin-left: 6px; }
+.q-option-rationale { font-size: 12px; color: var(--ink-soft); line-height: 1.45; margin: 3px 0 0; }
+.q-notes { width: 100%; background: var(--paper); border: 1px solid var(--paper-rule); border-radius: 4px; padding: 8px 10px; font-family: inherit; font-size: 12.5px; color: var(--ink); resize: vertical; min-height: 50px; }
+.q-notes:focus { outline: 1.5px solid var(--accent); }
+.copy-bar { position: sticky; bottom: 0; margin: 32px -40px -96px; padding: 16px 40px; background: color-mix(in srgb, var(--paper-deep) 96%, transparent); border-top: 1.5px solid var(--paper-rule); backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); display: flex; justify-content: space-between; align-items: center; gap: 16px; }
+.copy-bar .copy-meta { font-size: 12.5px; color: var(--ink-soft); }
+.copy-bar #answered-count { color: var(--accent); font-weight: 700; }
+.copy-bar button { background: var(--accent); color: white; border: none; border-radius: 5px; padding: 9px 18px; font-family: inherit; font-size: 13.5px; font-weight: 600; cursor: pointer; transition: background 0.12s; }
+.copy-bar button:hover { background: color-mix(in srgb, black 8%, var(--accent)); }
+.copy-bar button.copied { background: var(--pass); }
+</style>
+</head>
+<body>
+
+<header class="page-head">
+  <h1>Ghost tiles + jitter loop · root cause + fix decisions</h1>
+  <div class="meta">
+    <span class="pill">Decision gate</span>
+    <span class="pill">3 questions</span>
+    Filed 2026-05-29 · BUG-191 (ghost tiles) + BUG-192 (jitter loop) · ENH-182 project rail
+  </div>
+</header>
+
+<div class="intro">
+  <strong>Owner report.</strong> <em>"I am still running into an issue with ghost project tiles that persist when no files or terminal tabs from that project are open; I also encountered a recursive jitter loop I needed to force quit when closing a project tile through right click."</em>
+  <br><br>
+  <strong>How this was produced.</strong> A 38-agent root-cause workflow: 5 parallel readers mapped the project-rail subsystems → ranked candidate root causes per bug → each candidate attacked by 3 independent skeptics (reachability · existing-guards · symptom-fidelity); a candidate survives only if fewer than 2 lenses refute it. The headline up front:
+  <ul style="margin: 6px 0 0;">
+    <li><strong>BUG-191 (ghost tiles)</strong> — <span class="badge conf-med">Medium confidence</span> root cause found and <span class="badge confirmed">survived all 3 lenses</span>: a terminal's <code>cwd</code> is frozen at launch, so a shell that <code>cd</code>'d away — or exited — keeps a tile alive forever.</li>
+    <li><strong>BUG-192 (jitter loop)</strong> — <span class="badge conf-low">Low confidence</span>. Honest finding: <em>every</em> concrete loop candidate was refuted by static analysis (they all converge in today's build). The structurally-implicated handler is named, but proving the runaway needs a live repro. Recommended path includes instrumentation.</li>
+  </ul>
+</div>
+
+<!-- ════════════════════════ BUG-191 ════════════════════════ -->
+<h2>BUG-191 · Ghost project tile (zero open members) <span class="badge conf-med">Medium</span></h2>
+
+<div class="rc">
+  <div class="rc-cause">
+    <strong>Root cause — frozen terminal launch-cwd.</strong> A tile renders only if its root owns ≥1 <em>member</em> or is pinned. A terminal's <code>cwd</code> is set <em>once</em> at construction (<code>makeTab</code>) and is <strong>never rewritten</strong> — not when the shell <code>cd</code>s elsewhere, not when the shell process exits. So a terminal whose launch directory was under project A keeps qualifying A on every derive, even after you've navigated away or the shell is dead. A pure zero-member <em>unpinned</em> tile is provably impossible in the derivation layer, so a ghost is always one of three buckets:
+  </div>
+  <ol style="margin: 10px 0 0; font-size: 13px;">
+    <li><strong>Frozen-cwd / dead-shell terminal</strong> still in <code>tabs[]</code> — <span class="badge confirmed">confirmed, refuteCount 0</span> · pip-less · <em>the primary defect.</em></li>
+    <li><strong>Deleted-file working tab</strong> never pruned from <code>fileTabs[]</code> — secondary · pip-less.</li>
+    <li><strong>Pinned tile</strong> — shows the pin pip · working-as-designed (D12) or the FOLLOWUP-037 deleted-marker caveat.</li>
+  </ol>
+</div>
+
+<div class="chain">
+  <span class="step">Open terminal, launch cwd <code>~/GitHub/duo</code> (project A, A's only member)</span>
+  <span class="arrow">→</span>
+  <span class="step">Inside the shell: <code>cd ~</code> &nbsp;<em>(or the shell <code>exit</code>s)</em></span>
+  <span class="arrow">→</span>
+  <span class="step bad"><code>tabs[].cwd</code> still says <code>~/GitHub/duo</code> — never updated</span>
+  <span class="arrow">→</span>
+  <span class="step bad">Tile A persists, pip-less, "0 things open"</span>
+</div>
+
+<div class="triage">
+  <div class="t-title">⟐ Triage first — the pin pip tells you which bucket you're in</div>
+  The single decisive observable is whether the ghost tile shows a small <strong>pin pip</strong> (top-right dot). This determines whether it's even a bug:
+  <div class="tile-row" style="margin-top: 12px;">
+    <div class="tile-demo">
+      <div class="tile" style="background: var(--proj-harbor);">DU</div>
+      <div class="cap">No pip</div>
+      <div class="verdict bug">▶ stale-member BUG-191</div>
+    </div>
+    <div class="tile-demo">
+      <div class="tile" style="background: var(--proj-pine);">AP<span class="pip"></span></div>
+      <div class="cap">Pip present</div>
+      <div class="verdict ok">✓ pinned — by-design / FOLLOWUP-037</div>
+    </div>
+    <div style="flex: 1; min-width: 220px; font-size: 12.5px; color: var(--ink-soft);">
+      <strong>Pip absent</strong> → this is the frozen-cwd / dead-shell bug. Right-click it: a <code>"Close N terminals"</code> with N≥1 confirms a stale terminal; <code>"M tabs"</code> with M≥1 confirms a deleted-file tab.<br>
+      <strong>Pip present</strong> → it's pinned. Check <code>~/.claude/duo/projects.json</code> and whether the folder/marker still exists (FOLLOWUP-037). Not the live defect.
+    </div>
+  </div>
+</div>
+
+<h4>Evidence</h4>
+<ul class="evidence">
+  <li><code>renderer/App.tsx:192-200</code> — <code>makeTab</code> sets <code>cwd</code> once at construction; no later writer (13-site <code>setTabs</code> audit confirms no <code>cwd</code> mutation anywhere).</li>
+  <li><code>renderer/App.tsx:882-885</code> — <code>projectTerminals</code> = unfiltered <code>tabs.map(t =&gt; ({id, cwd}))</code>, carrying the frozen launch cwd straight into derivation.</li>
+  <li><code>shared/types.ts:1398-1402</code> — <code>PTY_LIVE_CWD</code> (the <em>live</em> shell cwd) already exists, but is only read to <em>seed</em> a new tab (<code>App.tsx:1561-1562, 2626-2627</code>) — never written back to the tab.</li>
+  <li><code>renderer/hooks/useTerminal.ts:24-26</code> + <code>renderer/components/TerminalPane.tsx:439-441</code> — both PTY-exit subscribers only <code>writeln('[process exited]')</code>; neither removes the tab nor clears <code>cwd</code> (a dead shell stays a full member).</li>
+  <li><code>renderer/App.tsx:1600</code> — <code>closeTab</code> floor-of-1 guard prevents closing a sole stale terminal, <em>amplifying</em> the ghost.</li>
+  <li><code>shared/projects.ts:247-248, 260-262</code> — <code>terminalMembership</code> derives from <code>t.cwd</code> → re-adds the root on every derive.</li>
+  <li>Secondary (deleted file): <code>renderer/App.tsx:886-892</code> (filter is <code>!!path &amp;&amp; !isNew</code> only — no existence check); <code>MarkdownEditor.tsx:1024-1030</code> (<code>if (event.kind === 'removed') return</code> — a delete does <em>not</em> close the tab); no in-session <code>files.watch</code> prune exists.</li>
+</ul>
+
+<h4>Rejected hypotheses</h4>
+<div class="rejected">
+  <div class="rj"><span class="name">pinned-zero-member-by-design</span> <span class="badge refuted">refuted · symptom</span> — produces a tile <em>with</em> a pip and only via deliberate <code>togglePin</code>; can't be a surprise ghost hit "repeatedly."</div>
+  <div class="rj"><span class="name">deleted-pin-mid-session (FOLLOWUP-037)</span> <span class="badge refuted">refuted · symptom</span> — real but yields a <em>pip-bearing</em> tile and needs pinned + folder-deleted-out-of-band; already triaged Option-D-accepted.</div>
+  <div class="rj"><span class="name">stale-git-marker-cache</span> <span class="badge refuted">refuted · symptom</span> — the cache only <em>sustains</em> a tile that still has a member; it can't create one. A force-multiplier on frozen-cwd, not a standalone cause.</div>
+</div>
+
+<h4>Fix options</h4>
+<div class="option-grid">
+  <div class="option-card rec">
+    <div class="oc-head"><span class="letter">a</span>Track the live shell cwd into membership <span class="recommend-tag">Recommended</span><span class="oc-effort">Effort: M</span></div>
+    <div class="oc-body">Wire the existing <code>PTY_LIVE_CWD</code> channel through <code>useTerminal.ts</code> to update <code>tabs[].cwd</code> (or a new <code>liveCwd</code> field consulted at <code>App.tsx:882-885</code>) when the shell <code>cd</code>s. On PTY exit, drop the tab's project membership or surface a dead-shell affordance.</div>
+    <div class="oc-trade"><strong>Trade-off:</strong> fixes the root perception mismatch — the rail follows where the shell <em>is</em>, not where it <em>started</em> — and covers both the cd-away and shell-exit variants. Cost: new IPC traffic on every cwd change + a dead-shell UX call.</div>
+    <div class="oc-files">Files: <code>renderer/hooks/useTerminal.ts</code>, <code>renderer/App.tsx</code> (882-885 + exit handling), <code>shared/types.ts</code>.</div>
+  </div>
+  <div class="option-card">
+    <div class="oc-head"><span class="letter">b</span>Prune dead members reactively<span class="oc-effort">Effort: M</span></div>
+    <div class="oc-body">On PTY exit, clear the tab's cwd contribution; add a <code>files.watch</code>-driven prune of <code>fileTabs[]</code> on <code>'removed'</code>, mirroring PR #59's navigator self-heal.</div>
+    <div class="oc-trade"><strong>Trade-off:</strong> closes both leaks (dead shell + deleted-file tab) and matches established prior art. Risk: must prune <em>membership</em> without yanking MarkdownEditor's buffer (it deliberately keeps a deleted file open to allow save-to-recreate).</div>
+    <div class="oc-files">Files: <code>renderer/App.tsx</code> (PTY-exit subscriber, new fileTabs prune effect), <code>renderer/components/editor/MarkdownEditor.tsx</code>.</div>
+  </div>
+  <div class="option-card">
+    <div class="oc-head"><span class="letter">c</span>Diagnostics only — explain, don't remove<span class="oc-effort">Effort: S</span></div>
+    <div class="oc-body">Leave membership alone; show the live cwd / <code>[exited]</code> state in the tile's right-click count and add a "this terminal cd'd out of the project" hint.</div>
+    <div class="oc-trade"><strong>Trade-off:</strong> smallest change, zero derivation risk — but the tile still persists, so it likely won't satisfy "stop showing me ghosts."</div>
+    <div class="oc-files">Files: <code>renderer/components/ProjectRail/ProjectRail.tsx</code>, <code>renderer/App.tsx</code> (<code>projectCounts</code>).</div>
+  </div>
+</div>
+
+<!-- ════════════════════════ BUG-192 ════════════════════════ -->
+<h2>BUG-192 · Recursive jitter / force-quit loop on right-click close <span class="badge conf-low">Low</span></h2>
+
+<div class="rc">
+  <div class="rc-cause">
+    <strong>Root cause — not pinned down by static analysis.</strong> Every concrete loop candidate was <span class="badge refuted">refuted across all 3 lenses</span> — they all <em>converge</em> in today's build (value-equality bailouts, monotone probe caches, a raw-cwd guard, and universal <code>focusedProject === null</code> early-returns). The best-supported remaining explanation is the <strong>unguarded cross-store setState burst inside <code>handleCloseProject</code></strong>: <code>setTabs</code> (with a <em>nested</em> <code>setActiveTabId</code> inside its updater) + <code>setFileTabs</code> + <code>setActiveWorking</code> + <code>setFocusedProject</code>, optionally split by an <code>await dialog.confirm</code>, feeding the live effect cluster (browser-redirect machine E5/E6/E7 + auto-spawn E9) while membership probes are still settling — with <strong>no in-flight / re-entrancy guard</strong> (FOLLOWUP-032, never implemented). You <em>did</em> force-quit, so a non-convergent region is reachable in practice; it most likely lives in the burst → effect-cluster interaction under specific timing (closing a <em>non-focused</em> tile keeps focus non-null and voids the convergence proofs, + a browser member tab + probe lag).
+  </div>
+</div>
+
+<div class="burst">
+<span class="dim">// handleCloseProject — App.tsx:1035-1101 — one user right-click fires:</span>
+<span class="danger">await</span> dialog.confirm(...)        <span class="dim">// only if a claude terminal — splits across ticks</span>
+setTabs(prev =&gt; {
+   <span class="hl">setActiveTabId(survivors[0].id)</span>   <span class="danger">// ← nested setState inside a supposed-pure updater</span>
+   <span class="hl">survivors.push(makeTab(home...))</span>   <span class="dim">// floor-of-1 append</span>
+})
+setFileTabs(...)  setActiveWorking({kind:'browser'})  setFocusedProject(null)
+<span class="dim">         ↓ feeds, while probes still settling ↓</span>
+<span class="danger">E5/E6/E7</span> browser-redirect machine  +  <span class="danger">E9</span> auto-spawn   <span class="dim">// no inFlightCloseRef guard · StrictMode off</span>
+</div>
+
+<h4>Evidence</h4>
+<ul class="evidence">
+  <li><code>renderer/App.tsx:1035-1101</code> — <code>handleCloseProject</code>; no <code>inFlightCloseRef</code> (FOLLOWUP-032, <code>tasks.md:386</code>).</li>
+  <li><code>renderer/App.tsx:1064-1075</code> — <code>setTabs</code> updater with a <strong>nested</strong> <code>setActiveTabId</code> (1071-1073) + <code>makeTab</code> append on zero survivors — a setState inside a supposed-pure updater.</li>
+  <li><code>renderer/App.tsx:1049-1060</code> — <code>await dialog.confirm</code> splits the handler across ticks (claude-terminal case only), letting intervening IPC renders land mid-flush.</li>
+  <li><code>renderer/App.tsx:1085-1087</code> vs <code>1458-1471</code> — redundant focus-release (the handler <em>and</em> effect E10 both set focus to <code>null</code>).</li>
+  <li><code>renderer/App.tsx:1242-1346</code> (E5/E6/E7) — browser-redirect state machine; async <code>browser.switchTab</code> re-enters a tick later; convergence is <em>conditional</em> on equality guards.</li>
+  <li><code>renderer/components/ProjectRail/ProjectRail.tsx:184</code> — the Close item gates on <code>n&gt;0||m&gt;0</code> regardless of focus, so a <strong>non-focused-tile close</strong> (focus stays non-null) is reachable and voids the <code>focusedProject===null</code> fixed-point proofs.</li>
+  <li><code>renderer/main.tsx:21-25</code> — StrictMode intentionally off → no double-invoke damping in dev.</li>
+  <li>Echo ruled out: <code>electron/main.ts:1841-1843</code> — the <code>pushState</code> handler is echo-free, so the IPC feedback loop is <em>not</em> the cause.</li>
+</ul>
+
+<h4>Rejected hypotheses <span style="font-weight: 400; font-size: 12px; color: var(--ink-mute);">(all converge in the current build)</span></h4>
+<div class="rejected">
+  <div class="rj"><span class="name">e9-e10 auto-spawn ↔ auto-release ping-pong</span> <span class="badge refuted">refuted · all 3</span> — <code>hasTerminalUnderRoot</code> reads raw <code>cwd</code> (immune to probe lag) + <code>autoSpawnedForRef</code> blocks re-spawn; the cycle's two preconditions can't co-hold. Bounded.</div>
+  <div class="rj"><span class="name">e5-e7 browser-redirect re-arm</span> <span class="badge refuted">refuted</span> — <code>browserTabMembership</code> is a pure synchronous prefix-match; <code>railProjects</code> is invariant to the <code>switchTab</code> round-trip → one-step convergence.</div>
+  <div class="rj"><span class="name">setActiveTabId-inside-setTabs-updater</span> <span class="badge refuted">refuted</span> — a real latent landmine, but inert <em>today</em>: StrictMode off + classic React 18.3 root means the updater runs exactly once. Worst case is a one-render flicker E9 self-repairs.</div>
+  <div class="rj"><span class="name">FOLLOWUP-032 double-invoke</span> <span class="badge refuted">refuted</span> — needs two concurrent close requests (CLI path); a single right-click can't double-invoke, and it converges anyway (idempotent re-flush).</div>
+  <div class="rj"><span class="name">convergent-burst-misread</span> <span class="badge refuted">refuted · symptom</span> — a transient settling flash doesn't need a force-quit; owner distinguishes benign instability from real loops. Must still be falsified live.</div>
+</div>
+
+<h4>Fix options</h4>
+<div class="option-grid">
+  <div class="option-card rec">
+    <div class="oc-head"><span class="letter">a</span>Atomic + re-entrancy-guarded handler <span class="recommend-tag">Recommended</span><span class="oc-effort">Effort: M</span></div>
+    <div class="oc-body">Add an <code>inFlightCloseRef</code> (FOLLOWUP-032's proposed fix) so a second invocation no-ops. Compute <code>survivors</code> <em>before</em> the updater and call <code>setActiveTabId</code> <em>after</em> <code>setTabs</code> (never inside it). Batch all writes in one synchronous continuation; move <code>await dialog.confirm</code> <em>before</em> any snapshot.</div>
+    <div class="oc-trade"><strong>Trade-off:</strong> removes the re-entrancy hazard, the cross-store updater anti-pattern, and the await-split window in one pass — hardens the implicated handler regardless of the exact trigger. Doesn't by itself <em>prove</em> the loop is gone (needs live confirmation), and touches the most load-bearing handler → full smoke-walk.</div>
+    <div class="oc-files">Files: <code>renderer/App.tsx:1035-1101</code>.</div>
+  </div>
+  <div class="option-card">
+    <div class="oc-head"><span class="letter">b</span>Instrument first, then fix<span class="oc-effort">Effort: S + M</span></div>
+    <div class="oc-body">Before changing logic, add a dev-only update-depth counter / effect fire-count log around E5/E7/E9/E10 and reproduce live (per the project's "build the visibility tool first" rule). Capture the actual non-converging edge, then apply the fix.</div>
+    <div class="oc-trade"><strong>Trade-off:</strong> highest diagnostic certainty — turns the Low-confidence root cause into a confirmed one before committing a fix. Costs a round-trip; ships no fix on its own. <em>Given the Low confidence, this is the conservative first move and composes with (a).</em></div>
+    <div class="oc-files">Files: temporary instrumentation in <code>renderer/App.tsx</code> / React DevTools profiler.</div>
+  </div>
+  <div class="option-card">
+    <div class="oc-head"><span class="letter">c</span>Decouple the browser-redirect machine from the close burst<span class="oc-effort">Effort: M</span></div>
+    <div class="oc-body">Gate E6/E7 so they don't re-arm during an in-flight close (read the same <code>inFlightCloseRef</code>); make E7's <code>switchTab</code> fire-and-forget without feeding <code>setFocusedProject</code> back through E5 during a close.</div>
+    <div class="oc-trade"><strong>Trade-off:</strong> targets the specific conditional-convergence region flagged as residual risk; lower blast radius than (a) — but only helps if the loop is in fact in that cluster, and leaves the nested-setState + re-entrancy hazards in place.</div>
+    <div class="oc-files">Files: <code>renderer/App.tsx:1242-1346</code>.</div>
+  </div>
+</div>
+
+<!-- ════════════════════════ Cross-cutting ════════════════════════ -->
+<h2>Cross-cutting — one root family, two faces</h2>
+<p>Both bugs descend from the same design facts: <strong>membership is fully re-derived every render</strong> (<code>shared/projects.ts:259-271</code>), <strong>probe caches are monotone and never invalidate</strong> (<code>useProjects.ts:84-94</code>), and <strong>there is no reactive prune of dead terminals / file-tabs.</strong></p>
+<ul>
+  <li><strong>BUG-191 is the steady-state face</strong> — a stale member lingers in <code>tabs[]</code>/<code>fileTabs[]</code> and quietly keeps a tile alive.</li>
+  <li><strong>BUG-192 is the transition face</strong> — the close mutates those same arrays across multiple stores while membership probes lag, driving the effect cluster.</li>
+</ul>
+<p>Reactively pruning stale members (191-b) shrinks the very arrays the close handler thrashes, <em>narrowing</em> 192's probe-pending window — a mitigation, not a cure (it leaves the re-entrancy / nested-setState hazards). The cleanest combined posture is <strong>191-a (live-cwd tracking) + 192-a (atomic guarded handler)</strong>: the rail reflects live state <em>and</em> the close becomes a single safe transition. The two are independent enough to ship and smoke-walk separately.</p>
+
+<!-- ════════════════════════ Confirmation plan ════════════════════════ -->
+<h2>Confirmation plan <span style="font-weight: 400; font-size: 13px; color: var(--ink-mute);">(this analysis is static — confirm live before/after)</span></h2>
+<h3>BUG-191 — disambiguate the bucket first (it picks which fix matters)</h3>
+<ol>
+  <li>Reproduce a ghost, then <strong>inspect the tile for a pin pip</strong> (<code>duo dom</code> / <code>duo eval</code> against <code>ProjectRail</code>, or screenshot). Pip → pinned case; pip-less → continue.</li>
+  <li>Right-click the ghost and read the "Close N terminals and M tabs" label (or query <code>projectCounts</code>). <code>N≥1</code> = stale terminal; <code>M≥1</code> = stale file tab.</li>
+  <li><strong>Frozen-cwd repro:</strong> open a terminal launched under a git/marker project A (A unpinned, no other members), then inside the shell <code>cd ~</code>. Confirm tile A persists, pip-less, <code>N=1</code>. Repeat letting the shell <code>exit</code> — confirm the dead-shell tab still counts.</li>
+  <li><strong>Deleted-file repro:</strong> open a markdown file under project B (B's only member), <code>rm</code> it from a shell without closing the tab. Confirm tile B persists, <code>M=1</code>.</li>
+  <li><strong>Regression tests:</strong> pure-function test of <code>deriveProjects</code> (a terminal whose cwd no longer maps drops the tile once cwd-tracking lands) + a prune test for a <code>fileTabs</code> entry pointing at a non-existent path. No Electron needed.</li>
+</ol>
+<h3>BUG-192 — confirm the loop, then the fix</h3>
+<ol>
+  <li><strong>Live repro with instrumentation:</strong> <code>npm run dev</code> + React DevTools (or temporary effect fire-count logs + an update-depth counter). Drive the gesture: be focused on a project with an active <code>file://</code> <em>browser</em> member tab, then right-click-close it — <em>and</em> the non-focused-tile variant (close a different project's tile while focused elsewhere). Watch for "Maximum update depth exceeded" / a non-settling fire-count.</li>
+  <li>If it reproduces, capture which effect's setState re-fires — that names the exact edge (expected: E5↔E6↔E7 with async <code>switchTab</code>, or the burst re-entering during the <code>await dialog.confirm</code> window).</li>
+  <li>Apply 192-a, re-run the same repro, confirm a single converging burst and no force-quit.</li>
+  <li><strong>Regression test:</strong> RTL test asserting two in-flight invocations flush once (guard works) + bounded render count after closing a project with a browser member tab. Full <code>/smoke-walk</code> since this touches the most load-bearing handler.</li>
+</ol>
+
+<!-- ════════════════════════ Decisions ════════════════════════ -->
+<h2>Decisions</h2>
+
+<div class="decision-card">
+  <div class="q-title">Q1 · BUG-191 ghost-tile fix</div>
+  <div class="q-prompt">How should we kill the ghost tiles?</div>
+  <p class="q-context">Confirmed root cause (frozen launch-cwd). Assumes the triage shows a <em>pip-less</em> tile — if your ghosts show a pip, this is the FOLLOWUP-037 pinned case instead, note that below.</p>
+  <div class="q-options">
+    <label class="q-option">
+      <input type="radio" name="q1-bug191-fix" value="a-live-cwd">
+      <div class="q-option-body">
+        <div class="q-option-title">a · Track the live shell cwd into membership <span class="recommend-tag">Recommended</span></div>
+        <div class="q-option-rationale">Rail follows where the shell <em>is</em>, not where it started. Covers cd-away + shell-exit. Effort M.</div>
+      </div>
+    </label>
+    <label class="q-option">
+      <input type="radio" name="q1-bug191-fix" value="b-reactive-prune">
+      <div class="q-option-body">
+        <div class="q-option-title">b · Prune dead members reactively (PTY-exit + files.watch)</div>
+        <div class="q-option-rationale">Closes both leaks, mirrors PR #59. Must prune membership without yanking the editor buffer. Effort M.</div>
+      </div>
+    </label>
+    <label class="q-option">
+      <input type="radio" name="q1-bug191-fix" value="c-diagnostics">
+      <div class="q-option-body">
+        <div class="q-option-title">c · Diagnostics only (explain the ghost, don't remove it)</div>
+        <div class="q-option-rationale">Smallest, zero derivation risk — but the tile still persists. Effort S.</div>
+      </div>
+    </label>
+  </div>
+  <textarea class="q-notes" name="q1-notes" placeholder="Notes / 'combine a+b' / 'my ghost has a pip' ..."></textarea>
+</div>
+
+<div class="decision-card">
+  <div class="q-title">Q2 · BUG-192 jitter-loop approach</div>
+  <div class="q-prompt">How should we approach the force-quit loop, given Low static confidence?</div>
+  <p class="q-context">No candidate survived verification — the loop is real (you force-quit) but its exact edge is timing-dependent. (a) hardens the implicated handler regardless; (b) confirms the edge first.</p>
+  <div class="q-options">
+    <label class="q-option">
+      <input type="radio" name="q2-bug192-approach" value="a-atomic-guard">
+      <div class="q-option-body">
+        <div class="q-option-title">a · Atomic + re-entrancy-guarded handler <span class="recommend-tag">Recommended</span></div>
+        <div class="q-option-rationale">inFlightCloseRef + hoist setActiveTabId out of the updater + move the confirm before any snapshot. Hardens regardless of trigger. Effort M.</div>
+      </div>
+    </label>
+    <label class="q-option">
+      <input type="radio" name="q2-bug192-approach" value="b-instrument-first">
+      <div class="q-option-body">
+        <div class="q-option-title">b · Instrument first, then fix (conservative)</div>
+        <div class="q-option-rationale">Build the visibility tool, repro live, capture the real edge, then apply (a). Highest certainty; composes with (a). Effort S + M.</div>
+      </div>
+    </label>
+    <label class="q-option">
+      <input type="radio" name="q2-bug192-approach" value="c-decouple-browser">
+      <div class="q-option-body">
+        <div class="q-option-title">c · Decouple the browser-redirect machine from the close burst</div>
+        <div class="q-option-rationale">Narrow, low blast radius — but only helps if the loop is in that cluster; leaves other hazards. Effort M.</div>
+      </div>
+    </label>
+  </div>
+  <textarea class="q-notes" name="q2-notes" placeholder="Notes / 'do b then a' ..."></textarea>
+</div>
+
+<div class="decision-card">
+  <div class="q-title">Q3 · Sequencing &amp; scope</div>
+  <div class="q-prompt">What order do we tackle these in?</div>
+  <p class="q-context">191 has a confirmed cause and high day-to-day annoyance; 192 is a force-quit but its edge is unconfirmed. They're independent enough to ship separately.</p>
+  <div class="q-options">
+    <label class="q-option">
+      <input type="radio" name="q3-sequencing" value="a-191-then-instrument-192">
+      <div class="q-option-body">
+        <div class="q-option-title">a · Ship 191 now, instrument 192 in parallel <span class="recommend-tag">Recommended</span></div>
+        <div class="q-option-rationale">Bank the confirmed fix immediately; de-risk 192 with eyes-on before committing its handler rewrite.</div>
+      </div>
+    </label>
+    <label class="q-option">
+      <input type="radio" name="q3-sequencing" value="b-both-together">
+      <div class="q-option-body">
+        <div class="q-option-title">b · Both together (combined 191-a + 192-a posture)</div>
+        <div class="q-option-rationale">One sprint, one smoke-walk of the whole rail-close surface. Bigger blast radius at once.</div>
+      </div>
+    </label>
+    <label class="q-option">
+      <input type="radio" name="q3-sequencing" value="c-192-first">
+      <div class="q-option-body">
+        <div class="q-option-title">c · 192 first — a force-quit outranks an annoyance</div>
+        <div class="q-option-rationale">Severity-led. Accepts working on the Low-confidence bug before the confirmed one.</div>
+      </div>
+    </label>
+    <label class="q-option">
+      <input type="radio" name="q3-sequencing" value="d-file-only">
+      <div class="q-option-body">
+        <div class="q-option-title">d · File both, decide at next sprint-plan</div>
+        <div class="q-option-rationale">No work now; BUG-191/192 enter the backlog and get prioritized with everything else.</div>
+      </div>
+    </label>
+  </div>
+  <textarea class="q-notes" name="q3-notes" placeholder="Notes..."></textarea>
+</div>
+
+<div class="copy-bar">
+  <div class="copy-meta">
+    <span id="answered-count">0 / 3</span> decisions answered. Hit Copy, then paste back to Claude.
+  </div>
+  <button id="copy-decisions" type="button">Copy decisions</button>
+</div>
+
+<script>
+(function () {
+  const counter = document.getElementById('answered-count');
+  const button = document.getElementById('copy-decisions');
+  const QS = [
+    { id: 'q1-bug191-fix', title: 'Q1 · BUG-191 ghost-tile fix' },
+    { id: 'q2-bug192-approach', title: 'Q2 · BUG-192 jitter-loop approach' },
+    { id: 'q3-sequencing', title: 'Q3 · Sequencing & scope' }
+  ];
+  function refresh() {
+    let answered = 0;
+    for (const q of QS) {
+      if (document.querySelector('input[name="' + q.id + '"]:checked')) answered++;
+    }
+    counter.textContent = answered + ' / ' + QS.length;
+  }
+  document.addEventListener('change', refresh);
+  document.addEventListener('input', refresh);
+  refresh();
+  function buildPayload() {
+    const lines = [];
+    lines.push('GHOST TILES + JITTER LOOP — FIX DECISIONS (' + new Date().toISOString().slice(0, 10) + ')');
+    lines.push('BUG-191 (ghost tiles) + BUG-192 (jitter loop)');
+    lines.push('=================================================');
+    lines.push('');
+    for (const q of QS) {
+      const checked = document.querySelector('input[name="' + q.id + '"]:checked');
+      const value = checked ? checked.value : '(no pick)';
+      const notes = (document.querySelector('textarea[name="' + q.id.replace(/^(q\d+)-.+$/, '$1') + '-notes"]')?.value || '').trim();
+      lines.push('[' + value.toUpperCase() + '] ' + q.title);
+      if (notes) for (const line of notes.split('\n')) lines.push('    ' + line);
+      lines.push('');
+    }
+    lines.push('---');
+    lines.push('Source: docs/research/bug-191-192-ghost-tiles-jitter-rootcause.html');
+    return lines.join('\n');
+  }
+  button.addEventListener('click', async () => {
+    const payload = buildPayload();
+    try {
+      await navigator.clipboard.writeText(payload);
+      button.textContent = 'Copied!';
+      button.classList.add('copied');
+      setTimeout(() => {
+        button.textContent = 'Copy decisions';
+        button.classList.remove('copied');
+      }, 2000);
+    } catch (err) {
+      button.textContent = 'Copy failed';
+      console.error(err);
+    }
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,7 +2,10 @@ import { app, BrowserWindow, Menu, dialog, ipcMain, nativeImage, nativeTheme, pr
 import type { MenuItemConstructorOptions, WebContents } from 'electron'
 import * as nodeFs from 'fs/promises'
 import * as nodePath from 'path'
-import { execSync } from 'child_process'
+import { execSync, execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
 
 // BUG-148 — suppress EPIPE on stdout/stderr. When the parent process
 // (npm / electron-vite / the launching terminal) detaches or closes
@@ -1240,6 +1243,13 @@ function setupIPC(): void {
     if (!pid) return null
     return getLiveCwdForPid(pid)
   })
+
+  // BUG-191 — batched, non-blocking live-cwd + liveness for the project
+  // rail's ghost-tile fix. The renderer polls this on an interval; see
+  // getLiveCwdsForIds.
+  ipcMain.handle(IPC.PTY_LIVE_CWDS, (_event, { ids }: { ids: string[] }) =>
+    getLiveCwdsForIds(ids)
+  )
 
   // ── Browser ───────────────────────────────────────────────────────────────
 
@@ -2679,6 +2689,44 @@ function getLiveCwdForPid(pid: number): string | null {
   } catch {
     return null
   }
+}
+
+// BUG-191 — async sibling of getLiveCwdForPid. Uses execFile (no shell,
+// args array) and does NOT block the main thread, so the project-rail
+// poll can resolve many terminals' live cwds in parallel.
+async function getLiveCwdForPidAsync(pid: number): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('lsof', ['-a', '-d', 'cwd', '-p', String(pid), '-Fn'], {
+      timeout: 1000
+    })
+    const line = stdout.split('\n').find((l) => l.startsWith('n'))
+    if (!line) return null
+    const cwd = line.slice(1).trim()
+    return cwd || null
+  } catch {
+    return null
+  }
+}
+
+// BUG-191 — batched live-cwd + liveness for the project rail. 'exited'
+// shells report alive:false (the renderer drops their ghost tile),
+// 'unknown' shells (PTY not spawned yet) report alive:true with a null
+// cwd (renderer keeps the launch cwd), and 'live' shells get an lsof
+// probe. All probes run in parallel so the main thread never blocks.
+async function getLiveCwdsForIds(
+  ids: string[]
+): Promise<Record<string, { alive: boolean; cwd: string | null }>> {
+  const entries = await Promise.all(
+    ids.map(async (id) => {
+      const liveness = ptyManager.getLiveness(id)
+      if (liveness === 'exited') return [id, { alive: false, cwd: null }] as const
+      if (liveness === 'unknown') return [id, { alive: true, cwd: null }] as const
+      const pid = ptyManager.getPid(id)
+      const cwd = pid ? await getLiveCwdForPidAsync(pid) : null
+      return [id, { alive: true, cwd }] as const
+    })
+  )
+  return Object.fromEntries(entries)
 }
 
 // ENH-167 — apply a new SessionState to the running Duo without

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -80,6 +80,9 @@ const api: ElectronAPI = {
     liveCwd: (id) =>
       ipcRenderer.invoke(IPC.PTY_LIVE_CWD, { id }),
 
+    liveCwds: (ids) =>
+      ipcRenderer.invoke(IPC.PTY_LIVE_CWDS, { ids }),
+
     onData: (id, cb) => {
       const handler = (_: IpcRendererEvent, data: string) => cb(data)
       ipcRenderer.on(IPC.PTY_DATA(id), handler)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duo",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "macOS desktop app pairing Claude Code terminals with an embedded Chrome browser",
   "repository": {
     "type": "git",

--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -37,11 +37,21 @@ import { encodeUtf8 } from './components/editor/markdown-io'
 import { findVaultRoot, resolveWikilinkInVault } from './components/editor/wikilinkResolver'
 import type { TabSession, DirEntry, TerminalTabKind, NewTabResult, PinEntry, SessionState, BrowserTab, ActiveWorkspace } from '@shared/types'
 import { reorderVisible } from '@shared/reorderTabs'
+import {
+  effectiveProjectTerminals,
+  mergeLiveCwdInfo,
+  planProjectClose,
+  type LiveCwdEntry
+} from '@shared/project-lifecycle'
 
 // Stage 10 § D32: auto-collapse the Files column on windows narrower than
 // this. The user can manually re-expand; we don't re-collapse again unless
 // the threshold is re-crossed (hysteresis prevents jitter).
 const AUTO_COLLAPSE_WIDTH = 1100
+// BUG-191 — how often to re-probe each terminal's live shell cwd so the
+// project rail tracks where the shell IS, not where it launched. Coarse
+// (lsof is not free) but well under "feels stuck"; gated on tab visibility.
+const LIVE_CWD_POLL_MS = 5000
 
 // Stage 9: cozy-mode persistence keys. Per-tab map survives within a
 // session but tab UUIDs don't span relaunches; the last-choice flag is the
@@ -879,9 +889,14 @@ export function App() {
     () => new Set(pins.filter((p) => p.kind === 'file').map((p) => p.ref)),
     [pins]
   )
+  // BUG-191 — live shell-cwd info per terminal (id → {alive, cwd}),
+  // refreshed by the poll effect below. `deriveProjects` consumes this
+  // via effectiveProjectTerminals so a shell that cd-d away or exited
+  // stops keeping a ghost tile.
+  const [liveCwdInfo, setLiveCwdInfo] = useState<Map<string, LiveCwdEntry>>(() => new Map())
   const projectTerminals = useMemo(
-    () => tabs.map((t) => ({ id: t.id, cwd: t.cwd })),
-    [tabs]
+    () => effectiveProjectTerminals(tabs, liveCwdInfo),
+    [tabs, liveCwdInfo]
   )
   const projectWorkingTabs = useMemo(
     () =>
@@ -890,6 +905,37 @@ export function App() {
         .map((t) => ({ id: t.id, path: t.path })),
     [fileTabs]
   )
+  // BUG-191 — poll each open terminal's real shell cwd (+ liveness) so
+  // the rail follows where the shell IS, not where it launched. Batched +
+  // async in main (lsof never blocks the main thread); merged only when
+  // something actually changed (mergeLiveCwdInfo keeps the map reference
+  // stable) so a steady poll doesn't re-derive the project set every tick.
+  // Re-armed only when the SET of tab ids changes (not on title updates).
+  const tabIdsKey = useMemo(() => tabs.map((t) => t.id).join(','), [tabs])
+  useEffect(() => {
+    const ids = tabIdsKey ? tabIdsKey.split(',') : []
+    if (ids.length === 0) {
+      setLiveCwdInfo((prev) => (prev.size === 0 ? prev : new Map()))
+      return
+    }
+    let cancelled = false
+    const poll = async () => {
+      try {
+        const info = await window.electron.pty.liveCwds(ids)
+        if (!cancelled) setLiveCwdInfo((prev) => mergeLiveCwdInfo(prev, info, ids))
+      } catch {
+        /* transient lsof/IPC failure — keep prior info (launch-cwd fallback) */
+      }
+    }
+    void poll()
+    const handle = window.setInterval(() => {
+      if (!document.hidden) void poll()
+    }, LIVE_CWD_POLL_MS)
+    return () => {
+      cancelled = true
+      window.clearInterval(handle)
+    }
+  }, [tabIdsKey])
   // ENH-182 Phase 3a — persisted projects.json slice (pins + color
   // overrides). Loaded once on mount; subscribes to PROJECTS_CHANGED
   // pushes from main (toggle-pin, set-color-override, Phase 4 CLI
@@ -1032,20 +1078,20 @@ export function App() {
   // Leaves at least one terminal alive — if we'd close every tab in
   // `tabs`, append a fresh shell at the home dir so the strip stays
   // non-empty (the existing closeTab path enforces a floor of 1).
+  // BUG-192 — re-entrancy guard. A second close for the same root (rapid
+  // double-trigger, or the CLI close path racing the right-click menu)
+  // no-ops instead of re-running the multi-store flush mid-flush (the
+  // FOLLOWUP-032 fix, generalized to the UI path).
+  const inFlightCloseRef = useRef<Set<string>>(new Set())
   const handleCloseProject = useCallback(
     async (root: string) => {
+      if (inFlightCloseRef.current.has(root)) return
       const counts = projectCounts.get(root)
       if (!counts || (counts.terminals === 0 && counts.workingTabs === 0)) return
-      // Compute member id sets at click time so a parallel re-render
-      // doesn't shift what we're closing.
-      const memberTermIds = new Set<string>()
-      for (const t of tabs) {
-        if (terminalMembership[t.id] === root) memberTermIds.add(t.id)
-      }
-      const memberFileIds = new Set<string>()
-      for (const ft of fileTabs) {
-        if (tabMembership[ft.id] === root) memberFileIds.add(ft.id)
-      }
+      // BUG-192 — confirm BEFORE taking any snapshot or writing state, so
+      // the `await` can never split a partially-applied flush across
+      // renders (a window the old "snapshot, then await, then mutate"
+      // ordering left open).
       if (counts.hasClaudeKindTerminal) {
         const result = await window.electron.dialog.confirm({
           title: 'Close project?',
@@ -1058,32 +1104,45 @@ export function App() {
         })
         if (result.response !== 1) return
       }
-      // Atomic membership flush. The terminal setter enforces the
-      // floor-of-1; if every existing terminal is a member, append a
-      // fresh shell at home BEFORE filtering so the floor holds.
-      setTabs((prev) => {
-        const survivors = prev.filter((t) => !memberTermIds.has(t.id))
-        if (survivors.length === 0) {
-          survivors.push(makeTab(home, 'shell', home))
+      inFlightCloseRef.current.add(root)
+      try {
+        // Pure plan (member/survivor/active-shift) — no setState nesting.
+        const plan = planProjectClose({
+          tabs,
+          fileTabs,
+          terminalMembership,
+          tabMembership,
+          activeTabId,
+          activeWorkingFileId: activeWorking.kind === 'file' ? activeWorking.id : null,
+          root
+        })
+        const memberTermIds = new Set(plan.memberTermIds)
+        const memberFileIds = new Set(plan.memberFileIds)
+        // Pre-create the floor-of-1 replacement OUTSIDE the updater so its
+        // id is known for the active-tab shift (BUG-192 — never call
+        // setActiveTabId from inside the setTabs updater).
+        const replacement = plan.needsReplacementShell ? makeTab(home, 'shell', home) : null
+        setTabs((prev) => {
+          const survivors = prev.filter((t) => !memberTermIds.has(t.id))
+          return survivors.length === 0 ? [replacement ?? makeTab(home, 'shell', home)] : survivors
+        })
+        if (plan.activeTerminalBecameMember) {
+          setActiveTabId(plan.survivingTermIds[0] ?? replacement?.id ?? activeTabId)
         }
-        // If the active terminal was a member, shift to the first
-        // survivor (whether pre-existing or freshly spawned).
-        if (memberTermIds.has(activeTabId)) {
-          setActiveTabId(survivors[0].id)
+        setFileTabs((prev) => prev.filter((ft) => !memberFileIds.has(ft.id)))
+        // If the active working tab was a member, drop to the browser
+        // surface (matches closeFileTab's degenerate-case behavior).
+        if (plan.activeWorkingFileBecameMember) {
+          setActiveWorking({ kind: 'browser' })
         }
-        return survivors
-      })
-      setFileTabs((prev) => prev.filter((ft) => !memberFileIds.has(ft.id)))
-      // If the active working tab was a member, drop to the browser
-      // surface (matches closeFileTab's degenerate-case behavior).
-      if (activeWorking.kind === 'file' && memberFileIds.has(activeWorking.id)) {
-        setActiveWorking({ kind: 'browser' })
-      }
-      // If the focus chip is on this project, release focus — the
-      // project has zero members now (unless it's pinned, in which
-      // case the tile stays but the focus would be on an empty set).
-      if (focusedProject === root) {
-        setFocusedProject(null)
+        // If the focus chip is on this project, release focus — the
+        // project has zero members now (unless it's pinned, in which case
+        // the tile stays but the focus would be on an empty set).
+        if (focusedProject === root) {
+          setFocusedProject(null)
+        }
+      } finally {
+        inFlightCloseRef.current.delete(root)
       }
     },
     [

--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -41,6 +41,7 @@ import {
   effectiveProjectTerminals,
   mergeLiveCwdInfo,
   planProjectClose,
+  shouldReleaseFocus,
   type LiveCwdEntry
 } from '@shared/project-lifecycle'
 
@@ -1067,6 +1068,19 @@ export function App() {
       setFocusedProject(project)
     }
   }, [activeWorking, tabMembership, focusedProject])
+  // BUG-194 — release focus when the focused project vanishes. With
+  // BUG-191's live-cwd tracking, `cd`-ing the focused project's last
+  // terminal OUT of it drops the project from the rail; if focus stayed
+  // pinned to it, the visibility filter (`membership === focusedProject`)
+  // would hide the now-orphaned terminals/tabs — the active terminal
+  // "disappears" and ⌘T / ⌃Tab lose their target. Releasing to All keeps
+  // them visible. Pinned-but-empty projects stay in `railProjects`, so
+  // focusing one correctly does NOT trip this.
+  useEffect(() => {
+    if (shouldReleaseFocus(focusedProject, railProjects.map((p) => p.root))) {
+      setFocusedProject(null)
+    }
+  }, [railProjects, focusedProject])
   // Phase 3c-browser + FOLLOWUP-030 effects live below, after
   // visibleBrowserTabIds + browserTabMembership are declared
   // (declaration order matters; they need to come AFTER the visible

--- a/shared/host-api.ts
+++ b/shared/host-api.ts
@@ -59,6 +59,12 @@ export interface ElectronPtyAPI {
   // by ⌘T / `duo new-tab` so the new tab opens where the user IS, not
   // where the previous tab LAUNCHED.
   liveCwd: (id: string) => Promise<string | null>
+  // BUG-191 — batched live-cwd + liveness for the project rail. For each
+  // tab id: `alive:false` = the shell exited (no project membership);
+  // `cwd` = the live shell cwd, or null when unknown (fall back to the
+  // tab's launch cwd). lsof runs async + in parallel in main, so this
+  // never blocks the main thread the way the single `liveCwd` can.
+  liveCwds: (ids: string[]) => Promise<Record<string, { alive: boolean; cwd: string | null }>>
   // Note: tab titles come from xterm.js Terminal.onTitleChange() (OSC sequences),
   // not via IPC — no main-process emit needed.
 }

--- a/shared/project-lifecycle.test.ts
+++ b/shared/project-lifecycle.test.ts
@@ -3,8 +3,25 @@ import {
   effectiveProjectTerminals,
   mergeLiveCwdInfo,
   planProjectClose,
+  shouldReleaseFocus,
   type LiveCwdEntry
 } from './project-lifecycle'
+
+// ── BUG-194 · shouldReleaseFocus ─────────────────────────────────────
+describe('shouldReleaseFocus (BUG-194 — focus follows a vanishing project)', () => {
+  it('releases focus when the focused project is gone from the rail', () => {
+    expect(shouldReleaseFocus('/p/a', ['/p/b', '/p/c'])).toBe(true)
+  })
+  it('keeps focus when the focused project is still present', () => {
+    expect(shouldReleaseFocus('/p/a', ['/p/a', '/p/b'])).toBe(false)
+  })
+  it('is a no-op in All mode (null focus)', () => {
+    expect(shouldReleaseFocus(null, ['/p/a'])).toBe(false)
+  })
+  it('releases when the rail is empty', () => {
+    expect(shouldReleaseFocus('/p/a', [])).toBe(true)
+  })
+})
 
 // ── BUG-191 · effectiveProjectTerminals ─────────────────────────────
 describe('effectiveProjectTerminals (BUG-191 ghost-tile fix)', () => {

--- a/shared/project-lifecycle.test.ts
+++ b/shared/project-lifecycle.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import {
+  effectiveProjectTerminals,
+  mergeLiveCwdInfo,
+  planProjectClose,
+  type LiveCwdEntry
+} from './project-lifecycle'
+
+// ── BUG-191 · effectiveProjectTerminals ─────────────────────────────
+describe('effectiveProjectTerminals (BUG-191 ghost-tile fix)', () => {
+  const tabs = [
+    { id: 't1', cwd: '/proj/a' },
+    { id: 't2', cwd: '/proj/b' }
+  ]
+
+  it('falls back to launch cwd when there is no live info yet (no regression on first paint)', () => {
+    expect(effectiveProjectTerminals(tabs, new Map())).toEqual([
+      { id: 't1', cwd: '/proj/a' },
+      { id: 't2', cwd: '/proj/b' }
+    ])
+  })
+
+  it('uses the LIVE cwd when the shell cd-d elsewhere — the ghost-tile cause', () => {
+    const live = new Map<string, LiveCwdEntry>([['t1', { alive: true, cwd: '/somewhere/else' }]])
+    expect(effectiveProjectTerminals(tabs, live)).toEqual([
+      { id: 't1', cwd: '/somewhere/else' }, // no longer qualifies /proj/a
+      { id: 't2', cwd: '/proj/b' }
+    ])
+  })
+
+  it('OMITS an exited shell entirely (dead terminal stops keeping a tile alive)', () => {
+    const live = new Map<string, LiveCwdEntry>([['t1', { alive: false, cwd: null }]])
+    expect(effectiveProjectTerminals(tabs, live)).toEqual([{ id: 't2', cwd: '/proj/b' }])
+  })
+
+  it('keeps the launch cwd when a live shell reports an unknown cwd (probe pending/failed)', () => {
+    const live = new Map<string, LiveCwdEntry>([['t1', { alive: true, cwd: null }]])
+    expect(effectiveProjectTerminals(tabs, live)).toEqual([
+      { id: 't1', cwd: '/proj/a' },
+      { id: 't2', cwd: '/proj/b' }
+    ])
+  })
+})
+
+// ── BUG-191 · mergeLiveCwdInfo (churn guard) ─────────────────────────
+describe('mergeLiveCwdInfo (BUG-191 poll churn guard)', () => {
+  it('returns the SAME map reference when nothing changed (no re-derive churn)', () => {
+    const prev = new Map<string, LiveCwdEntry>([
+      ['t1', { alive: true, cwd: '/x' }],
+      ['t2', { alive: true, cwd: '/y' }]
+    ])
+    const merged = mergeLiveCwdInfo(prev, { t1: { alive: true, cwd: '/x' }, t2: { alive: true, cwd: '/y' } }, ['t1', 't2'])
+    expect(merged).toBe(prev)
+  })
+
+  it('returns a new map when a cwd changes', () => {
+    const prev = new Map<string, LiveCwdEntry>([['t1', { alive: true, cwd: '/x' }]])
+    const merged = mergeLiveCwdInfo(prev, { t1: { alive: true, cwd: '/moved' } }, ['t1'])
+    expect(merged).not.toBe(prev)
+    expect(merged.get('t1')).toEqual({ alive: true, cwd: '/moved' })
+  })
+
+  it('returns a new map when a shell dies', () => {
+    const prev = new Map<string, LiveCwdEntry>([['t1', { alive: true, cwd: '/x' }]])
+    const merged = mergeLiveCwdInfo(prev, { t1: { alive: false, cwd: null } }, ['t1'])
+    expect(merged).not.toBe(prev)
+    expect(merged.get('t1')).toEqual({ alive: false, cwd: null })
+  })
+
+  it('returns a new map when the id set shrinks (a tab closed)', () => {
+    const prev = new Map<string, LiveCwdEntry>([
+      ['t1', { alive: true, cwd: '/x' }],
+      ['t2', { alive: true, cwd: '/y' }]
+    ])
+    const merged = mergeLiveCwdInfo(prev, { t1: { alive: true, cwd: '/x' } }, ['t1'])
+    expect(merged).not.toBe(prev)
+    expect(merged.has('t2')).toBe(false)
+  })
+
+  it('defaults a missing reply to alive-with-unknown-cwd (never drops a tile on a dropped IPC)', () => {
+    const merged = mergeLiveCwdInfo(new Map(), {}, ['t1'])
+    expect(merged.get('t1')).toEqual({ alive: true, cwd: null })
+  })
+})
+
+// ── BUG-192 · planProjectClose ───────────────────────────────────────
+describe('planProjectClose (BUG-192 jitter-loop fix)', () => {
+  const base = {
+    tabs: [{ id: 't1' }, { id: 't2' }, { id: 't3' }],
+    fileTabs: [{ id: 'f1' }, { id: 'f2' }],
+    terminalMembership: { t1: '/proj/a', t2: '/proj/a', t3: '/proj/b' } as Record<string, string | null>,
+    tabMembership: { f1: '/proj/a', f2: '/proj/b' } as Record<string, string | null>,
+    activeTabId: 't3',
+    activeWorkingFileId: null as string | null,
+    root: '/proj/a'
+  }
+
+  it('identifies members and survivors for the closing root', () => {
+    const plan = planProjectClose(base)
+    expect(plan.memberTermIds).toEqual(['t1', 't2'])
+    expect(plan.survivingTermIds).toEqual(['t3'])
+    expect(plan.memberFileIds).toEqual(['f1'])
+  })
+
+  it('does not need a replacement shell when survivors remain', () => {
+    expect(planProjectClose(base).needsReplacementShell).toBe(false)
+  })
+
+  it('needs a replacement shell when EVERY terminal is a member (floor-of-1)', () => {
+    const plan = planProjectClose({
+      ...base,
+      tabs: [{ id: 't1' }, { id: 't2' }],
+      terminalMembership: { t1: '/proj/a', t2: '/proj/a' },
+      activeTabId: 't1'
+    })
+    expect(plan.needsReplacementShell).toBe(true)
+    expect(plan.survivingTermIds).toEqual([])
+  })
+
+  it('flags the active terminal shift only when the active terminal was a member', () => {
+    expect(planProjectClose({ ...base, activeTabId: 't1' }).activeTerminalBecameMember).toBe(true)
+    expect(planProjectClose({ ...base, activeTabId: 't3' }).activeTerminalBecameMember).toBe(false)
+  })
+
+  it('flags the active working-file drop only when that file was a member', () => {
+    expect(planProjectClose({ ...base, activeWorkingFileId: 'f1' }).activeWorkingFileBecameMember).toBe(true)
+    expect(planProjectClose({ ...base, activeWorkingFileId: 'f2' }).activeWorkingFileBecameMember).toBe(false)
+    expect(planProjectClose({ ...base, activeWorkingFileId: null }).activeWorkingFileBecameMember).toBe(false)
+  })
+
+  it('closing a root with no members yields empty plans (caller no-ops)', () => {
+    const plan = planProjectClose({ ...base, root: '/proj/never' })
+    expect(plan.memberTermIds).toEqual([])
+    expect(plan.memberFileIds).toEqual([])
+    expect(plan.needsReplacementShell).toBe(false)
+  })
+})

--- a/shared/project-lifecycle.ts
+++ b/shared/project-lifecycle.ts
@@ -85,6 +85,25 @@ export function mergeLiveCwdInfo(
   return changed ? out : (prev as Map<string, LiveCwdEntry>)
 }
 
+/**
+ * BUG-194 — whether the focus chip points at a project that no longer
+ * exists. A consequence of BUG-191's live-cwd tracking: when the focused
+ * project's last terminal `cd`s OUT of it, that terminal's membership goes
+ * null and the project drops from the rail — but `focusedProject` still
+ * points at it, so the visibility filter (`membership === focusedProject`)
+ * hides the now-orphaned terminals/tabs. The active terminal "disappears"
+ * and ⌘T / ⌃Tab lose their target. When this returns true the host
+ * releases focus to "All" so those tabs become visible again. Pinned
+ * projects persist in `projectRoots` even with zero members, so focusing a
+ * pinned-but-empty project correctly does NOT release.
+ */
+export function shouldReleaseFocus(
+  focusedProject: string | null,
+  projectRoots: ReadonlyArray<string>
+): boolean {
+  return focusedProject !== null && !projectRoots.includes(focusedProject)
+}
+
 /** BUG-192 — the pure plan for closing every member of a project. The
  *  React handler applies this with a single, un-nested setState burst. */
 export interface ProjectClosePlan {

--- a/shared/project-lifecycle.ts
+++ b/shared/project-lifecycle.ts
@@ -1,0 +1,156 @@
+// BUG-191 + BUG-192 — pure project-lifecycle helpers.
+//
+// The project rail derives tiles from open terminals + working tabs
+// (see `deriveProjects` in ./projects.ts). Two defects lived in how the
+// renderer FED that derivation and how it MUTATED tab state on close:
+//
+//   • BUG-191 — a terminal's `cwd` is frozen at launch and never tracks
+//     where the shell actually `cd`'d to (or whether it exited), so a
+//     tile lingers as a "ghost" after its members are effectively gone.
+//     `effectiveProjectTerminals` folds live shell-cwd info into the
+//     membership inputs; `mergeLiveCwdInfo` keeps the poll churn-free.
+//   • BUG-192 — `handleCloseProject` ran a multi-store setState burst
+//     with a nested `setActiveTabId` and no re-entrancy guard, which
+//     could drive a non-converging render loop. `planProjectClose`
+//     isolates the pure member/survivor/active-shift computation so the
+//     React handler just applies it (no setState nesting, fully tested).
+//
+// All three functions are side-effect-free so they unit-test without
+// Electron / a renderer.
+
+/** Live shell state for one terminal tab, resolved in the main process
+ *  via `lsof` + the PtyManager session map (BUG-191). `alive: false`
+ *  means the shell process has EXITED — the tab contributes no project
+ *  membership. `cwd: null` on a live tab means "not yet known" (probe
+ *  pending or failed) — fall back to the launch cwd, never drop a tile
+ *  speculatively. */
+export interface LiveCwdEntry {
+  alive: boolean
+  cwd: string | null
+}
+
+/**
+ * BUG-191 — the effective `{id, cwd}` membership inputs for the project
+ * derivation, given the latest live-cwd info.
+ *
+ *   • Exited shell (`alive === false`)  → omitted (no membership).
+ *   • Live shell with a known live cwd  → uses the LIVE cwd (so a tab
+ *     that `cd`'d out of project A stops qualifying A and starts
+ *     qualifying wherever it landed).
+ *   • Live shell, cwd unknown / probe pending → falls back to the tab's
+ *     launch cwd (current behaviour; never a regression on first paint).
+ */
+export function effectiveProjectTerminals(
+  tabs: ReadonlyArray<{ id: string; cwd: string }>,
+  liveInfo: ReadonlyMap<string, LiveCwdEntry>
+): Array<{ id: string; cwd: string }> {
+  const out: Array<{ id: string; cwd: string }> = []
+  for (const t of tabs) {
+    const info = liveInfo.get(t.id)
+    if (info && !info.alive) continue // exited shell → not "working in" anything
+    out.push({ id: t.id, cwd: info && info.cwd ? info.cwd : t.cwd })
+  }
+  return out
+}
+
+/**
+ * BUG-191 — merge a fresh batch of live-cwd results into the prior map,
+ * returning the SAME map reference when nothing changed.
+ *
+ * The rail polls live cwds on an interval; without identity stability a
+ * steady poll would hand `deriveProjects` a new input every tick and
+ * re-fire every membership-keyed effect. We only allocate a new map when
+ * an entry's `{alive, cwd}` actually differs (or the id set changed).
+ *
+ * A missing entry in `next` (id we asked about but main didn't answer
+ * for) defaults to `{alive: true, cwd: null}` — assume alive with an
+ * unknown cwd so a dropped IPC reply never drops a tile.
+ */
+export function mergeLiveCwdInfo(
+  prev: ReadonlyMap<string, LiveCwdEntry>,
+  next: Readonly<Record<string, LiveCwdEntry>>,
+  ids: ReadonlyArray<string>
+): Map<string, LiveCwdEntry> {
+  const out = new Map<string, LiveCwdEntry>()
+  let changed = ids.length !== prev.size
+  for (const id of ids) {
+    const n = next[id] ?? { alive: true, cwd: null }
+    out.set(id, n)
+    const p = prev.get(id)
+    if (!p || p.alive !== n.alive || p.cwd !== n.cwd) changed = true
+  }
+  // `prev` is typed readonly here but is a plain Map at the call site;
+  // returning it unchanged preserves referential identity (the whole
+  // point — no churn).
+  return changed ? out : (prev as Map<string, LiveCwdEntry>)
+}
+
+/** BUG-192 — the pure plan for closing every member of a project. The
+ *  React handler applies this with a single, un-nested setState burst. */
+export interface ProjectClosePlan {
+  /** Terminal tab ids that belong to the closing project. */
+  memberTermIds: string[]
+  /** Working (file) tab ids that belong to the closing project. */
+  memberFileIds: string[]
+  /** Terminal tab ids that survive the close, in input order. */
+  survivingTermIds: string[]
+  /** True when EVERY terminal was a member — the caller must append a
+   *  fresh shell so the terminal strip keeps its floor-of-1. */
+  needsReplacementShell: boolean
+  /** The active terminal was a member → caller shifts the active id to
+   *  the first survivor (or the replacement shell). */
+  activeTerminalBecameMember: boolean
+  /** The active working tab was a member file → caller drops to the
+   *  browser surface. */
+  activeWorkingFileBecameMember: boolean
+}
+
+/**
+ * BUG-192 — compute, with no side effects, what closing `root` does to
+ * the terminal + working-tab sets. Keeping this pure means the member /
+ * survivor / active-shift logic is unit-tested independently of React,
+ * and the handler that consumes it never nests one setState inside
+ * another's updater (the anti-pattern implicated in the jitter loop).
+ */
+export function planProjectClose(input: {
+  tabs: ReadonlyArray<{ id: string }>
+  fileTabs: ReadonlyArray<{ id: string }>
+  terminalMembership: Readonly<Record<string, string | null>>
+  tabMembership: Readonly<Record<string, string | null>>
+  activeTabId: string
+  /** id of the active working tab IFF it is a file tab, else null. */
+  activeWorkingFileId: string | null
+  root: string
+}): ProjectClosePlan {
+  const {
+    tabs,
+    fileTabs,
+    terminalMembership,
+    tabMembership,
+    activeTabId,
+    activeWorkingFileId,
+    root
+  } = input
+
+  const memberTermIds: string[] = []
+  const survivingTermIds: string[] = []
+  for (const t of tabs) {
+    if (terminalMembership[t.id] === root) memberTermIds.push(t.id)
+    else survivingTermIds.push(t.id)
+  }
+
+  const memberFileIds: string[] = []
+  for (const ft of fileTabs) {
+    if (tabMembership[ft.id] === root) memberFileIds.push(ft.id)
+  }
+
+  return {
+    memberTermIds,
+    memberFileIds,
+    survivingTermIds,
+    needsReplacementShell: survivingTermIds.length === 0 && memberTermIds.length > 0,
+    activeTerminalBecameMember: memberTermIds.includes(activeTabId),
+    activeWorkingFileBecameMember:
+      activeWorkingFileId != null && memberFileIds.includes(activeWorkingFileId)
+  }
+}

--- a/shared/projects.ts
+++ b/shared/projects.ts
@@ -250,6 +250,20 @@ export function deriveProjects(input: DeriveProjectsInput): DeriveProjectsOutput
 
   const tabMembership: Record<string, string | null> = {}
   for (const tab of workingTabs) {
+    // BUG-193 — a PINNED tab is a cross-project reference (D2): it never
+    // counts toward "working in", so it gets NO membership. Without this,
+    // a pinned tab whose own deepest project isn't in `qualifyingSet`
+    // (pinned tabs are skipped during candidate-gathering above, so their
+    // ancestors are never added) would resolve to the shallowest
+    // qualifying ancestor contributed by some OTHER member — e.g. a
+    // git-repo parent like `~/Documents` — spuriously spawning that parent
+    // as a project tile AND making the D11 auto-switch steal focus to it
+    // whenever the pinned tab is active. Null membership fixes both, and
+    // matches how the visibility filter already special-cases pinned tabs.
+    if (pinnedTabPaths.has(tab.path)) {
+      tabMembership[tab.id] = null
+      continue
+    }
     tabMembership[tab.id] = tab.path
       ? deepestEnclosingRoot(dirname(tab.path), qualifyingSet)
       : null

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1400,6 +1400,10 @@ export const IPC = {
   // shell cwd (where the user has `cd`'d to), not the launch cwd from
   // the navigator's follow-mode-synced state.
   PTY_LIVE_CWD: 'pty:live-cwd',
+  // BUG-191 — batched, liveness-aware live-cwd lookup for the project
+  // rail. Returns `{alive, cwd}` per tab id so a shell that cd-d away
+  // (cwd changes) or exited (alive:false) stops keeping a ghost tile.
+  PTY_LIVE_CWDS: 'pty:live-cwds',
   PTY_DATA: (id: string) => `pty:data:${id}`,
   PTY_EXIT: (id: string) => `pty:exit:${id}`,
 

--- a/tasks.md
+++ b/tasks.md
@@ -84,6 +84,18 @@
 
 ---
 
+### BUG-194: Focused project's last terminal cd-d out → terminal tab vanishes (multitab breaks)
+
+**Status:** 🟡 **Fix implemented + verified live on branch `claude/kind-goldstine-6904c1` (2026-06-01)** — direct follow-on regression from BUG-191. **Priority:** High (loses access to a live terminal + breaks ⌘T/⌃Tab). **Effort:** S.
+
+**Symptom (owner, smoke walk).** While focused on a project that had a single terminal, `cd`-ing that terminal OUT into a no-project root cleared the tile as expected — but the active terminal's TAB disappeared too. With the terminal strip empty, ⌘T just replaced the current terminal and ⌃Tab cycled the canvas tabs instead of terminals (multitab effectively dead).
+
+**Root cause (introduced by BUG-191).** Membership now tracks the live shell cwd, so `cd`-ing the focused project's last terminal out drops the project from the rail. But `focusedProject` stayed pinned to the now-gone project, and the visibility filter `visibleTerminals = tabs.filter(t => terminalMembership[t.id] === focusedProject)` (`renderer/App.tsx`) then matched nothing — the orphaned terminal was filtered out of view (still in `tabs`, just hidden), and ⌘T/⌃Tab lost their target. Pre-BUG-191 this couldn't happen because membership was frozen at launch cwd (a cd never changed it).
+
+**Fix (2026-06-01).** New pure `shouldReleaseFocus(focusedProject, projectRoots)` (`shared/project-lifecycle.ts`) + an effect in `renderer/App.tsx` keyed on `[railProjects, focusedProject]` that releases focus to "All" when the focused project is no longer in the rail. All view shows every terminal, so the orphaned terminal reappears and multitab works again. Pinned projects persist in `railProjects` even with zero members, so focusing a pinned-but-empty project correctly does NOT release. **Verified live:** focus released to All after the sole member cd-d out (terminal stays visible); tile clears once the project truly empties. Unit-covered (`shared/project-lifecycle.test.ts`, 4 cases). 868/868 tests pass.
+
+---
+
 ### BUG-190: Quit-loop crash — "Object has been destroyed" cycling dialog on app quit
 
 **Status:** 🟡 **Fix pushed `claude/duo-quit-loop-bug-OBZHB` 2026-05-27.** **Priority:** High (app un-quittable without force-quit). **Effort:** ~30 min.

--- a/tasks.md
+++ b/tasks.md
@@ -28,6 +28,48 @@
 
 ---
 
+### BUG-191: Ghost project tile persists with no open files/terminals (frozen launch-cwd)
+
+**Status:** 🟡 **Fix implemented + verified live on branch `claude/kind-goldstine-6904c1` (2026-05-31)** — option (a) live-cwd tracking. Root-caused via 38-agent workflow (5-reader map → ranked hypotheses → 3-lens adversarial verification). **Priority:** Medium (persistent daily annoyance; functionally benign). **Effort:** M.
+
+**Fix (2026-05-31).** Membership now tracks each terminal's LIVE shell cwd, not its frozen launch cwd. New batched, liveness-aware main handler `PTY_LIVE_CWDS` (async `lsof` + a `PtyManager.getLiveness` tri-state so an exited shell drops its tile while a not-yet-spawned tab keeps its launch cwd) — `electron/main.ts`, `core/pty-manager.ts`. Renderer polls it on a visibility-gated 5s interval into a `liveCwdInfo` map that `deriveProjects` consumes via the new pure `effectiveProjectTerminals` (`shared/project-lifecycle.ts`); `mergeLiveCwdInfo` keeps the map reference stable so a steady poll doesn't re-derive every tick (`renderer/App.tsx`). **Verified live:** a shell that `cd`s out of a project clears its tile within the poll window; `cd` back restores it; tiles for `/tmp`-launched terminals canonicalize to `/private/tmp` via the live probe. Unit-covered in `shared/project-lifecycle.test.ts`.
+
+**Symptom (owner, recurring).** A project tile persists in the rail "when no files or terminal tabs from that project are open."
+
+**Root cause — frozen terminal launch-cwd** (confirmed: survived all three adversarial lenses, `refuteCount 0`). A tile renders only if its root owns ≥1 member or is pinned; a zero-member *unpinned* tile is provably impossible. A terminal's `cwd` is set once in `makeTab` (`renderer/App.tsx:192-200`) and **never rewritten** — not when the shell `cd`s away, not when the shell process exits. So `projectTerminals` (`App.tsx:882-885`, unfiltered `tabs.map(t => ({id, cwd}))`) carries the stale launch cwd into `deriveProjects`, and `terminalMembership` (`shared/projects.ts:247-248, 260-262`) re-qualifies the launch project on every derive. The `closeTab` floor-of-1 guard (`App.tsx:1600`) prevents closing a sole stale terminal, amplifying it. `PTY_LIVE_CWD` (the live shell cwd, `shared/types.ts:1398-1402`) already exists but is only read to *seed* a new tab, never written back. Secondary vector: a working tab whose file was deleted on disk is never pruned from `fileTabs[]` (no in-session `files.watch` prune; `MarkdownEditor.tsx:1024-1030` ignores `'removed'`).
+
+**Triage (decisive observable).** The ghost's **pin pip** (`ProjectRail.tsx:250-256`) splits the cases: **pip-less** → this frozen-cwd/dead-shell bug; **pip present** → pinned tile, i.e. by-design (D12) or [FOLLOWUP-037](#followup-037) (pinned + marker deleted out-of-band) — *not* this bug. Right-click count `N≥1` = stale terminal, `M≥1` = stale file tab.
+
+**Fix options (see playground).** (a) **[rec]** track the live shell cwd into membership (wire `PTY_LIVE_CWD` through `useTerminal.ts` → `tabs[].cwd`; drop membership on PTY exit); (b) prune dead members reactively (PTY-exit + `files.watch` on `'removed'`, mirrors PR #59's navigator self-heal); (c) diagnostics only (explain the ghost, don't remove it).
+
+**Deliverable.** Decision-bearing HTML playground [`docs/research/bug-191-192-ghost-tiles-jitter-rootcause.html`](research/bug-191-192-ghost-tiles-jitter-rootcause.html) (Atelier kernel, pin-pip triage mockup, causal-chain diagram, option cards, 3 decision cards + Copy-decisions footer; per rule 11). **Open via `duo open`, not the Claude preview panel** (clipboard).
+
+**Related.** Distinct from [FOLLOWUP-037](#followup-037) (pip-bearing pinned case). Same stale-persisted-state family as [BUG-167](#bug-167) / PR #59 (the prune pattern option (b) reuses). Shares a root family with [BUG-192](#bug-192) (the *transition* face of the same membership-state design).
+
+**Next.** Owner walks the playground (Q1 fix + Q3 sequencing), pastes decisions back → pins implementation scope. **Review task: surfaces in every smoke walk until owner closes the decision.**
+
+---
+
+### BUG-192: Recursive jitter / force-quit loop when closing a project tile via right-click
+
+**Status:** 🟡 **Fix implemented on branch `claude/kind-goldstine-6904c1` (2026-05-31); close path verified responsive** — option (a) atomic + re-entrancy-guarded handler. **Priority:** High (force-quit-level) but **Low static-confidence** on the exact edge. **Effort:** M.
+
+**Fix (2026-05-31).** `handleCloseProject` (`renderer/App.tsx`) now: (1) guards re-entrancy via `inFlightCloseRef` (a second close for the same root no-ops — generalizes [FOLLOWUP-032](#followup-032)); (2) runs `await dialog.confirm` BEFORE any snapshot/mutation, closing the await-split window; (3) hoists `setActiveTabId` OUT of the `setTabs` updater (the nested-setState anti-pattern). Member/survivor/active-shift logic extracted to the pure, unit-tested `planProjectClose` (`shared/project-lifecycle.ts`). **Verified:** a live `duo project close` closes the project, the floor-of-1 holds (fresh shell appended), and the app stays responsive — no loop/hang. The exact original right-click gesture with the owner's specific tab/browser state was not reproduced (it was never deterministic); the structural hazards are removed, so the owner's retry is the final confirmation.
+
+**Symptom (owner).** Right-clicking a project tile and choosing the close item triggered a recursive/jittering re-render loop severe enough to require a force quit.
+
+**Root cause — not pinned down by static analysis (honest).** Every *concrete* loop candidate was refuted across all three lenses — they each provably converge in today's build (value-equality bailouts, monotone probe caches, the `hasTerminalUnderRoot` raw-cwd guard, universal `focusedProject===null` early-returns). The best-supported remaining explanation is the **unguarded cross-store setState burst in `handleCloseProject`** (`App.tsx:1035-1101`): `setTabs` *with a nested `setActiveTabId` inside its updater* (`1064-1075`) + `setFileTabs` + `setActiveWorking` + `setFocusedProject`, optionally split by an `await dialog.confirm` (`1049-1060`), feeding the live effect cluster (browser-redirect machine E5/E6/E7 at `1242-1346` + auto-spawn E9) while membership probes settle — with **no in-flight/re-entrancy guard** (`inFlightCloseRef`, proposed in [FOLLOWUP-032](#followup-032), never implemented). StrictMode is off (`main.tsx:21-25`, no double-invoke damping) and the Close menu item gates on `n>0||m>0` regardless of focus (`ProjectRail.tsx:184`), so a **non-focused-tile close** keeps focus non-null and voids the convergence proofs. The owner *did* force-quit → a non-convergent region is reachable; it most likely lives in the burst→effect-cluster interaction under specific timing (non-focused close + a `file://` browser member tab + probe lag). IPC echo ruled out: `pushState` is echo-free (`electron/main.ts:1841-1843`).
+
+**Fix options (see playground).** (a) **[rec]** make the handler atomic + re-entrancy-guarded (`inFlightCloseRef`; hoist `setActiveTabId` out of the `setTabs` updater; move the confirm before any snapshot) — hardens regardless of the exact trigger; (b) instrument first, then fix (dev-only update-depth counter / effect fire-count logs, repro live per the "build the visibility tool first" rule, then apply (a)) — the conservative move given Low confidence; (c) decouple the browser-redirect machine from the close burst.
+
+**Deliverable.** Same playground as [BUG-191](#bug-191).
+
+**Related.** Sibling "loop crash" to [BUG-190](#bug-190) but distinct (that is an app-quit `Object has been destroyed` cycle, not a render loop). Overlaps [FOLLOWUP-032](#followup-032) (the `inFlightCloseRef` guard option (a) adds). Shares a root family with [BUG-191](#bug-191) (the *steady-state* face).
+
+**Next.** Owner walks the playground (Q2 approach + Q3 sequencing). Recommend instrument-first to confirm the edge before committing the handler rewrite. **Review task: surfaces in every smoke walk until closed.**
+
+---
+
 ### BUG-190: Quit-loop crash — "Object has been destroyed" cycling dialog on app quit
 
 **Status:** 🟡 **Fix pushed `claude/duo-quit-loop-bug-OBZHB` 2026-05-27.** **Priority:** High (app un-quittable without force-quit). **Effort:** ~30 min.

--- a/tasks.md
+++ b/tasks.md
@@ -30,7 +30,7 @@
 
 ### BUG-191: Ghost project tile persists with no open files/terminals (frozen launch-cwd)
 
-**Status:** 🟡 **Fix implemented + verified live on branch `claude/kind-goldstine-6904c1` (2026-05-31)** — option (a) live-cwd tracking. Root-caused via 38-agent workflow (5-reader map → ranked hypotheses → 3-lens adversarial verification). **Priority:** Medium (persistent daily annoyance; functionally benign). **Effort:** M.
+**Status:** ✅ **Cut into v0.8.5 (2026-06-02) on agent verification** — option (a) live-cwd tracking. Root-caused via 38-agent workflow (5-reader map → ranked hypotheses → 3-lens adversarial verification). **Priority:** Medium (persistent daily annoyance; functionally benign). **Effort:** M. **Smoke walk v0.8.5: owner SKIP** (didn't hand-walk); owner accepted **agent live-verification (3 ways:** unit tests + socket cd-out/cd-in tile clear+restore + computer-use screenshots**)** as sufficient for the cut.
 
 **Fix (2026-05-31).** Membership now tracks each terminal's LIVE shell cwd, not its frozen launch cwd. New batched, liveness-aware main handler `PTY_LIVE_CWDS` (async `lsof` + a `PtyManager.getLiveness` tri-state so an exited shell drops its tile while a not-yet-spawned tab keeps its launch cwd) — `electron/main.ts`, `core/pty-manager.ts`. Renderer polls it on a visibility-gated 5s interval into a `liveCwdInfo` map that `deriveProjects` consumes via the new pure `effectiveProjectTerminals` (`shared/project-lifecycle.ts`); `mergeLiveCwdInfo` keeps the map reference stable so a steady poll doesn't re-derive every tick (`renderer/App.tsx`). **Verified live:** a shell that `cd`s out of a project clears its tile within the poll window; `cd` back restores it; tiles for `/tmp`-launched terminals canonicalize to `/private/tmp` via the live probe. Unit-covered in `shared/project-lifecycle.test.ts`.
 
@@ -52,7 +52,7 @@
 
 ### BUG-192: Recursive jitter / force-quit loop when closing a project tile via right-click
 
-**Status:** 🟡 **Fix implemented on branch `claude/kind-goldstine-6904c1` (2026-05-31); close path verified responsive** — option (a) atomic + re-entrancy-guarded handler. **Priority:** High (force-quit-level) but **Low static-confidence** on the exact edge. **Effort:** M.
+**Status:** ✅ **Owner-PASS on smoke walk v0.8.5 (2026-06-02).** Fix on branch `claude/kind-goldstine-6904c1` — option (a) atomic + re-entrancy-guarded handler. **Priority:** High (force-quit-level) but was **Low static-confidence** on the exact edge; owner walked the right-click close gesture with no jitter/force-quit. **Effort:** M.
 
 **Fix (2026-05-31).** `handleCloseProject` (`renderer/App.tsx`) now: (1) guards re-entrancy via `inFlightCloseRef` (a second close for the same root no-ops — generalizes [FOLLOWUP-032](#followup-032)); (2) runs `await dialog.confirm` BEFORE any snapshot/mutation, closing the await-split window; (3) hoists `setActiveTabId` OUT of the `setTabs` updater (the nested-setState anti-pattern). Member/survivor/active-shift logic extracted to the pure, unit-tested `planProjectClose` (`shared/project-lifecycle.ts`). **Verified:** a live `duo project close` closes the project, the floor-of-1 holds (fresh shell appended), and the app stays responsive — no loop/hang. The exact original right-click gesture with the owner's specific tab/browser state was not reproduced (it was never deterministic); the structural hazards are removed, so the owner's retry is the final confirmation.
 
@@ -72,7 +72,7 @@
 
 ### BUG-193: Pinned reference tab spuriously maps to a shallow parent project (phantom parent tile + D11 focus theft)
 
-**Status:** 🟡 **Fix implemented + verified live on branch `claude/kind-goldstine-6904c1` (2026-05-31)** — found during the v0.8.5 BUG-191/192 smoke walk. **Priority:** Medium-High (rail unusable when a git-repo parent + pinned tabs coincide). **Effort:** S.
+**Status:** ✅ **Owner-PASS on smoke walk v0.8.5 (2026-06-02).** Fix on branch `claude/kind-goldstine-6904c1` — found during the v0.8.5 BUG-191/192 smoke walk. **Priority:** Medium-High (rail unusable when a git-repo parent + pinned tabs coincide). **Effort:** S.
 
 **Symptom (owner, smoke walk).** Opened a terminal in `~/Documents/GitHub/stoop`; the rail spawned TWO tiles — `stoop` AND `~/Documents` — even though only stoop was opened. Worse: clicking the `stoop` tile, focus was immediately stolen by the `Documents` tile (the navigator briefly re-rooted to stoop, then snapped back to Documents). Documents then dominated focus for all projects.
 
@@ -86,7 +86,7 @@
 
 ### BUG-194: Focused project's last terminal cd-d out → terminal tab vanishes (multitab breaks)
 
-**Status:** 🟡 **Fix implemented + verified live on branch `claude/kind-goldstine-6904c1` (2026-06-01)** — direct follow-on regression from BUG-191. **Priority:** High (loses access to a live terminal + breaks ⌘T/⌃Tab). **Effort:** S.
+**Status:** ✅ **Owner-PASS on smoke walk v0.8.5 (2026-06-02).** Fix on branch `claude/kind-goldstine-6904c1` — direct follow-on regression from BUG-191. **Priority:** High (loses access to a live terminal + breaks ⌘T/⌃Tab). **Effort:** S.
 
 **Symptom (owner, smoke walk).** While focused on a project that had a single terminal, `cd`-ing that terminal OUT into a no-project root cleared the tile as expected — but the active terminal's TAB disappeared too. With the terminal strip empty, ⌘T just replaced the current terminal and ⌃Tab cycled the canvas tabs instead of terminals (multitab effectively dead).
 

--- a/tasks.md
+++ b/tasks.md
@@ -70,6 +70,20 @@
 
 ---
 
+### BUG-193: Pinned reference tab spuriously maps to a shallow parent project (phantom parent tile + D11 focus theft)
+
+**Status:** 🟡 **Fix implemented + verified live on branch `claude/kind-goldstine-6904c1` (2026-05-31)** — found during the v0.8.5 BUG-191/192 smoke walk. **Priority:** Medium-High (rail unusable when a git-repo parent + pinned tabs coincide). **Effort:** S.
+
+**Symptom (owner, smoke walk).** Opened a terminal in `~/Documents/GitHub/stoop`; the rail spawned TWO tiles — `stoop` AND `~/Documents` — even though only stoop was opened. Worse: clicking the `stoop` tile, focus was immediately stolen by the `Documents` tile (the navigator briefly re-rooted to stoop, then snapped back to Documents). Documents then dominated focus for all projects.
+
+**Root cause (pre-existing ENH-182; NOT the BUG-191 change — it lives in `deriveProjects`, untouched by that work).** `~/Documents` is itself a git repo, so it qualifies. The stoop terminal's candidate walk adds BOTH `stoop` (marker) and `~/Documents` (git root) to the qualifying set. The owner's pinned reference tabs (`tasks.md`, `idle-thoughts.md` in `~/Documents/GitHub/duo`) are correctly **excluded from candidate-gathering** per D2 — so `…/duo` is never added to the set — but their **membership was still computed** in Step 3 (`shared/projects.ts`). With `…/duo` and `…/GitHub` absent from the set, `deepestEnclosingRoot` walked up to the shallowest qualifying ancestor present — `~/Documents` — and assigned it as the pinned tabs' membership. That spurious membership (a) was added to the project set (Step 4) → the phantom Documents tile, and (b) was read by the D11 auto-switch effect (`renderer/App.tsx`) whenever a pinned tab was active → focus snapped to Documents on every rail click.
+
+**Fix (2026-05-31).** `shared/projects.ts` Step 3 — a pinned tab now gets `tabMembership = null` (it's a cross-project reference with no home project, extending D2 from candidate-gathering to membership). This kills both symptoms at the source: no spurious parent root reaches the project set, and D11 reads `null` for an active pinned tab so it never auto-switches. Safe across all consumers — the visibility filter already special-cases pinned tabs (always visible), and `projectCounts` / the close handler correctly stop counting/closing pinned cross-refs. **Verified live:** the Documents tile disappeared (rail → `[stoop]` only); regression test in `core/projects-service.test.ts` ("BUG-193 — a pinned tab does NOT resolve to a shallow parent seeded by another member") fails pre-fix, passes post-fix; 864/864 tests pass.
+
+**Note.** A separate, debatable question remains (not fixed here): should a giant git-tracked parent like `~/Documents` qualify as a project at all? With this fix it only surfaces when something genuinely non-pinned sits directly in it, which is arguably correct. File a follow-up if the owner wants parent-git-repo suppression.
+
+---
+
 ### BUG-190: Quit-loop crash — "Object has been destroyed" cycling dialog on app quit
 
 **Status:** 🟡 **Fix pushed `claude/duo-quit-loop-bug-OBZHB` 2026-05-27.** **Priority:** High (app un-quittable without force-quit). **Effort:** ~30 min.


### PR DESCRIPTION
## Summary

Four project-rail correctness fixes, all descending from one root: *membership was derived from inputs that didn't reflect reality, and churned hardest during close.* Root-caused via a 38-agent investigation workflow (decision playground at `docs/research/bug-191-192-ghost-tiles-jitter-rootcause.html`).

| Bug | Fix | Verification |
|---|---|---|
| **BUG-191** ghost tiles persist with no open files/terminals | Membership follows the **live shell cwd** (new batched, liveness-aware `PTY_LIVE_CWDS` IPC + `PtyManager` liveness tri-state; renderer polls into `liveCwdInfo` consumed by `deriveProjects` via pure `effectiveProjectTerminals`) | agent-verified 3 ways (unit + socket cd-out/cd-in + computer-use) |
| **BUG-192** recursive jitter / force-quit on right-click close | Atomic, re-entrancy-guarded `handleCloseProject` (`inFlightCloseRef`, confirm-before-snapshot, `setActiveTabId` hoisted out of the `setTabs` updater; pure `planProjectClose`) | owner-PASS |
| **BUG-193** pinned reference tab → phantom parent tile + D11 focus theft | Pinned tabs get **null** `tabMembership` in `deriveProjects` | owner-PASS |
| **BUG-194** focused project's last terminal cd-d out → terminal vanishes / multitab breaks | Release focus to "All" when the focused project drops from the rail (`shouldReleaseFocus`) | owner-PASS |

## Key design decisions

1. **Track the live shell cwd, don't freeze it.** `lsof` runs async off the main thread; a liveness tri-state distinguishes an *exited* shell (drop its tile) from a *not-yet-spawned* tab (keep its launch cwd).
2. **Make the close handler atomic and idempotent.** Guards re-entry, moves the confirm before any snapshot, removes the nested-setState anti-pattern.
3. **Pinned tabs have no home project** — a cross-project reference shouldn't qualify whatever folder it sits under.
4. **Poll without churn** — `mergeLiveCwdInfo` returns the same map reference when nothing changed.

## Tests

- New pure module `shared/project-lifecycle.ts` with **19 unit tests** (effectiveProjectTerminals / mergeLiveCwdInfo / planProjectClose / shouldReleaseFocus).
- **868/868 tests pass**; typecheck clean.

## Notes

- BUG-192/193/194 owner-PASSed on the v0.8.5 smoke walk; BUG-191 (the keystone) was owner-SKIP but agent-verified live three ways, accepted for the cut.
- Tagged `v0.8.5` (cut commit `159a981`); branch carries the follow-on `chore: bump to v0.8.6`.
- DMG build + GitHub Release run post-merge from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)