### PR TITLE
ENH-191 Phase H (Cut 0): serialize shared on-disk writers (lost-update fix)

### DIFF
--- a/core/nav-pins-service.ts
+++ b/core/nav-pins-service.ts
@@ -28,9 +28,9 @@ import * as fs from 'fs/promises'
 import * as path from 'path'
 import * as os from 'os'
 import type { NavPinEntry } from '../shared/types'
+import { createWriteQueue, uniqueTmpPath } from './write-queue'
 
-const NAV_PINS_DIR = path.join(os.homedir(), '.claude', 'duo')
-const NAV_PINS_PATH = path.join(NAV_PINS_DIR, 'nav-pins.json')
+const DEFAULT_DIR = path.join(os.homedir(), '.claude', 'duo')
 const SCHEMA_VERSION = 1
 
 interface NavPinsFile {
@@ -39,9 +39,23 @@ interface NavPinsFile {
 }
 
 export class NavPinsService {
+  private readonly dir: string
+  private readonly file: string
+  // Phase H (ENH-191 Cut 0) — serialize the read-modify-write so a
+  // socket toggle + a renderer-click toggle (or two windows) cannot
+  // interleave at the await points and lose an update.
+  private readonly enqueue = createWriteQueue()
+
+  // `baseDir` is injectable for tests (avoids polluting the real
+  // ~/.claude/duo); production constructs it no-arg.
+  constructor(baseDir: string = DEFAULT_DIR) {
+    this.dir = baseDir
+    this.file = path.join(baseDir, 'nav-pins.json')
+  }
+
   async list(): Promise<NavPinEntry[]> {
     try {
-      const raw = await fs.readFile(NAV_PINS_PATH, 'utf8')
+      const raw = await fs.readFile(this.file, 'utf8')
       const parsed = JSON.parse(raw) as Partial<NavPinsFile>
       if (!Array.isArray(parsed.pins)) return []
       // Filter malformed entries defensively rather than throwing —
@@ -59,20 +73,28 @@ export class NavPinsService {
   }
 
   async toggle(entry: NavPinEntry): Promise<NavPinEntry[]> {
-    const current = await this.list()
-    const idx = current.findIndex(p => p.path === entry.path)
-    const next = idx >= 0
-      ? [...current.slice(0, idx), ...current.slice(idx + 1)]
-      : [...current, entry]
-    await this.write(next)
-    return next
+    return this.enqueue(async () => {
+      const current = await this.list()
+      const idx = current.findIndex(p => p.path === entry.path)
+      const next = idx >= 0
+        ? [...current.slice(0, idx), ...current.slice(idx + 1)]
+        : [...current, entry]
+      await this.write(next)
+      return next
+    })
   }
 
   private async write(pins: NavPinEntry[]): Promise<void> {
-    await fs.mkdir(NAV_PINS_DIR, { recursive: true })
+    await fs.mkdir(this.dir, { recursive: true })
     const file: NavPinsFile = { version: SCHEMA_VERSION, pins }
-    const tmp = NAV_PINS_PATH + '.duo.tmp'
-    await fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n')
-    await fs.rename(tmp, NAV_PINS_PATH)
+    const tmp = uniqueTmpPath(this.file)
+    try {
+      await fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n')
+      await fs.rename(tmp, this.file)
+    } catch (err) {
+      // Best-effort cleanup so a failed write doesn't orphan a unique tmp.
+      await fs.rm(tmp, { force: true }).catch(() => {})
+      throw err
+    }
   }
 }

--- a/core/pin-services.test.ts
+++ b/core/pin-services.test.ts
@@ -1,0 +1,74 @@
+// Phase H (ENH-191 Cut 0) — interleave-safety for the shared on-disk
+// pin writers. These exercise the REAL services (not just the queue
+// primitive) against a temp dir via the injectable `baseDir`.
+//
+// The proof: fire two concurrent toggles of DIFFERENT entries. Without
+// serialization each toggle reads the same (empty) list, adds only its
+// own entry, and writes a one-element list — the second write clobbers
+// the first, so only ONE survives. With the Phase H queue, both survive.
+// (Reverting the `enqueue(...)` wrapper in any service turns these red,
+// which is the negative control — see write-queue.test.ts for the pure,
+// always-present lost-update control.)
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import * as os from 'os'
+import { NavPinsService } from './nav-pins-service'
+import { PinsService } from './pins-service'
+import { ProjectsService } from './projects-service'
+
+describe('Phase H — pin-service write serialization (interleave safety)', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'duo-phaseH-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('NavPinsService: two concurrent toggles of different pins both survive', async () => {
+    const svc = new NavPinsService(dir)
+    await Promise.all([
+      svc.toggle({ path: '/a', kind: 'file' }),
+      svc.toggle({ path: '/b', kind: 'file' }),
+    ])
+    const list = await svc.list()
+    expect(list.map((p) => p.path).sort()).toEqual(['/a', '/b'])
+  })
+
+  it('PinsService: two concurrent toggles of different pins both survive', async () => {
+    const svc = new PinsService(dir)
+    await Promise.all([
+      svc.toggle({ kind: 'file', ref: '/a', title: 'a' }),
+      svc.toggle({ kind: 'file', ref: '/b', title: 'b' }),
+    ])
+    const list = await svc.list()
+    expect(list.map((p) => p.ref).sort()).toEqual(['/a', '/b'])
+  })
+
+  it('ProjectsService: two concurrent togglePins both survive', async () => {
+    const svc = new ProjectsService(dir)
+    await Promise.all([svc.togglePin('/a'), svc.togglePin('/b')])
+    const file = await svc.read()
+    expect([...file.pins].sort()).toEqual(['/a', '/b'])
+  })
+
+  it('ProjectsService: a togglePin and a setColorOverride do not clobber each other', async () => {
+    // Both mutators share `read`, so they MUST share one queue.
+    const svc = new ProjectsService(dir)
+    await Promise.all([svc.togglePin('/a'), svc.setColorOverride('/a', 3)])
+    const file = await svc.read()
+    expect(file.pins).toEqual(['/a'])
+    expect(file.colorOverrides['/a']).toBe(3)
+  })
+
+  it('write uses a unique tmp — no orphaned .duo.tmp remains after a write', async () => {
+    const svc = new NavPinsService(dir)
+    await svc.toggle({ path: '/a', kind: 'file' })
+    const entries = await fs.readdir(dir)
+    expect(entries).toEqual(['nav-pins.json'])
+  })
+})

--- a/core/pins-service.ts
+++ b/core/pins-service.ts
@@ -25,9 +25,9 @@ import * as fs from 'fs/promises'
 import * as path from 'path'
 import * as os from 'os'
 import type { PinEntry } from '../shared/types'
+import { createWriteQueue, uniqueTmpPath } from './write-queue'
 
-const PINS_DIR = path.join(os.homedir(), '.claude', 'duo')
-const PINS_PATH = path.join(PINS_DIR, 'pins.json')
+const DEFAULT_DIR = path.join(os.homedir(), '.claude', 'duo')
 const SCHEMA_VERSION = 1
 
 interface PinsFile {
@@ -36,9 +36,23 @@ interface PinsFile {
 }
 
 export class PinsService {
+  private readonly dir: string
+  private readonly file: string
+  // Phase H (ENH-191 Cut 0) — serialize the read-modify-write so a
+  // socket toggle + a renderer-click toggle (or two windows) cannot
+  // interleave at the await points and lose an update.
+  private readonly enqueue = createWriteQueue()
+
+  // `baseDir` is injectable for tests (avoids polluting the real
+  // ~/.claude/duo); production constructs it no-arg.
+  constructor(baseDir: string = DEFAULT_DIR) {
+    this.dir = baseDir
+    this.file = path.join(baseDir, 'pins.json')
+  }
+
   async list(): Promise<PinEntry[]> {
     try {
-      const raw = await fs.readFile(PINS_PATH, 'utf8')
+      const raw = await fs.readFile(this.file, 'utf8')
       const parsed = JSON.parse(raw) as Partial<PinsFile>
       if (!Array.isArray(parsed.pins)) return []
       // Filter out malformed entries defensively rather than throwing —
@@ -56,20 +70,28 @@ export class PinsService {
   }
 
   async toggle(entry: PinEntry): Promise<PinEntry[]> {
-    const current = await this.list()
-    const idx = current.findIndex(p => p.kind === entry.kind && p.ref === entry.ref)
-    const next = idx >= 0
-      ? [...current.slice(0, idx), ...current.slice(idx + 1)]
-      : [...current, entry]
-    await this.write(next)
-    return next
+    return this.enqueue(async () => {
+      const current = await this.list()
+      const idx = current.findIndex(p => p.kind === entry.kind && p.ref === entry.ref)
+      const next = idx >= 0
+        ? [...current.slice(0, idx), ...current.slice(idx + 1)]
+        : [...current, entry]
+      await this.write(next)
+      return next
+    })
   }
 
   private async write(pins: PinEntry[]): Promise<void> {
-    await fs.mkdir(PINS_DIR, { recursive: true })
+    await fs.mkdir(this.dir, { recursive: true })
     const file: PinsFile = { version: SCHEMA_VERSION, pins }
-    const tmp = PINS_PATH + '.duo.tmp'
-    await fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n')
-    await fs.rename(tmp, PINS_PATH)
+    const tmp = uniqueTmpPath(this.file)
+    try {
+      await fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n')
+      await fs.rename(tmp, this.file)
+    } catch (err) {
+      // Best-effort cleanup so a failed write doesn't orphan a unique tmp.
+      await fs.rm(tmp, { force: true }).catch(() => {})
+      throw err
+    }
   }
 }

--- a/core/projects-service.test.ts
+++ b/core/projects-service.test.ts
@@ -656,39 +656,21 @@ describe('normalize', () => {
 })
 
 describe('ProjectsService', () => {
-  let tmpHome: string
-  let originalHome: string | undefined
+  let tmpDir: string
   let svc: ProjectsService
 
   beforeEach(async () => {
-    originalHome = process.env.HOME
-    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'duo-projects-test-'))
-    process.env.HOME = tmpHome
-    // Re-import to pick up new HOME — but `os.homedir()` is computed
-    // once at import time of projects-service.ts. So the test has to
-    // operate on the original path. We work around by writing
-    // directly to the file the service uses, OR by skipping the
-    // env-rebinding tests when this proves flaky. For now: drive the
-    // service via toggle/setColorOverride and read back.
-    svc = new ProjectsService()
+    // Phase H (ENH-191 Cut 0) — the service now takes an injectable
+    // baseDir, so tests use a hermetic temp dir. This replaces the old
+    // workaround that wrote to the user's REAL ~/.claude/duo/projects.json
+    // (os.homedir() is import-time-bound, so $HOME rebinding never took
+    // effect) and then conditionally cleaned it up.
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'duo-projects-test-'))
+    svc = new ProjectsService(tmpDir)
   })
 
   afterEach(async () => {
-    if (originalHome) process.env.HOME = originalHome
-    await fs.rm(tmpHome, { recursive: true, force: true })
-    // Also clean up the real projects.json the test would have
-    // written under the actual $HOME, since the env-rebind didn't
-    // take effect post-import.
-    const realPath = path.join(os.homedir(), '.claude', 'duo', 'projects.json')
-    try {
-      const raw = await fs.readFile(realPath, 'utf8')
-      const parsed = JSON.parse(raw)
-      if (parsed?.pins?.includes('/test-pin-marker')) {
-        await fs.rm(realPath, { force: true })
-      }
-    } catch {
-      // file not present or unreadable — fine
-    }
+    await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
   it('togglePin adds a pin when absent, removes when present', async () => {

--- a/core/projects-service.ts
+++ b/core/projects-service.ts
@@ -14,9 +14,9 @@ import * as path from 'path'
 import * as os from 'os'
 import type { ProjectsFile } from '../shared/types'
 import { NUM_PROJECT_COLORS, normalizeProjectsFile } from '../shared/projects'
+import { createWriteQueue, uniqueTmpPath } from './write-queue'
 
-const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'duo')
-const PROJECTS_PATH = path.join(PROJECTS_DIR, 'projects.json')
+const DEFAULT_DIR = path.join(os.homedir(), '.claude', 'duo')
 const SCHEMA_VERSION = 1
 
 // Re-export pure helpers so existing imports of this file keep working.
@@ -40,9 +40,24 @@ export type { Project, ProjectsFile } from '../shared/types'
  * file returns the empty default).
  */
 export class ProjectsService {
+  private readonly dir: string
+  private readonly file: string
+  // Phase H (ENH-191 Cut 0) — serialize the read-modify-write so a
+  // socket toggle + a renderer-click toggle (or two windows) cannot
+  // interleave at the await points and lose an update. Covers BOTH
+  // mutators (togglePin + setColorOverride) since they share `read`.
+  private readonly enqueue = createWriteQueue()
+
+  // `baseDir` is injectable for tests (avoids polluting the real
+  // ~/.claude/duo); production constructs it no-arg.
+  constructor(baseDir: string = DEFAULT_DIR) {
+    this.dir = baseDir
+    this.file = path.join(baseDir, 'projects.json')
+  }
+
   async read(): Promise<ProjectsFile> {
     try {
-      const raw = await fs.readFile(PROJECTS_PATH, 'utf8')
+      const raw = await fs.readFile(this.file, 'utf8')
       const parsed = JSON.parse(raw) as Partial<ProjectsFile>
       return normalizeProjectsFile(parsed)
     } catch {
@@ -51,41 +66,51 @@ export class ProjectsService {
   }
 
   async togglePin(root: string): Promise<ProjectsFile> {
-    const current = await this.read()
-    const idx = current.pins.indexOf(root)
-    const next: ProjectsFile = {
-      ...current,
-      pins:
-        idx >= 0
-          ? [...current.pins.slice(0, idx), ...current.pins.slice(idx + 1)]
-          : [...current.pins, root]
-    }
-    await this.write(next)
-    return next
+    return this.enqueue(async () => {
+      const current = await this.read()
+      const idx = current.pins.indexOf(root)
+      const next: ProjectsFile = {
+        ...current,
+        pins:
+          idx >= 0
+            ? [...current.pins.slice(0, idx), ...current.pins.slice(idx + 1)]
+            : [...current.pins, root]
+      }
+      await this.write(next)
+      return next
+    })
   }
 
   async setColorOverride(root: string, colorIndex: number | null): Promise<ProjectsFile> {
-    const current = await this.read()
-    const overrides = { ...current.colorOverrides }
-    if (colorIndex === null) {
-      delete overrides[root]
-    } else if (
-      Number.isInteger(colorIndex) &&
-      colorIndex >= 0 &&
-      colorIndex < NUM_PROJECT_COLORS
-    ) {
-      overrides[root] = colorIndex
-    }
-    const next: ProjectsFile = { ...current, colorOverrides: overrides }
-    await this.write(next)
-    return next
+    return this.enqueue(async () => {
+      const current = await this.read()
+      const overrides = { ...current.colorOverrides }
+      if (colorIndex === null) {
+        delete overrides[root]
+      } else if (
+        Number.isInteger(colorIndex) &&
+        colorIndex >= 0 &&
+        colorIndex < NUM_PROJECT_COLORS
+      ) {
+        overrides[root] = colorIndex
+      }
+      const next: ProjectsFile = { ...current, colorOverrides: overrides }
+      await this.write(next)
+      return next
+    })
   }
 
   private async write(file: ProjectsFile): Promise<void> {
-    await fs.mkdir(PROJECTS_DIR, { recursive: true })
-    const tmp = PROJECTS_PATH + '.duo.tmp'
-    await fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n')
-    await fs.rename(tmp, PROJECTS_PATH)
+    await fs.mkdir(this.dir, { recursive: true })
+    const tmp = uniqueTmpPath(this.file)
+    try {
+      await fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n')
+      await fs.rename(tmp, this.file)
+    } catch (err) {
+      // Best-effort cleanup so a failed write doesn't orphan a unique tmp.
+      await fs.rm(tmp, { force: true }).catch(() => {})
+      throw err
+    }
   }
 }
 

--- a/core/session-state-service.ts
+++ b/core/session-state-service.ts
@@ -39,6 +39,7 @@ import * as path from 'path'
 import * as os from 'os'
 import type { SessionState } from '../shared/types'
 import { EMPTY_SESSION_STATE } from '../shared/types'
+import { uniqueTmpPath } from './write-queue'
 
 const SESSION_DIR = path.join(os.homedir(), '.claude', 'duo')
 const SESSION_PATH = path.join(SESSION_DIR, 'session-state.json')
@@ -194,9 +195,14 @@ export class SessionStateService {
       }
     }
 
+    // Phase H (ENH-191 Cut 0) — unique tmp suffix so two atomic writes
+    // (e.g. two Duo processes) never race the same rename target. The
+    // `writing` flag above already serializes flushes WITHIN this
+    // process; the unique tmp covers the cross-process case. (P4 adds
+    // the per-window compose-flush + its concurrent-flush test.)
+    const tmp = uniqueTmpPath(SESSION_PATH, 'tmp')
     try {
       await fs.mkdir(SESSION_DIR, { recursive: true })
-      const tmp = SESSION_PATH + '.tmp'
       await fs.writeFile(tmp, JSON.stringify(state, null, 2), 'utf8')
       await fs.rename(tmp, SESSION_PATH)
       // ENH-167 v1.2 — mirror to the active .duo-session if there is
@@ -211,6 +217,9 @@ export class SessionStateService {
         }
       }
     } catch (err) {
+      // Phase H — best-effort cleanup so a failed write doesn't orphan
+      // the unique tmp file.
+      await fs.rm(tmp, { force: true }).catch(() => {})
       // Persistent failure — log and move on. We don't bubble; the
       // renderer doesn't have a meaningful response to "save failed."
       console.warn('[session-state] save failed:', (err as Error)?.message ?? err)

--- a/core/write-queue.test.ts
+++ b/core/write-queue.test.ts
@@ -1,0 +1,101 @@
+// Phase H (ENH-191 Cut 0) — write-serialization primitive tests.
+//
+// The load-bearing test is the lost-update pair: the SAME read-modify-
+// write run through the queue keeps both updates, but run un-serialized
+// loses one. The negative control proves the test actually exercises
+// the race the queue fixes (a test with no failing-without-the-fix case
+// proves nothing).
+
+import { describe, it, expect } from 'vitest'
+import { createWriteQueue, uniqueTmpPath } from './write-queue'
+
+/** Yield to the macrotask queue — the interleave window where an
+ *  un-serialized read-modify-write loses an update. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/** Models a service toggle: read a shared value, await (yield), write
+ *  value+1. Two concurrent runs that both read before either writes
+ *  collapse to a single increment — the lost update. */
+function makeRmw(store: { value: number }) {
+  return async (): Promise<number> => {
+    const cur = store.value
+    await tick()
+    store.value = cur + 1
+    return store.value
+  }
+}
+
+describe('createWriteQueue', () => {
+  it('serializes read-modify-write so concurrent ops do NOT lose updates', async () => {
+    const enqueue = createWriteQueue()
+    const store = { value: 0 }
+    const rmw = makeRmw(store)
+    await Promise.all([enqueue(rmw), enqueue(rmw)])
+    // Each op runs after the prior settles → 0→1→2.
+    expect(store.value).toBe(2)
+  })
+
+  it('NEGATIVE CONTROL: the same RMW run UN-serialized loses an update', async () => {
+    const store = { value: 0 }
+    const rmw = makeRmw(store)
+    // No queue: both read 0, both write 1 → one increment is lost.
+    await Promise.all([rmw(), rmw()])
+    expect(store.value).toBe(1)
+  })
+
+  it('preserves enqueue order under contention', async () => {
+    const enqueue = createWriteQueue()
+    const order: number[] = []
+    await Promise.all(
+      [1, 2, 3, 4, 5].map((n) =>
+        enqueue(async () => {
+          await tick()
+          order.push(n)
+        })
+      )
+    )
+    expect(order).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('a failing op does NOT wedge the queue (later ops still run)', async () => {
+    const enqueue = createWriteQueue()
+    const order: string[] = []
+    const bad = enqueue(async () => {
+      order.push('bad')
+      throw new Error('boom')
+    })
+    await expect(bad).rejects.toThrow('boom')
+    const good = await enqueue(async () => {
+      order.push('good')
+      return 42
+    })
+    expect(good).toBe(42)
+    expect(order).toEqual(['bad', 'good'])
+  })
+
+  it('returns each op\'s own result / rejection to its caller', async () => {
+    const enqueue = createWriteQueue()
+    await expect(enqueue(async () => 'a')).resolves.toBe('a')
+    await expect(
+      enqueue(async () => {
+        throw new Error('b')
+      })
+    ).rejects.toThrow('b')
+  })
+})
+
+describe('uniqueTmpPath', () => {
+  it('produces a distinct path per call (no fixed shared tmp)', () => {
+    const a = uniqueTmpPath('/x/pins.json')
+    const b = uniqueTmpPath('/x/pins.json')
+    expect(a).not.toBe(b)
+    expect(a.startsWith('/x/pins.json.')).toBe(true)
+    expect(a.endsWith('.duo.tmp')).toBe(true)
+  })
+
+  it('honors a custom extension', () => {
+    expect(uniqueTmpPath('/x/session-state.json', 'tmp').endsWith('.tmp')).toBe(true)
+  })
+})

--- a/core/write-queue.ts
+++ b/core/write-queue.ts
@@ -1,0 +1,60 @@
+// Phase H (ENH-191 Cut 0) — write-serialization primitives.
+//
+// Why this exists: the shared on-disk JSON writers (pins, nav-pins,
+// projects, session-state) each do an async read-modify-write —
+// `const cur = await read()` then `await write(next)` — with two await
+// points and no mutex. Two callers interleave at those await points: a
+// `duo` CLI command over the socket + a renderer click over IPC (and,
+// once ENH-191 lands, two windows). Both read the old value, both
+// compute `next` from it, the second write clobbers the first — a lost
+// update. Separately, a *fixed* shared temp path lets two in-flight
+// atomic writes race the same `rename`.
+//
+// `createWriteQueue` serializes RMW ops so each runs to completion
+// before the next starts. `uniqueTmpPath` gives every atomic write its
+// own temp file so concurrent renames (e.g. two Duo processes) can
+// never collide. Both are pure / node-only and unit-tested in
+// isolation (write-queue.test.ts) with a lost-update negative control.
+
+import { randomBytes } from 'node:crypto'
+
+/**
+ * Returns an `enqueue` function that runs each async op strictly after
+ * the previous one has fully settled (resolved OR rejected), so a
+ * read-modify-write executes atomically with respect to other ops on
+ * the same queue. The caller still receives that op's own result or
+ * rejection; a failing op never wedges the queue for later ops.
+ *
+ * One queue per resource (e.g. per service instance) — ops on
+ * different queues run independently.
+ */
+export function createWriteQueue(): <T>(op: () => Promise<T>) => Promise<T> {
+  let tail: Promise<unknown> = Promise.resolve()
+  return function enqueue<T>(op: () => Promise<T>): Promise<T> {
+    // Run `op` once `tail` settles, regardless of HOW it settled
+    // (op is passed as both the fulfilled and rejected handler).
+    const run: Promise<T> = tail.then(op, op)
+    // The next enqueue waits for THIS op to settle, but the chain must
+    // never reject — swallow so one failing op can't wedge the queue.
+    tail = run.then(swallow, swallow)
+    return run
+  }
+}
+
+function swallow(): void {
+  /* keep the queue alive regardless of the prior op's outcome */
+}
+
+/**
+ * A collision-proof temp path for an atomic write (`writeFile` to tmp,
+ * then `rename` over the final path). Includes the pid + random bytes
+ * so two writers — even in separate Duo processes — never target the
+ * same temp file and race the rename.
+ *
+ * @param finalPath the destination file the tmp will be renamed onto
+ * @param ext       trailing extension (default `duo.tmp`; session-state
+ *                  uses `tmp` to match its historical suffix)
+ */
+export function uniqueTmpPath(finalPath: string, ext = 'duo.tmp'): string {
+  return `${finalPath}.${process.pid}.${randomBytes(4).toString('hex')}.${ext}`
+}


### PR DESCRIPTION
## What & why

The `pins` / `nav-pins` / `projects` services each do an **unserialized async read-modify-write** — `const cur = await read()` then `await write(next)` — on a **fixed shared `.duo.tmp`** with no mutex, and the `SocketServer` dispatches **fire-and-forget** ([`socket-server.ts:413`](../blob/main/core/socket-server.ts#L413)). Two writers interleave at the `await` points — a `duo` CLI pin command + a navigator click, or two windows once ENH-191 lands — so both read the old list, both compute `next`, and the second write **clobbers the first** (lost update); the two `rename`s can also race the shared tmp. **This is latent today**, not just under multi-window.

This is **Cut 0** of the ENH-191 multi-window sequence, pulled forward per owner decision because it's independently shippable, fixes a present bug, and gives P4's persistence work a hardened base. See `docs/prd/enh-191-multi-window.md` → **Phase H** + risk **R6**.

> Context: the spec's own Appendix C named this concurrency class but **dismissed** it ("funnels through main, so safe"). That's wrong — a single process does **not** serialize async RMW that interleaves at `await` points. The v0.8.6 audit caught the dismissal; this PR is the fix.

## The change

- **`core/write-queue.ts`** (new) — `createWriteQueue()` (a per-resource async serial queue: each op runs only after the previous fully settles) + `uniqueTmpPath()` (collision-proof atomic-write temp, `pid` + random bytes).
- **`pins` / `nav-pins` / `projects`** — route **every** mutator through the queue; unique tmp + cleanup-on-error; an **injectable `baseDir`** constructor param (defaults to `~/.claude/duo`) so tests are hermetic. `ProjectsService` shares one queue across `togglePin` + `setColorOverride` (they share `read`).
- **`session-state`** — already single-writer via the `writing` flag; just adds the unique tmp suffix + cleanup. (Per-window compose-flush + its concurrent-flush test are deferred to P4.)
- **`projects-service.test.ts`** — de-hacked to use `baseDir`; it was previously writing to the user's **real** `~/.claude/duo/projects.json` (because `os.homedir()` is import-time-bound, the old `$HOME` rebind never took effect).

## Tests

- `core/write-queue.test.ts` — pure lost-update test **with an always-on negative control** (the same RMW run un-serialized loses an update), plus order-preservation, failing-op-doesn't-wedge, and `uniqueTmpPath` distinctness.
- `core/pin-services.test.ts` — real-service interleave tests: two concurrent toggles of different entries both survive (would collapse to one without the queue) + no orphaned tmp.
- **Negative control proven:** temporarily bypassing serialization in the primitive turns **5 tests red** (the queue test + all 4 service interleave tests); reverted.

## Gates

- ✅ `npm run typecheck` (both tsc projects)
- ✅ `npm run test:run` — **880/880** pass (47 files)
- ⚠️ `npm run lint` — **`eslint` is not installed in this worktree's `node_modules`** (pre-existing; unrelated to this change — `eslint .` would fail on `main` too). Flagging as a discovered issue; the systemic fix (ensure lint is runnable / add the standalone `check:routing` grep-gate) is tracked under the ENH-191 plan.

## Scope / risk

Zero user-visible change. Pure internal hardening; reverts cleanly (additive). No on-disk format change. The only behavioral change is that concurrent writes now serialize instead of racing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
