### PR TITLE
docs(pack-builder): fix dangling cross-reference links in SKILL.md

### DIFF
--- a/skill/pack-builder/SKILL.md
+++ b/skill/pack-builder/SKILL.md
@@ -43,7 +43,7 @@ my-distro-pack/                           ← the pack root (any name)
 ```
 
 **A reference template** ships at
-[`examples/distro-pack-template/`](examples/distro-pack-template/) in the
+[`examples/distro-pack-template/`](../../examples/distro-pack-template/) in the
 Duo source repo. Copy that folder; fill in the manifests; replace the
 example skills/agents with your content; ship the result as a folder
 the user (or IT) drops into `~/.claude/duo/extra-packs/<distro-name>/`.
@@ -255,10 +255,10 @@ only on first detection of a new pack name.
 
 ## Cross-references
 
-- **PRD**: [`docs/prd/stage-21d-distro-packs.md`](../../../docs/prd/stage-21d-distro-packs.md)
-- **Sample template**: [`examples/distro-pack-template/`](../../../examples/distro-pack-template/)
+- **PRD**: [`docs/prd/stage-21d-distro-packs.md`](../../docs/prd/stage-21d-distro-packs.md)
+- **Sample template**: [`examples/distro-pack-template/`](../../examples/distro-pack-template/)
 - **HOW-TO-FORK** § Layer 2.5 (drop-in distro packs):
-  [`docs/HOW-TO-FORK.md`](../../../docs/HOW-TO-FORK.md)
+  [`docs/HOW-TO-FORK.md`](../../docs/HOW-TO-FORK.md)
 - **Make a playground** (modality lock + browser-default): `make-playground.md`
 - **Make a page** (canvas-default reference content): `make-page.md`
 - **CLI surface**: `duo pack list` / `duo pack uninstall <name>`


### PR DESCRIPTION
## What & why

`scripts/check-skill-currency.mjs` reported an **A4 NO-DANGLING** failure on `skill/pack-builder/SKILL.md`: two reference links did not resolve. The guard is warn-and-continue in `predev`/`pretest` (build stays green) but **fails under `--strict`** — the gate the `cut-version` skill runs at release time — so this blocked a clean strict currency check.

Root cause: the links used `../../../` from `skill/pack-builder/SKILL.md`, which climbs to the **parent of the repo root** — one `../` too many. The target docs all exist; the paths were just over-deep. The fix collapses `../../../` → `../../` (file-dir-relative to the repo root, matching the house style in `skill/references/`).

## Changes (`skill/pack-builder/SKILL.md` only)

| Line | Before | After |
|---|---|---|
| 261 | `../../../docs/HOW-TO-FORK.md` | `../../docs/HOW-TO-FORK.md` |
| 258 | `../../../docs/prd/stage-21d-distro-packs.md` | `../../docs/prd/stage-21d-distro-packs.md` |
| 259 | `../../../examples/distro-pack-template/` | `../../examples/distro-pack-template/` |
| 46 | `examples/distro-pack-template/` | `../../examples/distro-pack-template/` |

The first two are the guard-flagged links. Lines 259 and 46 are the **same** over-`../` defect on a sibling link: 259 wasn't flagged only because the guard skips targets that don't end in `.md`/`.html`, and 46 was a third, divergent path to the *same* template dir. Fixing all four keeps the Cross-references block internally consistent and GitHub-clickable.

## Verification

- `node scripts/check-skill-currency.mjs` → **A4 PASS**, `0 failures · 0 warnings` across 65 verbs.
- `node scripts/check-skill-currency.mjs --strict` → **exit 0** (release gate clear).
- Each new href resolves on disk from `skill/pack-builder/`.

Pre-existing breakage (not introduced by ENH-203), outside the pack-builder ships-to-end-users boundary. Pure doc hygiene — no behavior change.

https://claude.ai/code/session_012c1yV6LC4Rd59YCKJWTaAw

---
_Generated by [Claude Code](https://claude.ai/code/session_012c1yV6LC4Rd59YCKJWTaAw)_