### PR TITLE
Duo project template: hook-availability probe + exploration notes

### DIFF
--- a/docs/research/duo-project-template/README.md
+++ b/docs/research/duo-project-template/README.md
@@ -1,0 +1,187 @@
+# Duo project template — feature exploration
+
+> Status: **exploration.** Audience + marking scheme + trigger timing are
+> decided (below). One architectural decision — *where* detection runs — is
+> deliberately deferred until we have evidence about hook availability on a
+> real managed machine. This folder holds the probe that gathers that
+> evidence.
+
+## The feature in one paragraph
+
+Define a reusable template for a **duo project**: a folder that declares a
+"start here" page. When you enter that folder in Duo, Duo automatically opens
+the start-here page in the **browser pane** — a landing / onboarding page for
+the human. A manifest file marks the folder as a duo project *and* names the
+start-here file explicitly, so detection is a single file read with zero
+false positives.
+
+## Decided (from owner, 2026-06-09)
+
+| Question | Decision |
+|---|---|
+| **Audience** of the auto-opened page | **The user** — it's a landing page (like auto-opening a README), not context for Claude. |
+| **Marking scheme** | **Manifest file** — one sentinel (e.g. `.duo-project.json`) that both marks the folder *and* names the start-here file. No HTML globbing, no meta-tag scanning, no guessing. |
+| **Trigger timing** | **Once per window, on first entry** to the project — does not reopen on every new terminal tab in the same folder. |
+| **Where detection runs** | **DEFERRED** — decide on evidence. See below. |
+
+### Why "manifest names the file" kills the false-positive problem
+
+The owner's two original worries were (a) the trigger doesn't know what to look
+for, and (b) it false-positives on an arbitrary HTML file. A manifest solves
+both at once:
+
+```jsonc
+// .duo-project.json  (at the project root)
+{
+  "duoProject": 1,            // the marker — presence = "this is a duo project"
+  "startHere": "welcome.html" // the exact file to open; no scanning, no globbing
+}
+```
+
+Detection becomes: `stat .duo-project.json` → parse → open the one named file.
+Nothing else in the folder can accidentally match. (We can *optionally* add a
+belt-and-suspenders confirming `<meta name="duo-start-here">` tag in the named
+file later, but it isn't needed to be safe.)
+
+> Note: this is consistent with Duo's existing project-qualification logic
+> (`shared/projects.ts`, keyed on `CLAUDE.md` / `.claude/` / git-root markers).
+> `.duo-project.json` is an additional, explicit, opt-in marker layered on top.
+
+## The one open decision: where does detect + auto-open run?
+
+Auto-open is an **action** (`duo open <file>`), and Duo controls *both* the
+terminal's working directory *and* the browser pane. So there are hook-free
+places to put this that are immune to enterprise policy. The candidates, from
+most to least enterprise-proof:
+
+| Option | Hook-dependent? | Fires when | Note |
+|---|---|---|---|
+| **Duo-native** (Duo's own `PtyManager` detects the CWD it spawns into and opens the file) | **No** | Any Duo terminal entering the project | Most deterministic; touches zero Claude Code machinery |
+| **PATH shim** (`~/.claude/duo/bin/claude` wrapper, which already runs on every in-Duo `claude` launch) | **No** | Only when `claude` launches in a Duo terminal | Hook-free, but misses bare shells |
+| **Claude Code SessionStart hook** | **Yes** | Session start — *if hooks are permitted* | Lowest-complexity **iff** hooks fire here. The thing the probe tests. |
+
+The owner's preference: **if the SessionStart hook reliably fires on the work
+machine, use it** (least new code). If it's silenced by policy, fall back to
+the Duo-native trigger. The probe below decides which world we're in.
+
+> Background on why hooks are the only real unknown:
+> `skill/references/enterprise-deployments.md` already maps Duo's four
+> onboarding mechanisms. The managed CLAUDE.md block, the skill/agent
+> registries, and the PATH shim are all hook-free and always work (given a
+> writable `~/.claude`). The **SessionStart hook is the single
+> policy-fragile mechanism** — so it's the only thing worth empirically
+> testing.
+
+## How enterprise machines actually disable hooks
+
+(Confirmed against current Claude Code docs.) Admins set, in the **managed**
+settings file — macOS `/Library/Application Support/ClaudeCode/managed-settings.json`,
+Linux `/etc/claude-code/managed-settings.json` — one of:
+
+- `"disableAllHooks": true` — every non-managed hook becomes a **silent no-op**.
+- `"allowManagedHooksOnly": true` — only admin-managed/SDK hooks run; yours are blocked.
+- a `permissions.deny` rule that blocks the Bash command a hook would run.
+
+There is **no error** when this happens — the hook just never fires. That's
+why the probe both *reads the policy file* and *empirically watches a real
+hook*, and trusts the empirical result if they disagree.
+
+---
+
+## Test plan — run this on the work machine
+
+### Step 1 — get the probe onto the machine
+
+It's a single self-contained bash script (no repo clone, no deps beyond `bash`
++ the `claude` CLI). Either copy `duo-hook-probe.sh` from this folder, or fetch
+it directly:
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/dudgeon/duo/claude/duo-project-template-feature-b3vlai/docs/research/duo-project-template/duo-hook-probe.sh \
+  -o duo-hook-probe.sh
+chmod +x duo-hook-probe.sh
+```
+
+> The script writes **only** under `~/duo-hook-probe/` (a throwaway folder) and
+> only *reads* the managed policy file. It never edits your real `~/.claude`
+> config. `./duo-hook-probe.sh clean` removes everything.
+
+### Step 2 — inspect policy + build the test
+
+```bash
+./duo-hook-probe.sh setup
+```
+
+This prints a read-only **policy inspection** (managed-settings presence,
+`disableAllHooks` / `allowManagedHooksOnly`, whether `~/.claude` is writable,
+your `claude` version) and creates an isolated test project at
+`~/duo-hook-probe/` with a project-scoped `.claude/settings.json` defining
+three probe hooks: `SessionStart`, `UserPromptSubmit`, and `PreToolUse(Bash)`.
+
+> Project scope is representative on purpose: `disableAllHooks` /
+> `allowManagedHooksOnly` kill non-managed hooks at **every** scope, so if
+> project hooks fire, user-level hooks (where Duo installs its real one) would
+> fire too — and we never risk your real config.
+
+### Step 3 — exercise the hooks
+
+In a **new** terminal:
+
+```bash
+cd ~/duo-hook-probe
+claude
+```
+
+- If prompted to **trust the folder**, accept.
+- If prompted to **review/approve hooks**, approve. *Being unable to approve
+  is itself a finding — note it.*
+- `SessionStart` fires on launch automatically. To exercise the other two,
+  type: `Run this bash command for me: echo probe-ok`
+- **Context-injection check:** ask Claude `Did you receive a token starting
+  with DUO_HOOK_PROBE? If so, repeat it.` If Claude echoes the sentinel, the
+  SessionStart hook can hand Claude *instructions* (relevant if we ever want a
+  hook to tell Claude to do something, not just run a command).
+
+### Step 4 — read the verdict
+
+Back in the first terminal:
+
+```bash
+./duo-hook-probe.sh check
+```
+
+It reports `[FIRED]` / `[silent]` per hook and a plain-English verdict.
+
+### Step 5 — clean up
+
+```bash
+./duo-hook-probe.sh clean
+```
+
+## Decision tree (what the result means)
+
+- **SessionStart `[FIRED]`** → hooks are available here. We can ship the
+  detect+open as a SessionStart hook (lowest complexity), with the Duo-native
+  trigger as an optional belt-and-suspenders. Paste the `check` output back
+  and we'll proceed to design the manifest + hook.
+- **SessionStart `[silent]`** → don't depend on Claude Code hooks. Build the
+  **Duo-native** trigger: `PtyManager` already knows the CWD it spawns each
+  terminal into (`electron/pty-manager.ts`); it reads `.duo-project.json` and
+  drives Duo's existing `open` path directly. Immune to any hook/permission
+  policy. The once-per-window dedup lives in in-memory window state (allowed
+  per CLAUDE.md rule 12 — a Duo-owned concept, no sidecar).
+- **Mixed / approval blocked** → note exactly what happened (trust prompt
+  refused? `/hooks` empty?) and paste it back; that nuance changes the
+  fallback.
+
+## Not in scope for this probe
+
+- Whether `duo open` itself works under the corporate Bash sandbox — that's a
+  separate, already-documented concern
+  (`skill/references/sandbox-troubleshooting.md`). The Duo-native trigger
+  sidesteps it entirely since the open happens inside the Electron main
+  process, not through the agent's Bash tool.
+- The actual manifest schema finalization, the template scaffold (`duo project
+  init`?), and the once-per-window implementation — those come *after* the
+  where-it-runs decision.

--- a/docs/research/duo-project-template/duo-hook-probe.sh
+++ b/docs/research/duo-project-template/duo-hook-probe.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# duo-hook-probe.sh — Does Claude Code run hooks on THIS machine?
+# ----------------------------------------------------------------
+# A self-contained diagnostic for corporate / managed installs. It tells you
+# whether a SessionStart hook (and a couple of others) actually fires, or
+# whether enterprise policy has silenced them. No repo clone, no dependencies
+# beyond bash + the `claude` CLI. It NEVER touches your real ~/.claude config —
+# everything lives in an isolated throwaway folder you can delete.
+#
+# Why this matters: Duo wants to auto-open a project's "start here" page when
+# you enter the folder. The cleanest way to do that depends on whether hooks
+# are available here. This probe gives a yes/no answer from evidence.
+#
+# Usage:
+#   ./duo-hook-probe.sh setup     # build the isolated test project + inspect policy
+#   # ...then follow the printed instructions (launch `claude` in the test dir)...
+#   ./duo-hook-probe.sh check     # read the results and print a verdict
+#   ./duo-hook-probe.sh clean     # delete the test folder
+#   ./duo-hook-probe.sh inspect   # read-only policy inspection only (no setup)
+#
+# Safe by design: writes only under ~/duo-hook-probe/. Reads (never writes)
+# the managed-settings policy file. Removing the folder undoes everything.
+
+set -u
+
+PROBE_DIR="$HOME/duo-hook-probe"
+RESULTS_DIR="$PROBE_DIR/results"
+LOG="$RESULTS_DIR/hook-events.log"
+SENTINEL="DUO_HOOK_PROBE_SENTINEL_8f3a2c"
+
+# Managed-settings policy file (the only place disableAllHooks is effective).
+case "$(uname -s)" in
+  Darwin) MANAGED="/Library/Application Support/ClaudeCode/managed-settings.json" ;;
+  *)      MANAGED="/etc/claude-code/managed-settings.json" ;;
+esac
+
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+yel()   { printf '\033[33m%s\033[0m\n' "$*"; }
+rule()  { printf '%s\n' "------------------------------------------------------------"; }
+
+# ---------------------------------------------------------------------------
+# Read-only inspection of policy + existing Duo config. Writes nothing.
+# ---------------------------------------------------------------------------
+inspect() {
+  bold "POLICY INSPECTION (read-only)"
+  rule
+
+  printf 'claude CLI:        '
+  if command -v claude >/dev/null 2>&1; then
+    green "$(command -v claude)  ($(claude --version 2>/dev/null || echo 'version unknown'))"
+  else
+    red "NOT on PATH — open this terminal from inside Duo, or add claude to PATH."
+  fi
+
+  printf 'managed-settings:  '
+  if [ -r "$MANAGED" ]; then
+    yel "$MANAGED (exists, readable)"
+    if grep -Eq '"disableAllHooks"[[:space:]]*:[[:space:]]*true' "$MANAGED" 2>/dev/null; then
+      red   '   -> disableAllHooks: true  ==> ALL non-managed hooks are silenced by policy.'
+    elif grep -Eq '"allowManagedHooksOnly"[[:space:]]*:[[:space:]]*true' "$MANAGED" 2>/dev/null; then
+      red   '   -> allowManagedHooksOnly: true  ==> only admin-managed hooks run; yours are blocked.'
+    else
+      green '   -> no disableAllHooks / allowManagedHooksOnly key found (hooks likely permitted).'
+    fi
+    if grep -Eq '"permissions"' "$MANAGED" 2>/dev/null; then
+      yel  '   -> a "permissions" block exists; a Bash deny-rule could still block hook commands.'
+    fi
+  elif [ -e "$MANAGED" ]; then
+    yel "$MANAGED (exists but not readable by you)"
+  else
+    green "none at $MANAGED (no machine-wide hook policy at the usual path)."
+  fi
+
+  printf 'user settings:     '
+  if [ -f "$HOME/.claude/settings.json" ]; then
+    yel "$HOME/.claude/settings.json (exists)"
+    if grep -q '"SessionStart"' "$HOME/.claude/settings.json" 2>/dev/null; then
+      printf '   -> already defines a SessionStart hook'
+      grep -q '"_duo"' "$HOME/.claude/settings.json" 2>/dev/null && printf ' (Duo-managed entry present)'
+      printf '\n'
+    fi
+  else
+    green "no $HOME/.claude/settings.json yet."
+  fi
+
+  printf 'writable ~/.claude:'
+  if [ -d "$HOME/.claude" ] && [ -w "$HOME/.claude" ]; then
+    green " yes"
+  elif [ ! -e "$HOME/.claude" ]; then
+    yel " ~/.claude does not exist yet (created on first claude run)"
+  else
+    red " NO — Duo's installer can't write skill/agent/hook files here."
+  fi
+  rule
+}
+
+# ---------------------------------------------------------------------------
+# Build the isolated test project with a project-scoped .claude/settings.json.
+# Project scope is representative: disableAllHooks / allowManagedHooksOnly kill
+# non-managed hooks at EVERY scope, so if project hooks fire, user hooks would
+# too — and we never risk your real ~/.claude/settings.json.
+# ---------------------------------------------------------------------------
+setup() {
+  rm -rf "$PROBE_DIR"
+  mkdir -p "$RESULTS_DIR" "$PROBE_DIR/.claude"
+
+  # Helper the hooks call. Records that an event fired + dumps the event JSON.
+  cat > "$PROBE_DIR/record.sh" <<EOF
+#!/usr/bin/env bash
+EVENT="\$1"
+DIR="$RESULTS_DIR"
+mkdir -p "\$DIR"
+STDIN="\$(cat 2>/dev/null)"
+printf '%s\t%s\n' "\$(date '+%Y-%m-%dT%H:%M:%S')" "\$EVENT" >> "$LOG"
+printf '%s\n' "\$STDIN" > "\$DIR/\$EVENT.last.json"
+# SessionStart stdout is injected into Claude's context — emit a sentinel so we
+# can also confirm the *context-injection* path (the one a real feature needs).
+if [ "\$EVENT" = "SessionStart" ]; then
+  echo "$SENTINEL — if you can read this line, reply with the exact token $SENTINEL."
+fi
+exit 0
+EOF
+  chmod +x "$PROBE_DIR/record.sh"
+
+  cat > "$PROBE_DIR/.claude/settings.json" <<EOF
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [ { "type": "command", "command": "$PROBE_DIR/record.sh SessionStart" } ] }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [ { "type": "command", "command": "$PROBE_DIR/record.sh UserPromptSubmit" } ] }
+    ],
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "$PROBE_DIR/record.sh PreToolUse" } ] }
+    ]
+  }
+}
+EOF
+
+  : > "$LOG"
+
+  inspect
+  echo
+  bold "TEST PROJECT READY"
+  rule
+  echo "An isolated test project was created at:"
+  echo "    $PROBE_DIR"
+  echo
+  bold "Now do this, in order:"
+  echo "  1. Open a NEW terminal and change into the test folder:"
+  echo "         cd \"$PROBE_DIR\""
+  echo "  2. Launch Claude Code there:"
+  echo "         claude"
+  echo "     - If asked to TRUST the folder, accept it."
+  echo "     - If asked to REVIEW / APPROVE hooks, approve them."
+  echo "       (Being unable to approve is itself a finding — note it.)"
+  echo "  3. SessionStart fires on launch. To also exercise the other two hooks,"
+  echo "     type this prompt and let Claude run it:"
+  echo "         Run this bash command for me: echo probe-ok"
+  echo "  4. (Context-injection check) ask Claude:"
+  echo "         Did you receive a token starting with DUO_HOOK_PROBE? If so, repeat it."
+  echo "     If Claude echoes $SENTINEL, SessionStart context-injection works."
+  echo "  5. Exit Claude, return to THIS terminal, and run:"
+  echo "         ./duo-hook-probe.sh check"
+  rule
+}
+
+# ---------------------------------------------------------------------------
+# Read results and print a verdict + what it implies for the feature.
+# ---------------------------------------------------------------------------
+check() {
+  if [ ! -f "$LOG" ]; then
+    red "No results found. Run './duo-hook-probe.sh setup' first, then launch claude in $PROBE_DIR."
+    exit 1
+  fi
+
+  bold "HOOK PROBE RESULTS"
+  rule
+  fired() { grep -q "	$1$" "$LOG" 2>/dev/null; }
+
+  for e in SessionStart UserPromptSubmit PreToolUse; do
+    if fired "$e"; then
+      green "  [FIRED]   $e"
+    else
+      red   "  [silent]  $e"
+    fi
+  done
+  echo
+  echo "Raw event log ($LOG):"
+  sed 's/^/    /' "$LOG" 2>/dev/null || true
+  rule
+
+  echo
+  bold "VERDICT"
+  rule
+  if fired SessionStart; then
+    green "SessionStart hooks FIRE on this machine."
+    echo  "  -> A SessionStart hook is a viable, low-complexity home for the"
+    echo  "     duo-project detect + auto-open. We can keep this simple."
+    echo  "  -> Confirm the context-injection check (step 4) too: if Claude echoed"
+    echo  "     $SENTINEL, the hook can also hand Claude instructions, not just run a command."
+  else
+    red  "SessionStart hooks DID NOT fire."
+    echo "  -> Likely cause: disableAllHooks / allowManagedHooksOnly in the managed"
+    echo "     policy file, a Bash permission deny-rule, or an un-approvable hook prompt."
+    echo "     (Re-read the POLICY INSPECTION above for which.)"
+    echo "  -> Implication: don't rely on Claude Code hooks for the feature. Use a"
+    echo "     Duo-native trigger (Duo's own terminal-spawn opens the file) or the"
+    echo "     PATH-shim wrapper — both are hook-free and immune to this policy."
+  fi
+  rule
+  echo "When done: ./duo-hook-probe.sh clean   (removes $PROBE_DIR)"
+}
+
+clean() {
+  rm -rf "$PROBE_DIR"
+  green "Removed $PROBE_DIR"
+}
+
+case "${1:-}" in
+  setup)   setup ;;
+  check)   check ;;
+  inspect) inspect ;;
+  clean)   clean ;;
+  *)
+    bold "duo-hook-probe.sh — does Claude Code run hooks on this machine?"
+    echo
+    echo "  ./duo-hook-probe.sh setup     build isolated test + inspect policy, then follow steps"
+    echo "  ./duo-hook-probe.sh check     read results, print verdict"
+    echo "  ./duo-hook-probe.sh inspect   read-only policy inspection (no files written)"
+    echo "  ./duo-hook-probe.sh clean     delete the test folder"
+    ;;
+esac


### PR DESCRIPTION
## What this is

Exploration toward a **duo project** feature: a folder that declares a "start here" page, which Duo auto-opens in the browser pane (a landing page for the user) when you enter the folder.

This PR doesn't implement the feature. It ships the **diagnostic** needed to make the one open architectural decision — *where* detection runs — on evidence instead of guesswork.

## Decided (with owner)

- **Audience:** the user (landing page, like auto-opening a README) — not context for Claude.
- **Marking:** a manifest file (`.duo-project.json`) that both marks the folder *and* names the start-here file — zero false positives, no HTML scanning.
- **Timing:** auto-open once per window, on first entry to the project.

## The deferred decision

Auto-open is an action, and Duo controls both the terminal CWD and the browser pane, so there are **hook-free** places to put it (Duo-native `PtyManager`, or the existing PATH shim) that are immune to enterprise policy. The only real unknown is whether a low-complexity **SessionStart hook** survives on a managed machine — which admins silence via `disableAllHooks` / `allowManagedHooksOnly` in the managed-settings file, as a **silent no-op**.

## What's here

- `docs/research/duo-project-template/duo-hook-probe.sh` — self-contained bash probe (`setup` / `check` / `inspect` / `clean`). Reads the managed-settings policy and empirically fires `SessionStart` / `UserPromptSubmit` / `PreToolUse` in an isolated `~/duo-hook-probe/` test project. Never touches the real `~/.claude` config. Verified end-to-end (fired/silent detection, SessionStart stdout sentinel, verdict logic).
- `docs/research/duo-project-template/README.md` — decided requirements, the deferred decision, the run-it-on-the-work-machine test sequence, and a decision tree mapping each outcome to a build path.

## Next step

Owner runs the probe on the work machine and pastes back the `check` verdict; that picks SessionStart-hook vs. Duo-native trigger, and we proceed to the manifest schema + implementation.

https://claude.ai/code/session_01ChEWHSWiSqzPjNNRmCw122

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChEWHSWiSqzPjNNRmCw122)_