### PR TITLE
ENH-208 Phase 1 · PR2 — base lint + render

### DIFF
--- a/agents/duo.md
+++ b/agents/duo.md
@@ -278,6 +278,8 @@ empty.
 | `duo vault search <query> [--vault <path>]` | Full-text search over the vault (CLI twin of ⌘⇧F). JSON `[{path, absPath, line, excerpt}]`. |
 | `duo graph backlinks <note> [--vault <path>]` | Notes linking to `<note>` (basename-resolved; scans frontmatter + body). JSON `[{path, absPath, line, excerpt}]`. |
 | `duo graph orphans [--vault <path>]` | Notes with no inbound and no outbound links (a processing work-list). JSON `string[]`. |
+| `duo base lint <file\|--all> [--vault <path>]` | Validate a `.base` (or a note's embedded ` ```base ` blocks, or all with `--all`) against the corpus — bad types, unresolved `[[entities]]`, off-enum values, unknown functions/view-types, each with a "did you mean". Advisory, never blocks (D15). JSON `[{source, findings:[{severity, message, suggestion?}]}]`. |
+| `duo base render <file\|note> [--out p] [--open] [--vault <path>]` | Evaluate filters/formulas over live frontmatter → a stamped Duo-owned HTML artifact (generated-at · source-hash · as-of). A note renders its embedded ` ```base ` blocks with `this` = the note. Default writes to `out/`; `--open` opens it as a tab. JSON `{path, sourceHash, bases:[{label, views:[{name, rows}]}]}`. |
 
 For deeper detail, the Duo skill at `~/.claude/skills/duo/` is the
 source of truth — fetch sections from it rather than guessing:

--- a/cli/duo
+++ b/cli/duo
@@ -25,8 +25,8 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 // cli/duo.ts
 var net = __toESM(require("net"));
 var os = __toESM(require("os"));
-var path6 = __toESM(require("path"));
-var fs6 = __toESM(require("fs"));
+var path8 = __toESM(require("path"));
+var fs8 = __toESM(require("fs"));
 var import_crypto = require("crypto");
 
 // core/vault/parse.ts
@@ -2659,7 +2659,7 @@ function parseFile(absPath, root) {
   const raw = import_node_fs.default.readFileSync(absPath, "utf8");
   const { frontmatter, body } = splitFrontmatter(raw);
   const rel = import_node_path.default.relative(root, absPath).split(import_node_path.default.sep).join("/");
-  const basename = import_node_path.default.basename(absPath, import_node_path.default.extname(absPath));
+  const basename2 = import_node_path.default.basename(absPath, import_node_path.default.extname(absPath));
   const dir = import_node_path.default.dirname(rel);
   let mtimeMs = 0;
   try {
@@ -2669,7 +2669,7 @@ function parseFile(absPath, root) {
   return {
     absPath,
     relPath: rel,
-    basename,
+    basename: basename2,
     folder: dir === "." ? "" : dir,
     ext: import_node_path.default.extname(absPath).slice(1).toLowerCase(),
     frontmatter,
@@ -2710,7 +2710,7 @@ function findVaultRoot(startPath) {
     dir = parent;
   }
 }
-var SCAN_SKIP = /* @__PURE__ */ new Set(["node_modules", ".git", ".obsidian", ".trash", "out"]);
+var SCAN_SKIP = /* @__PURE__ */ new Set(["node_modules", ".git", ".obsidian", ".trash", "out", "templates"]);
 function countNotes(root) {
   let n = 0;
   const stack = [root];
@@ -2927,6 +2927,779 @@ function search(root, query, limit = 200) {
     }
   }
   return hits;
+}
+
+// core/vault/render.ts
+var import_node_fs6 = __toESM(require("node:fs"));
+var import_node_path6 = __toESM(require("node:path"));
+var import_node_crypto = __toESM(require("node:crypto"));
+
+// core/vault/engine.ts
+var DAY_MS = 864e5;
+var DuoDate = class {
+  constructor(d, asOf) {
+    this.asOf = asOf;
+    this.d = d instanceof Date ? d : new Date(d);
+  }
+  d;
+  valueOf() {
+    return this.d.getTime();
+  }
+  relative() {
+    const days = Math.round((this.d.getTime() - this.asOf.getTime()) / DAY_MS);
+    if (days === 0) return "today";
+    if (days > 0) return "in " + days + (days === 1 ? " day" : " days");
+    return -days + (days === -1 ? " day ago" : " days ago");
+  }
+  format(fmt) {
+    const M = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    return fmt.replace("YYYY", String(this.d.getFullYear())).replace("MMM", M[this.d.getMonth()]).replace("DD", String(this.d.getDate()).padStart(2, "0")).replace("D", String(this.d.getDate()));
+  }
+  toString() {
+    return this.format("MMM D, YYYY");
+  }
+};
+var DUR_UNITS = {
+  s: 1e3,
+  second: 1e3,
+  seconds: 1e3,
+  m: 6e4,
+  minute: 6e4,
+  minutes: 6e4,
+  h: 36e5,
+  hour: 36e5,
+  hours: 36e5,
+  d: DAY_MS,
+  day: DAY_MS,
+  days: DAY_MS,
+  w: 7 * DAY_MS,
+  week: 7 * DAY_MS,
+  weeks: 7 * DAY_MS,
+  M: 30 * DAY_MS,
+  month: 30 * DAY_MS,
+  months: 30 * DAY_MS,
+  y: 365 * DAY_MS,
+  year: 365 * DAY_MS,
+  years: 365 * DAY_MS
+};
+function GB_DUR(s) {
+  const m = String(s).trim().match(/^(\d+)\s*([A-Za-z]+)$/);
+  if (!m || !(m[2] in DUR_UNITS)) throw new Error("bad duration: " + s);
+  return Number(m[1]) * DUR_UNITS[m[2]];
+}
+var Link = class {
+  target;
+  display;
+  constructor(target, display) {
+    this.target = target;
+    this.display = display || target;
+  }
+  toString() {
+    return this.display;
+  }
+};
+function parseLinkish(v, asOf) {
+  if (typeof v === "string") {
+    const m = v.match(/^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/);
+    if (m) return new Link(m[1].trim(), m[2] && m[2].trim());
+    return v;
+  }
+  if (Array.isArray(v)) return v.map((x) => parseLinkish(x, asOf));
+  if (v instanceof Date) {
+    return new DuoDate(new Date(v.getTime() + v.getTimezoneOffset() * 6e4), asOf);
+  }
+  return v;
+}
+function gbEq(a, b) {
+  const name = (x) => x instanceof Link ? x.target : x && x.name ? x.name : x;
+  return name(a) === name(b);
+}
+function buildEngineFiles(notes, asOf) {
+  const files = notes.map((n) => {
+    const properties = {};
+    for (const [k, v] of Object.entries(n.frontmatter)) properties[k] = parseLinkish(v, asOf);
+    const f = {
+      name: n.basename,
+      basename: n.basename,
+      path: n.relPath,
+      folder: n.folder,
+      ext: n.ext,
+      mtime: new DuoDate(new Date(n.mtimeMs), asOf),
+      properties,
+      _rawLinks: n.links,
+      links: [],
+      backlinks: [],
+      hasTag: () => false,
+      hasLink(other) {
+        const t = other instanceof Link ? other.target : other?.name ?? other;
+        return this._rawLinks.includes(t);
+      },
+      inFolder(folder) {
+        return this.folder === folder || this.folder.startsWith(folder + "/");
+      },
+      hasProperty(name) {
+        return name in this.properties;
+      },
+      asFile() {
+        return this;
+      },
+      toString() {
+        return n.basename;
+      }
+    };
+    return f;
+  });
+  const byName = new Map(files.map((f) => [f.name, f]));
+  for (const f of files) {
+    f.links = f._rawLinks.map((n) => byName.get(n)).filter(Boolean);
+    for (const target of f.links) target.backlinks.push(f);
+  }
+  return files;
+}
+function wrapImplicitLambdas(src) {
+  for (const fn of ["filter", "map"]) {
+    let i;
+    while ((i = src.indexOf("." + fn + "(")) !== -1) {
+      const open = i + fn.length + 2;
+      let depth = 1;
+      let j = open;
+      while (j < src.length && depth > 0) {
+        if (src[j] === "(") depth++;
+        else if (src[j] === ")") depth--;
+        j++;
+      }
+      const inner = src.slice(open, j - 1);
+      src = src.slice(0, open) + "(value)=>(" + inner + ")" + src.slice(j - 1);
+      src = src.slice(0, i) + ".GB_" + fn + src.slice(i + 1 + fn.length);
+    }
+    src = src.replaceAll(".GB_" + fn, "." + fn);
+  }
+  return src;
+}
+function splitTopLevel(s) {
+  const parts = [];
+  let depth = 0;
+  let cur = "";
+  let quote = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      cur += c;
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      cur += c;
+      continue;
+    }
+    if (c === "(") depth++;
+    if (c === ")") depth--;
+    if (c === "," && depth === 0) {
+      parts.push(cur);
+      cur = "";
+      continue;
+    }
+    cur += c;
+  }
+  parts.push(cur);
+  return parts;
+}
+function transformIfs(src) {
+  const re = /(?<![\w.])if\s*\(/;
+  let m;
+  while (m = re.exec(src)) {
+    const open = m.index + m[0].length;
+    let depth = 1;
+    let j = open;
+    while (j < src.length && depth > 0) {
+      if (src[j] === "(") depth++;
+      else if (src[j] === ")") depth--;
+      j++;
+    }
+    const args = splitTopLevel(src.slice(open, j - 1));
+    const cond = args[0];
+    const a = args[1] ?? "null";
+    const b = args[2] ?? "null";
+    src = src.slice(0, m.index) + "((" + cond + ") ? (" + a + ") : (" + b + "))" + src.slice(j);
+  }
+  return src;
+}
+function transform(expr) {
+  let src = String(expr);
+  src = wrapImplicitLambdas(src);
+  src = transformIfs(src);
+  src = src.replace(/([\w.[\]"]+)\s*==\s*this\b/g, "gbEq($1, GB_THIS)");
+  src = src.replace(/([\w.[\]"]+)\s*!=\s*this\b/g, "!gbEq($1, GB_THIS)");
+  src = src.replace(/([-+])\s*"(\d+\s*[A-Za-z]+)"/g, (mm, op, dur) => {
+    try {
+      GB_DUR(dur);
+      return op + ' GB_DUR("' + dur + '")';
+    } catch {
+      return mm;
+    }
+  });
+  return src;
+}
+var ICONS = {
+  check: '<span style="color:#4a7d3e">\u2714</span>',
+  "octagon-x": '<span style="color:#b13e3a">\u26D4</span>',
+  "circle-dot": '<span style="color:#4a7d3e">\u25C9</span>',
+  "alarm-clock": '<span style="color:#b07527">\u23F0</span>',
+  activity: '<span style="color:#3C6E93">\u223F</span>'
+};
+var globalsReady = false;
+function ensureEngineGlobals() {
+  if (globalsReady) return;
+  globalsReady = true;
+  if (!("round" in Number.prototype)) {
+    Object.defineProperty(Number.prototype, "round", {
+      value: function(digits = 0) {
+        const f = 10 ** digits;
+        return Math.round(this * f) / f;
+      },
+      enumerable: false,
+      writable: true,
+      configurable: true
+    });
+  }
+}
+function isEvalError(v) {
+  return !!v && typeof v === "object" && "__error" in v;
+}
+function makeCtx(file, thisFile, formulas, asOf) {
+  const formulaCache = {};
+  const formulaProxy = new Proxy(
+    {},
+    {
+      has: () => true,
+      get: (_t, k) => {
+        if (typeof k !== "string") return void 0;
+        if (!(k in formulaCache)) {
+          formulaCache[k] = "__evaluating__";
+          formulaCache[k] = formulas[k] ? evalExpr(formulas[k], file, thisFile, formulas, asOf) : null;
+        }
+        return formulaCache[k];
+      }
+    }
+  );
+  const scope = {
+    file,
+    note: file.properties,
+    formula: formulaProxy,
+    GB_THIS: thisFile,
+    gbEq,
+    GB_DUR,
+    today: () => new DuoDate(midnight(asOf), asOf),
+    now: () => new DuoDate(new Date(asOf), asOf),
+    date: (s) => new DuoDate(new Date(s), asOf),
+    duration: GB_DUR,
+    icon: (n) => ({ __html: ICONS[n] || '<span title="' + n + '">\u25C7</span>' }),
+    html: (s) => ({ __html: String(s) }),
+    list: (x) => Array.isArray(x) ? x : [x],
+    min: Math.min,
+    max: Math.max,
+    number: Number,
+    link: (p, d) => new Link(p, d)
+  };
+  return new Proxy(scope, {
+    has: () => true,
+    get: (t, k) => {
+      if (typeof k !== "string") return void 0;
+      if (k in t) return t[k];
+      if (k in file.properties) return file.properties[k];
+      return null;
+    }
+  });
+}
+function midnight(d) {
+  const t = new Date(d);
+  t.setHours(0, 0, 0, 0);
+  return t;
+}
+function evalExpr(expr, file, thisFile, formulas, asOf) {
+  ensureEngineGlobals();
+  const src = transform(expr);
+  try {
+    const fn = new Function("ctx", "with (ctx) { return (" + src + "); }");
+    return fn(makeCtx(file, thisFile, formulas, asOf));
+  } catch (e) {
+    return { __error: e instanceof Error ? e.message : String(e), __expr: expr };
+  }
+}
+function passes(filterNode, file, thisFile, formulas, asOf) {
+  if (filterNode == null) return true;
+  if (typeof filterNode === "string") {
+    const r = evalExpr(filterNode, file, thisFile, formulas, asOf);
+    return Boolean(r) && !isEvalError(r);
+  }
+  const node = filterNode;
+  if (node.and) return node.and.every((n) => passes(n, file, thisFile, formulas, asOf));
+  if (node.or) return node.or.some((n) => passes(n, file, thisFile, formulas, asOf));
+  if (node.not) return !node.not.every((n) => passes(n, file, thisFile, formulas, asOf));
+  return true;
+}
+function defaultAsOf() {
+  return /* @__PURE__ */ new Date();
+}
+
+// core/vault/render.ts
+function readCol(prop, file, thisFile, formulas, asOf) {
+  if (prop.startsWith("formula.")) {
+    return evalExpr(formulas[prop.slice(8)] ?? "null", file, thisFile, formulas, asOf);
+  }
+  if (prop.startsWith("file.")) return file[prop.slice(5)];
+  const key = prop.startsWith("note.") ? prop.slice(5) : prop;
+  return file.properties[key] ?? null;
+}
+function evaluateBaseDef(def, files, thisFile, asOf) {
+  const formulas = def.formulas || {};
+  const propCfg = def.properties || {};
+  const views = [];
+  for (const view of def.views || []) {
+    const rows = files.filter(
+      (f) => passes(def.filters, f, thisFile, formulas, asOf) && passes(view.filters, f, thisFile, formulas, asOf)
+    );
+    views.push({
+      name: view.name || view.type,
+      type: view.type,
+      order: view.order || ["file.name"],
+      groupBy: view.groupBy,
+      summaries: view.summaries,
+      rows
+    });
+  }
+  return { formulas, propCfg, views };
+}
+var esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+function cell(v) {
+  if (v == null || v === "") return '<span class="empty">\u2014</span>';
+  if (isEvalError(v)) return '<span class="err" title="' + esc(v.__expr) + '">\u26A0 ' + esc(v.__error) + "</span>";
+  if (typeof v === "object" && v !== null && "__html" in v) return v.__html;
+  if (v instanceof Link) return '<span class="wikilink">' + esc(v.display) + "</span>";
+  if (v instanceof DuoDate) return esc(v.toString());
+  if (Array.isArray(v)) return v.map(cell).join(", ");
+  if (typeof v === "number") return String(v);
+  return esc(String(v));
+}
+function colLabel(prop, propCfg) {
+  if (propCfg && propCfg[prop] && propCfg[prop].displayName) return propCfg[prop].displayName;
+  return prop.replace(/^(note|file|formula)\./, "");
+}
+var SUMMARY_FNS = {
+  Earliest: (vals) => {
+    const ds = vals.filter((v) => v instanceof DuoDate);
+    return ds.length ? ds.reduce((a, b) => a.valueOf() < b.valueOf() ? a : b) : null;
+  },
+  Latest: (vals) => {
+    const ds = vals.filter((v) => v instanceof DuoDate);
+    return ds.length ? ds.reduce((a, b) => a.valueOf() > b.valueOf() ? a : b) : null;
+  },
+  Filled: (vals) => vals.filter((v) => v != null && v !== "").length,
+  Empty: (vals) => vals.filter((v) => v == null || v === "").length,
+  Sum: (vals) => vals.filter((v) => typeof v === "number").reduce((a, b) => a + b, 0),
+  Average: (vals) => {
+    const ns = vals.filter((v) => typeof v === "number");
+    return ns.length ? Math.round(ns.reduce((a, b) => a + b, 0) / ns.length * 100) / 100 : null;
+  },
+  Unique: (vals) => new Set(vals.map((v) => String(v))).size
+};
+function summaryInline(rows, view, formulas, thisFile, asOf) {
+  if (!view.summaries) return "";
+  const parts = [];
+  for (const [prop, fnName] of Object.entries(view.summaries)) {
+    const fn = SUMMARY_FNS[fnName];
+    if (!fn) {
+      parts.push(esc(fnName) + ": ?");
+      continue;
+    }
+    const vals = rows.map((f) => readCol(prop, f, thisFile, formulas, asOf));
+    parts.push(esc(colLabel(prop)) + " " + esc(fnName).toLowerCase() + ": " + cell(fn(vals)));
+  }
+  return ' <span class="summary">' + parts.join(" \xB7 ") + "</span>";
+}
+function renderTable(view, formulas, thisFile, propCfg, asOf) {
+  const order = view.order;
+  const head = "<tr>" + order.map((p) => "<th>" + esc(colLabel(p, propCfg)) + "</th>").join("") + "</tr>";
+  const groups = /* @__PURE__ */ new Map();
+  if (view.groupBy) {
+    for (const f of view.rows) {
+      const v = readCol(view.groupBy.property, f, thisFile, formulas, asOf);
+      const key = v == null ? "\u2014" : String(v instanceof Link ? v.display : v);
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(f);
+    }
+  } else {
+    groups.set(null, view.rows);
+  }
+  const keys = [...groups.keys()].sort((a, b) => String(a).localeCompare(String(b)));
+  if (view.groupBy && String(view.groupBy.direction).toUpperCase() === "DESC") keys.reverse();
+  let html = "<table>" + head;
+  for (const key of keys) {
+    const gRows = groups.get(key);
+    if (key !== null) {
+      html += '<tr class="group"><td colspan="' + order.length + '">' + esc(key) + ' <span class="count">(' + gRows.length + ")</span>" + summaryInline(gRows, view, formulas, thisFile, asOf) + "</td></tr>";
+    }
+    for (const f of gRows) {
+      html += "<tr>" + order.map((p) => "<td>" + cell(readCol(p, f, thisFile, formulas, asOf)) + "</td>").join("") + "</tr>";
+    }
+  }
+  if (!view.groupBy && view.summaries) {
+    html += '<tr class="group"><td colspan="' + order.length + '">' + summaryInline(view.rows, view, formulas, thisFile, asOf) + "</td></tr>";
+  }
+  return html + "</table>";
+}
+function renderList(view, formulas, thisFile, asOf) {
+  return '<ul class="baselist">' + view.rows.map((f) => "<li>" + view.order.map((p) => cell(readCol(p, f, thisFile, formulas, asOf))).join(" ") + "</li>").join("") + "</ul>";
+}
+function renderCards(view, formulas, thisFile, asOf) {
+  return '<div class="cards">' + view.rows.map((f) => {
+    const [title, ...rest] = view.order;
+    return '<div class="card"><div class="card-title">' + cell(readCol(title, f, thisFile, formulas, asOf)) + "</div>" + rest.map(
+      (p) => '<div class="card-row"><span class="card-k">' + esc(colLabel(p)) + "</span> " + cell(readCol(p, f, thisFile, formulas, asOf)) + "</div>"
+    ).join("") + "</div>";
+  }).join("") + "</div>";
+}
+function renderBaseSection(evaluated, thisFile, label, asOf) {
+  let html = '<section class="base"><h2>' + esc(label) + "</h2>";
+  for (const view of evaluated.views) {
+    html += "<h3>" + esc(view.name) + ' <span class="count">' + view.rows.length + " rows</span></h3>";
+    if (view.type === "list") html += renderList(view, evaluated.formulas, thisFile, asOf);
+    else if (view.type === "cards") html += renderCards(view, evaluated.formulas, thisFile, asOf);
+    else html += renderTable(view, evaluated.formulas, thisFile, evaluated.propCfg, asOf);
+  }
+  return html + "</section>";
+}
+function sourceHash(root) {
+  const all = [];
+  const stack = [root];
+  const SKIP = /* @__PURE__ */ new Set([".obsidian", ".trash", "out", ".git", "node_modules"]);
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = import_node_fs6.default.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = import_node_path6.default.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (!SKIP.has(e.name)) stack.push(full);
+      } else if (e.name.endsWith(".md") || e.name.endsWith(".base")) {
+        try {
+          all.push(import_node_fs6.default.readFileSync(full, "utf8"));
+        } catch {
+        }
+      }
+    }
+  }
+  return import_node_crypto.default.createHash("sha256").update(all.sort().join(" ")).digest("hex").slice(0, 12);
+}
+function embeddedBaseDefs(note) {
+  const out2 = [];
+  for (const m of note.body.matchAll(/```base\n([\s\S]*?)```/g)) {
+    try {
+      const def = load(m[1]);
+      if (def && typeof def === "object") out2.push(def);
+    } catch {
+    }
+  }
+  return out2;
+}
+function renderTarget(root, target, opts = {}) {
+  const asOf = opts.asOf ?? defaultAsOf();
+  const notes = readNotes(root);
+  const files = buildEngineFiles(notes, asOf);
+  const byName = new Map(files.map((f) => [f.name, f]));
+  const bases = [];
+  const sections = [];
+  const abs = import_node_path6.default.isAbsolute(target) ? target : import_node_path6.default.resolve(root, target);
+  if (target.endsWith(".base")) {
+    const def = load(import_node_fs6.default.readFileSync(abs, "utf8"));
+    const label = import_node_path6.default.relative(root, abs).split(import_node_path6.default.sep).join("/");
+    const evaluated = evaluateBaseDef(def, files, null, asOf);
+    bases.push({ label, evaluated, thisFile: null });
+    sections.push(renderBaseSection(evaluated, null, label, asOf));
+  } else {
+    let note;
+    if (import_node_fs6.default.existsSync(abs) && abs.endsWith(".md")) note = parseFile(abs, root);
+    else note = notes.find((n) => n.basename === target.replace(/\.md$/, ""));
+    if (!note) throw new Error(`render target not found: ${target} (expected a .base file or a note path/name)`);
+    const thisFile = byName.get(note.basename) ?? null;
+    const defs = embeddedBaseDefs(note);
+    if (!defs.length) {
+      throw new Error(`no \`\`\`base blocks found in ${note.relPath} (nothing to render)`);
+    }
+    defs.forEach((def, i) => {
+      const label = `${note.relPath}${defs.length > 1 ? ` [block ${i + 1}]` : ""}  (this = ${note.basename})`;
+      const evaluated = evaluateBaseDef(def, files, thisFile, asOf);
+      bases.push({ label, evaluated, thisFile: note.basename });
+      sections.push(renderBaseSection(evaluated, thisFile, label, asOf));
+    });
+  }
+  const hash = sourceHash(root);
+  const generatedAt = (/* @__PURE__ */ new Date()).toISOString();
+  const asOfLabel = new DuoDate(asOf, asOf).format("YYYY-MMM-DD");
+  const html = assemblePage(sections, {
+    sourceHash: hash,
+    generatedAt,
+    asOfLabel,
+    noteCount: notes.length,
+    baseCount: bases.length,
+    target
+  });
+  return { html, bases, sourceHash: hash, generatedAt, asOfLabel };
+}
+function assemblePage(sections, meta) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Vault rollup \u2014 ${esc(meta.target)}</title>
+<style>
+:root { --paper:#fbf8f1; --paper-deep:#f3ede0; --paper-rule:#d9cea8; --ink:#2b2620;
+  --ink-soft:#4a4238; --ink-mute:#6f6557; --ink-ghost:#9a9080; --accent:#c46a1c;
+  --pass:#4a7d3e; --fail:#b13e3a; --harbor:#3C6E93; }
+* { box-sizing:border-box; }
+body { margin:0 auto; padding:32px 40px 64px; max-width:960px; background:var(--paper);
+  color:var(--ink); font:14px/1.55 -apple-system,"SF Pro Text",system-ui,sans-serif; }
+h1 { font-family:"New York","Iowan Old Style",Georgia,serif; font-style:italic; font-weight:500; font-size:22px; margin:0 0 4px; }
+.stamp { background:var(--paper-deep); border:1px solid var(--paper-rule); border-radius:6px;
+  padding:10px 14px; margin:14px 0 28px; font-size:12px; color:var(--ink-mute);
+  font-family:ui-monospace,"SF Mono",Menlo,monospace; }
+.stamp strong { color:var(--accent); }
+h2 { font-family:"New York",Georgia,serif; font-weight:600; font-size:18px;
+  border-bottom:1px solid var(--paper-rule); padding-bottom:6px; margin:34px 0 8px; }
+h3 { font-size:14px; margin:18px 0 6px; }
+.count { font-weight:400; font-size:11.5px; color:var(--ink-ghost); }
+table { border-collapse:collapse; width:100%; font-size:12.5px; margin:6px 0 14px; }
+th,td { border-bottom:1px solid var(--paper-rule); padding:6px 8px; text-align:left; vertical-align:top; }
+th { font-size:11px; text-transform:uppercase; letter-spacing:.03em; color:var(--ink-mute); }
+tr.group td { background:var(--paper-deep); font-weight:600; font-size:12px; }
+.summary { font-weight:400; color:var(--ink-mute); font-size:11.5px; }
+.wikilink { color:var(--harbor); border-bottom:1px dotted var(--harbor); }
+.empty { color:var(--ink-ghost); }
+.err { color:var(--fail); font-size:11px; }
+.baselist { margin:6px 0 14px; }
+.cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:10px; margin:6px 0 14px; }
+.card { background:white; border:1px solid var(--paper-rule); border-radius:6px; padding:10px 12px; }
+.card-title { font-weight:600; margin-bottom:6px; }
+.card-row { font-size:12px; color:var(--ink-soft); }
+.card-k { color:var(--ink-ghost); font-size:10.5px; text-transform:uppercase; letter-spacing:.03em; margin-right:4px; }
+footer { margin-top:40px; border-top:1px solid var(--paper-rule); padding-top:12px;
+  font-size:11.5px; color:var(--ink-mute); }
+</style>
+</head>
+<body>
+<h1>Vault rollup \u2014 ${esc(meta.target)}</h1>
+<div class="stamp"><strong>BUILD ARTIFACT</strong> \u2014 regenerate: duo base render ${esc(meta.target)} \xB7
+generated ${esc(meta.generatedAt)} \xB7 source hash <strong>${esc(meta.sourceHash)}</strong> \xB7
+date-relative formulas as of ${esc(meta.asOfLabel)} \xB7
+${meta.noteCount} notes, ${meta.baseCount} rendered base(s)</div>
+${sections.join("\n")}
+<footer>Duo-owned rollup render (ENH-208). Implements the locked Bases
+expression subset (filters and/or/not, link equality vs <code>this</code>,
+date math, if(), html(), icon(), backlink chains, groupBy, summaries).
+file.name is extension-less; child\u2192parent backlink rollups always resolve
+here. Re-render to refresh; the source hash above detects staleness.</footer>
+</body>
+</html>
+`;
+}
+
+// core/vault/lint.ts
+var import_node_fs7 = __toESM(require("node:fs"));
+var import_node_path7 = __toESM(require("node:path"));
+function lev(a, b) {
+  const m = a.length;
+  const n = b.length;
+  const d = Array.from({ length: m + 1 }, (_, i) => [i, ...Array(n).fill(0)]);
+  for (let j = 0; j <= n; j++) d[0][j] = j;
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      d[i][j] = Math.min(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1));
+  return d[m][n];
+}
+function suggest(word, candidates) {
+  let best = null;
+  let bestD = Infinity;
+  for (const c of candidates) {
+    const dd = lev(word.toLowerCase(), c.toLowerCase());
+    if (dd < bestD) {
+      bestD = dd;
+      best = c;
+    }
+  }
+  return best && bestD <= Math.max(2, Math.ceil(word.length / 3)) ? best : null;
+}
+var FUNCS = /* @__PURE__ */ new Set([
+  "file.hasTag",
+  "file.hasLink",
+  "file.inFolder",
+  "file.hasProperty",
+  "file.asLink",
+  "today",
+  "now",
+  "date",
+  "duration",
+  "if",
+  "icon",
+  "html",
+  "list",
+  "min",
+  "max",
+  "number",
+  "link",
+  "random",
+  "escapeHTML"
+]);
+var METHODS = /* @__PURE__ */ new Set([
+  "relative",
+  "format",
+  "date",
+  "time",
+  "isEmpty",
+  "round",
+  "toFixed",
+  "abs",
+  "ceil",
+  "floor",
+  "contains",
+  "containsAll",
+  "containsAny",
+  "startsWith",
+  "endsWith",
+  "lower",
+  "title",
+  "trim",
+  "replace",
+  "split",
+  "join",
+  "reverse",
+  "slice",
+  "sort",
+  "unique",
+  "filter",
+  "map",
+  "reduce",
+  "flat",
+  "length",
+  "asFile",
+  "linksTo",
+  "keys",
+  "values",
+  "toString",
+  "matches",
+  "mean"
+]);
+var VIEW_TYPES = ["table", "cards", "list", "map"];
+function collectExprs(node, out2) {
+  if (node == null) return;
+  if (typeof node === "string") {
+    out2.push(node);
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((n) => collectExprs(n, out2));
+    return;
+  }
+  if (typeof node === "object") {
+    const obj = node;
+    for (const v of ["and", "or", "not"]) if (obj[v]) collectExprs(obj[v], out2);
+  }
+}
+function lintBaseDef(def, corpus) {
+  const findings = [];
+  const add = (severity, message, suggestion) => findings.push(suggestion ? { severity, message, suggestion } : { severity, message });
+  const exprs = [];
+  collectExprs(def.filters, exprs);
+  for (const v of def.views || []) collectExprs(v.filters, exprs);
+  for (const f of Object.values(def.formulas || {})) exprs.push(String(f));
+  const knownEntities = /* @__PURE__ */ new Set([...corpus.entities.map((e) => e.name), ...Object.keys(corpus.aliases)]);
+  for (const e of exprs) {
+    for (const m of e.matchAll(/\btype\s*[=!]=\s*"([^"]+)"/g)) {
+      if (!corpus.types.includes(m[1])) {
+        const s = suggest(m[1], corpus.types);
+        add("error", `type == "${m[1]}" \u2014 no such type${s ? ` (did you mean "${s}"?)` : ""}. Known: ${corpus.types.join(", ")}`, s ?? void 0);
+      }
+    }
+    for (const m of e.matchAll(/\[\[([^\]|#]+)/g)) {
+      const name = m[1].trim();
+      if (!knownEntities.has(name)) {
+        const s = suggest(name, [...knownEntities]);
+        add("error", `[[${name}]] \u2014 unresolved entity${s ? ` (did you mean "${s}"?)` : ""}`, s ?? void 0);
+      }
+    }
+    for (const m of e.matchAll(/\b(?:note\.)?(\w+)\s*==\s*"([^"]+)"/g)) {
+      const [, prop, val] = m;
+      if (prop === "type") continue;
+      for (const [key, vals] of Object.entries(corpus.enumsByType)) {
+        if (key.endsWith("." + prop) && !vals.includes(val)) {
+          const s = suggest(val, vals);
+          if (s)
+            add("warn", `${prop} == "${val}" \u2014 no ${key.split(".")[0]} has this value (observed: ${vals.join(", ")}; did you mean "${s}"?)`, s);
+        }
+      }
+    }
+    for (const m of e.matchAll(/\b([a-z]\w*(?:\.\w+)?)\s*\(/gi)) {
+      const fn = m[1];
+      if (FUNCS.has(fn)) continue;
+      const tail = fn.includes(".") ? fn.split(".").pop() : fn;
+      if (METHODS.has(tail)) continue;
+      if (fn.includes(".")) continue;
+      const s = suggest(fn, [...FUNCS]);
+      add("warn", `${fn}(\u2026) \u2014 unknown function${s ? ` (did you mean "${s}"?)` : ""}`, s ?? void 0);
+    }
+  }
+  for (const v of def.views || []) {
+    if (v.type && !VIEW_TYPES.includes(v.type)) add("error", `view "${v.name || v.type}" \u2014 unknown view type "${v.type}"`);
+  }
+  return findings;
+}
+function lintVault(root, target) {
+  const corpus = buildCorpus(root);
+  const results = [];
+  const lintBaseFile = (abs) => {
+    const rel = import_node_path7.default.relative(root, abs).split(import_node_path7.default.sep).join("/");
+    let def;
+    try {
+      def = load(import_node_fs7.default.readFileSync(abs, "utf8"));
+    } catch (e) {
+      results.push({ source: rel, findings: [], parseError: e instanceof Error ? e.message : String(e) });
+      return;
+    }
+    results.push({ source: rel, findings: lintBaseDef(def || {}, corpus) });
+  };
+  const lintNoteEmbeds = (relPath, basename2, body) => {
+    let i = 0;
+    for (const m of body.matchAll(/```base\n([\s\S]*?)```/g)) {
+      i++;
+      let def;
+      try {
+        def = load(m[1]);
+      } catch (e) {
+        results.push({ source: relPath, embeddedIn: basename2, findings: [], parseError: e instanceof Error ? e.message : String(e) });
+        continue;
+      }
+      results.push({ source: `${relPath}${i > 1 ? ` [block ${i}]` : ""}`, embeddedIn: basename2, findings: lintBaseDef(def || {}, corpus) });
+    }
+  };
+  if (target === "--all") {
+    for (const abs of walk(root).filter((p) => p.endsWith(".base")).sort()) lintBaseFile(abs);
+    for (const note of readNotes(root)) lintNoteEmbeds(note.relPath, note.basename, note.body);
+  } else {
+    const abs = import_node_path7.default.isAbsolute(target) ? target : import_node_path7.default.resolve(root, target);
+    if (target.endsWith(".base")) {
+      lintBaseFile(abs);
+    } else {
+      const notes = readNotes(root);
+      const note = import_node_fs7.default.existsSync(abs) && abs.endsWith(".md") ? notes.find((n) => n.absPath === abs) : notes.find((n) => n.basename === target.replace(/\.md$/, ""));
+      if (!note) throw new Error(`lint target not found: ${target} (expected --all, a .base file, or a note path/name)`);
+      lintNoteEmbeds(note.relPath, note.basename, note.body);
+    }
+  }
+  return results;
 }
 
 // cli/duo.ts
@@ -3351,10 +4124,16 @@ var VERBS = [
     group: "Vault",
     args: "<backlinks <note>|orphans> [--vault p]",
     summary: "Vault graph queries (wikilinks resolve by basename, so they survive file moves). backlinks <note>: every note linking to <note>, with file + line (JSON). orphans: notes with no inbound and no outbound links \u2014 a processing work-list (JSON)."
+  },
+  {
+    name: "base",
+    group: "Vault",
+    args: "<lint <file|--all>|render <file|note>> [--out p] [--open] [--vault p]",
+    summary: "Obsidian Bases rollups. lint <file|--all> [--vault p]: validate a .base file (or a note's embedded ```base blocks, or every base with --all) against the live corpus \u2014 bad types / unresolved [[entities]] / off-enum values / unknown functions, each with a \"did you mean\" (JSON; warn-and-render, never blocks). render <file|note> [--out p] [--open]: evaluate filters/formulas over live frontmatter and emit a stamped Duo-owned HTML artifact (generated-at \xB7 source-hash \xB7 as-of). Default writes to the vault's out/; --out writes elsewhere; --open also opens it as a tab in the running app."
   }
 ];
-var SOCKET_PATH = process.env.DUO_SOCKET ?? path6.join(os.homedir(), "Library", "Application Support", "duo", "duo.sock");
-var PORT_FILE = process.env.DUO_PORT_FILE ?? path6.join(os.homedir(), "Library", "Application Support", "duo", "duo.port");
+var SOCKET_PATH = process.env.DUO_SOCKET ?? path8.join(os.homedir(), "Library", "Application Support", "duo", "duo.sock");
+var PORT_FILE = process.env.DUO_PORT_FILE ?? path8.join(os.homedir(), "Library", "Application Support", "duo", "duo.port");
 var windowOverride;
 function resolveWindowId() {
   if (windowOverride != null) return windowOverride;
@@ -3371,7 +4150,7 @@ var PER_CMD_TIMEOUT_MS = {
 };
 function readPortFile() {
   try {
-    const raw = fs6.readFileSync(PORT_FILE, "utf8");
+    const raw = fs8.readFileSync(PORT_FILE, "utf8");
     const parsed = JSON.parse(raw);
     if (typeof parsed.port === "number" && typeof parsed.token === "string") {
       return { port: parsed.port, token: parsed.token };
@@ -3437,7 +4216,7 @@ var FALLBACK_CONNECT_CODES = /* @__PURE__ */ new Set([
 ]);
 async function send(cmd, args = {}, opts = {}) {
   const timeoutMs = opts.timeoutMs ?? PER_CMD_TIMEOUT_MS[cmd] ?? TIMEOUT_MS;
-  if (process.env.DUO_TCP_ONLY !== "1" && fs6.existsSync(SOCKET_PATH)) {
+  if (process.env.DUO_TCP_ONLY !== "1" && fs8.existsSync(SOCKET_PATH)) {
     try {
       return await sendOver(
         () => ({ socket: net.createConnection(SOCKET_PATH) }),
@@ -3452,7 +4231,7 @@ async function send(cmd, args = {}, opts = {}) {
   }
   const portInfo = readPortFile();
   if (!portInfo) {
-    if (!fs6.existsSync(SOCKET_PATH)) {
+    if (!fs8.existsSync(SOCKET_PATH)) {
       die("Cannot connect: Duo app is not running.\nLaunch Duo.app first.");
     }
     die("Cannot connect: Unix socket failed and no TCP fallback available.\nRun `duo doctor` for details.");
@@ -3469,7 +4248,7 @@ async function send(cmd, args = {}, opts = {}) {
 }
 function sendStreamed(cmd, args, onAck, onEvent) {
   const factory = () => {
-    if (process.env.DUO_TCP_ONLY !== "1" && fs6.existsSync(SOCKET_PATH)) {
+    if (process.env.DUO_TCP_ONLY !== "1" && fs8.existsSync(SOCKET_PATH)) {
       return { socket: net.createConnection(SOCKET_PATH) };
     }
     const portInfo = readPortFile();
@@ -3555,6 +4334,19 @@ function die(msg, code = 1) {
 function flagValue(args, name) {
   const i = args.indexOf(name);
   return i !== -1 ? args[i + 1] : void 0;
+}
+function positionalArgs(args, valueFlags = []) {
+  const out2 = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (valueFlags.includes(a)) {
+      i++;
+      continue;
+    }
+    if (a.startsWith("--")) continue;
+    out2.push(a);
+  }
+  return out2;
 }
 function translateNavKeysForMac(key, modifiers) {
   if (process.platform !== "darwin") return { key, modifiers };
@@ -3760,8 +4552,8 @@ async function main() {
         const selector = selectorIdx !== -1 ? rest[selectorIdx + 1] : void 0;
         const b64 = await send("screenshot", { selector });
         if (outputPath) {
-          const abs = path6.resolve(outputPath);
-          fs6.writeFileSync(abs, Buffer.from(b64, "base64"));
+          const abs = path8.resolve(outputPath);
+          fs8.writeFileSync(abs, Buffer.from(b64, "base64"));
           out(`Saved to ${abs}`);
         } else {
           out(b64);
@@ -3976,7 +4768,7 @@ To confirm, re-run:
         if (sub === "open") {
           const p = rest[1];
           if (!p) die("Usage: duo split-view open <path>");
-          const resolved = path6.isAbsolute(p) ? p : path6.resolve(process.cwd(), p);
+          const resolved = path8.isAbsolute(p) ? p : path8.resolve(process.cwd(), p);
           out(await send("split-view", { op: "open", path: resolved }));
           break;
         }
@@ -4116,9 +4908,9 @@ To confirm, re-run:
           if (caseSensitive) payload["case-sensitive"] = true;
           out(await send("doc-find", payload));
         } else if (sub === "conflict-log") {
-          const logPath = path6.join(os.homedir(), ".claude", "duo", "logs", "last-conflict.log");
+          const logPath = path8.join(os.homedir(), ".claude", "duo", "logs", "last-conflict.log");
           try {
-            const raw = fs6.readFileSync(logPath, "utf8");
+            const raw = fs8.readFileSync(logPath, "utf8");
             process.stdout.write(raw);
             if (!raw.endsWith("\n")) process.stdout.write("\n");
           } catch (err) {
@@ -4519,7 +5311,7 @@ To confirm, re-run:
           const resolvedPatch = resolveFilePath(patchPath);
           let mergeJson;
           try {
-            mergeJson = fs6.readFileSync(resolvedPatch, "utf8");
+            mergeJson = fs8.readFileSync(resolvedPatch, "utf8");
           } catch (err) {
             die(`Could not read patch file ${resolvedPatch}: ${err?.message ?? err}`);
           }
@@ -4608,18 +5400,18 @@ To confirm, re-run:
         }
         if (sub === "save") {
           const subRest = rest.slice(1);
-          const path7 = subRest.find((a) => !a.startsWith("-"));
+          const path9 = subRest.find((a) => !a.startsWith("-"));
           const name = flagValue(subRest, "--name");
           const saveAs = subRest.includes("--save-as");
           const payload = { op: "save" };
-          if (path7) payload.path = path7;
+          if (path9) payload.path = path9;
           if (name) payload.name = name;
           if (saveAs) payload["save-as"] = true;
           out(await send("workspace", payload));
         } else if (sub === "open") {
-          const path7 = rest[1];
-          if (!path7) die("Usage: duo workspace open <path>");
-          out(await send("workspace", { op: "open", path: path7 }));
+          const path9 = rest[1];
+          if (!path9) die("Usage: duo workspace open <path>");
+          out(await send("workspace", { op: "open", path: path9 }));
         } else if (sub === "list-recent") {
           out(await send("workspace", { op: "list-recent" }));
         } else if (sub === "current") {
@@ -4691,7 +5483,7 @@ To confirm, re-run:
         } else if (sub === "schema") {
           out(buildCorpus(resolveVault(process.cwd(), vaultFlag)));
         } else if (sub === "search") {
-          const query = subRest.find((a) => !a.startsWith("--"));
+          const query = positionalArgs(subRest, ["--vault"])[0];
           if (!query) die("Usage: duo vault search <query> [--vault <path>]");
           out(search(resolveVault(process.cwd(), vaultFlag), query));
         } else {
@@ -4706,13 +5498,60 @@ To confirm, re-run:
         const subRest = rest.slice(1);
         const vaultFlag = flagValue(subRest, "--vault");
         if (sub === "backlinks") {
-          const note = subRest.find((a) => !a.startsWith("--"));
+          const note = positionalArgs(subRest, ["--vault"])[0];
           if (!note) die("Usage: duo graph backlinks <note> [--vault <path>]");
           out(backlinks(resolveVault(process.cwd(), vaultFlag), note));
         } else if (sub === "orphans") {
           out(orphans(resolveVault(process.cwd(), vaultFlag)));
         } else {
           die("Usage: duo graph <backlinks <note>|orphans> [--vault <path>]");
+        }
+        break;
+      }
+      case "base": {
+        const sub = rest[0];
+        const subRest = rest.slice(1);
+        const vaultFlag = flagValue(subRest, "--vault");
+        if (sub === "lint") {
+          const target = positionalArgs(subRest, ["--vault"])[0] ?? (subRest.includes("--all") ? "--all" : void 0);
+          if (!target) die("Usage: duo base lint <file|--all> [--vault <path>]");
+          const root = resolveVault(process.cwd(), vaultFlag);
+          out(lintVault(root, target));
+        } else if (sub === "render") {
+          const target = positionalArgs(subRest, ["--vault", "--out"])[0];
+          if (!target) die("Usage: duo base render <file|note> [--out <path>] [--open] [--vault <path>]");
+          const root = resolveVault(process.cwd(), vaultFlag);
+          const result = renderTarget(root, target);
+          const outFlag = flagValue(subRest, "--out");
+          const open = subRest.includes("--open");
+          const stem = path8.basename(target).replace(/\.(base|md)$/i, "") || "rollup";
+          let outPath;
+          if (outFlag) outPath = path8.resolve(process.cwd(), outFlag);
+          else if (open) outPath = path8.join(os.tmpdir(), `duo-rollup-${stem}-${Date.now()}.html`);
+          else outPath = path8.join(root, "out", `${stem}.html`);
+          fs8.mkdirSync(path8.dirname(outPath), { recursive: true });
+          fs8.writeFileSync(outPath, result.html);
+          let opened = null;
+          if (open) {
+            try {
+              opened = await send("open", { path: outPath });
+            } catch (e) {
+              opened = { error: e instanceof Error ? e.message : String(e) };
+            }
+          }
+          out({
+            path: outPath,
+            sourceHash: result.sourceHash,
+            generatedAt: result.generatedAt,
+            asOf: result.asOfLabel,
+            bases: result.bases.map((b) => ({
+              label: b.label,
+              views: b.evaluated.views.map((v) => ({ name: v.name, type: v.type, rows: v.rows.length }))
+            })),
+            ...open ? { opened } : {}
+          });
+        } else {
+          die("Usage: duo base <lint <file|--all>|render <file|note>> [--out <path>] [--open] [--vault <path>]");
         }
         break;
       }
@@ -4738,41 +5577,41 @@ function readStdin() {
 }
 function resolveFilePath(input) {
   if (input.startsWith("~/") || input === "~") {
-    return path6.resolve(input.replace(/^~/, os.homedir()));
+    return path8.resolve(input.replace(/^~/, os.homedir()));
   }
-  if (path6.isAbsolute(input)) return input;
-  return path6.resolve(process.cwd(), input);
+  if (path8.isAbsolute(input)) return input;
+  return path8.resolve(process.cwd(), input);
 }
 function resolveOpenTarget(target) {
   if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return target;
   let absolute;
   if (target.startsWith("~/") || target === "~") {
-    absolute = path6.resolve(target.replace(/^~/, os.homedir()));
+    absolute = path8.resolve(target.replace(/^~/, os.homedir()));
   } else {
-    absolute = path6.resolve(process.cwd(), target);
+    absolute = path8.resolve(process.cwd(), target);
   }
   const encoded = absolute.split("/").map((seg) => encodeURIComponent(seg).replace(/%2F/g, "/")).join("/");
   return "file://" + encoded;
 }
 function runInstall(opts = {}) {
-  const self = fs6.realpathSync(process.argv[1]);
+  const self = fs8.realpathSync(process.argv[1]);
   const targets = [];
   if (opts.system) {
     targets.push("/usr/local/bin/duo");
   } else {
-    targets.push(path6.join(os.homedir(), ".claude", "duo", "bin", "duo"));
-    targets.push(path6.join(os.homedir(), ".local", "bin", "duo"));
+    targets.push(path8.join(os.homedir(), ".claude", "duo", "bin", "duo"));
+    targets.push(path8.join(os.homedir(), ".local", "bin", "duo"));
   }
   for (const target of targets) {
     try {
-      fs6.mkdirSync(path6.dirname(target), { recursive: true });
+      fs8.mkdirSync(path8.dirname(target), { recursive: true });
       try {
-        fs6.unlinkSync(target);
+        fs8.unlinkSync(target);
       } catch {
       }
-      fs6.symlinkSync(self, target);
+      fs8.symlinkSync(self, target);
       out(`Installed: ${target} \u2192 ${self}`);
-      const dir = path6.dirname(target);
+      const dir = path8.dirname(target);
       const userPath = (process.env.PATH ?? "").split(":");
       if (!userPath.includes(dir)) {
         out("");
@@ -4798,7 +5637,7 @@ async function runDoctor() {
   let unixErr = null;
   let appVersion = null;
   let windowCount = null;
-  if (fs6.existsSync(SOCKET_PATH)) {
+  if (fs8.existsSync(SOCKET_PATH)) {
     try {
       const res = await probe(() => ({ socket: net.createConnection(SOCKET_PATH) }));
       unixOk = true;
@@ -4865,25 +5704,25 @@ async function runDoctor() {
   const cliPath = process.argv[1];
   let cliReal = null;
   try {
-    cliReal = fs6.realpathSync(cliPath);
+    cliReal = fs8.realpathSync(cliPath);
   } catch {
   }
   lines.push(`  CLI invoked as: ${cliPath}${cliReal && cliReal !== cliPath ? ` \u2192 ${cliReal}` : ""}`);
   const knownInstallTargets = [
     // ENH-141 — SHIM_DIR (auto-prepended to PTY $PATH; primary target).
-    path6.join(os.homedir(), ".claude", "duo", "bin", "duo"),
+    path8.join(os.homedir(), ".claude", "duo", "bin", "duo"),
     // Pre-ENH-141 sandbox-writable target (still listed for diagnosing
     // stale installs — the dir was never on PATH so the symlink was
     // effectively dead).
-    path6.join(os.homedir(), ".claude", "bin", "duo"),
-    path6.join(os.homedir(), ".local", "bin", "duo"),
+    path8.join(os.homedir(), ".claude", "bin", "duo"),
+    path8.join(os.homedir(), ".local", "bin", "duo"),
     "/usr/local/bin/duo"
   ];
   for (const t of knownInstallTargets) {
-    if (!fs6.existsSync(t)) continue;
+    if (!fs8.existsSync(t)) continue;
     let real = null;
     try {
-      real = fs6.realpathSync(t);
+      real = fs8.realpathSync(t);
     } catch {
     }
     const matches = real && cliReal && real === cliReal;
@@ -4891,10 +5730,10 @@ async function runDoctor() {
   }
   lines.push("");
   lines.push("Skill");
-  const skillFile = path6.join(os.homedir(), ".claude", "skills", "duo", "SKILL.md");
-  const agentFile = path6.join(os.homedir(), ".claude", "agents", "duo.md");
-  lines.push(`  ${fs6.existsSync(skillFile) ? "\u2713" : "\u2717"} ${skillFile}`);
-  lines.push(`  ${fs6.existsSync(agentFile) ? "\u2713" : "\u2717"} ${agentFile}`);
+  const skillFile = path8.join(os.homedir(), ".claude", "skills", "duo", "SKILL.md");
+  const agentFile = path8.join(os.homedir(), ".claude", "agents", "duo.md");
+  lines.push(`  ${fs8.existsSync(skillFile) ? "\u2713" : "\u2717"} ${skillFile}`);
+  lines.push(`  ${fs8.existsSync(agentFile) ? "\u2713" : "\u2717"} ${agentFile}`);
   lines.push("");
   lines.push("Locale");
   const localeVars = ["LC_ALL", "LC_CTYPE", "LANG"];

--- a/cli/duo
+++ b/cli/duo
@@ -5534,9 +5534,13 @@ To confirm, re-run:
           let opened = null;
           if (open) {
             try {
-              opened = await send("open", { path: outPath });
+              opened = await send("open", { url: resolveOpenTarget(outPath), mode: "browser", reveal: true });
             } catch (e) {
               opened = { error: e instanceof Error ? e.message : String(e) };
+            }
+            if (opened && typeof opened === "object" && "error" in opened) {
+              process.stderr.write(`duo: base render wrote ${outPath} but --open failed: ${opened.error}
+`);
             }
           }
           out({

--- a/cli/duo.ts
+++ b/cli/duo.ts
@@ -500,6 +500,13 @@ const VERBS: VerbSpec[] = [
     args: '<backlinks <note>|orphans> [--vault p]',
     summary:
       'Vault graph queries (wikilinks resolve by basename, so they survive file moves). backlinks <note>: every note linking to <note>, with file + line (JSON). orphans: notes with no inbound and no outbound links — a processing work-list (JSON).'
+  },
+  {
+    name: 'base',
+    group: 'Vault',
+    args: '<lint <file|--all>|render <file|note>> [--out p] [--open] [--vault p]',
+    summary:
+      'Obsidian Bases rollups. lint <file|--all> [--vault p]: validate a .base file (or a note\'s embedded ```base blocks, or every base with --all) against the live corpus — bad types / unresolved [[entities]] / off-enum values / unknown functions, each with a "did you mean" (JSON; warn-and-render, never blocks). render <file|note> [--out p] [--open]: evaluate filters/formulas over live frontmatter and emit a stamped Duo-owned HTML artifact (generated-at · source-hash · as-of). Default writes to the vault\'s out/; --out writes elsewhere; --open also opens it as a tab in the running app.'
   }
 ]
 
@@ -798,6 +805,27 @@ function die(msg: string, code = 1): never {
 function flagValue(args: string[], name: string): string | undefined {
   const i = args.indexOf(name)
   return i !== -1 ? args[i + 1] : undefined
+}
+
+/**
+ * Positional args with value-taking flags (and their values) and bare
+ * flags removed. Without this, a `--vault <path>` *value* looks like a
+ * positional to `args.find(a => !a.startsWith('--'))` — so
+ * `duo base lint --all --vault X` would mis-read X as the lint target.
+ * `valueFlags` are flags that consume the following token.
+ */
+function positionalArgs(args: string[], valueFlags: string[] = []): string[] {
+  const out: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (valueFlags.includes(a)) {
+      i++ // skip the flag's value too
+      continue
+    }
+    if (a.startsWith('--')) continue
+    out.push(a)
+  }
+  return out
 }
 
 /**
@@ -2317,7 +2345,7 @@ async function main(): Promise<void> {
         } else if (sub === 'schema') {
           out(vault.buildCorpus(vault.resolveVault(process.cwd(), vaultFlag)))
         } else if (sub === 'search') {
-          const query = subRest.find((a) => !a.startsWith('--'))
+          const query = positionalArgs(subRest, ['--vault'])[0]
           if (!query) die('Usage: duo vault search <query> [--vault <path>]')
           out(vault.search(vault.resolveVault(process.cwd(), vaultFlag), query))
         } else {
@@ -2335,13 +2363,63 @@ async function main(): Promise<void> {
         const subRest = rest.slice(1)
         const vaultFlag = flagValue(subRest, '--vault')
         if (sub === 'backlinks') {
-          const note = subRest.find((a) => !a.startsWith('--'))
+          const note = positionalArgs(subRest, ['--vault'])[0]
           if (!note) die('Usage: duo graph backlinks <note> [--vault <path>]')
           out(vault.backlinks(vault.resolveVault(process.cwd(), vaultFlag), note))
         } else if (sub === 'orphans') {
           out(vault.orphans(vault.resolveVault(process.cwd(), vaultFlag)))
         } else {
           die('Usage: duo graph <backlinks <note>|orphans> [--vault <path>]')
+        }
+        break
+      }
+      case 'base': {
+        const sub = rest[0]
+        const subRest = rest.slice(1)
+        const vaultFlag = flagValue(subRest, '--vault')
+        if (sub === 'lint') {
+          const target = positionalArgs(subRest, ['--vault'])[0] ?? (subRest.includes('--all') ? '--all' : undefined)
+          if (!target) die('Usage: duo base lint <file|--all> [--vault <path>]')
+          const root = vault.resolveVault(process.cwd(), vaultFlag)
+          out(vault.lintVault(root, target))
+        } else if (sub === 'render') {
+          const target = positionalArgs(subRest, ['--vault', '--out'])[0]
+          if (!target) die('Usage: duo base render <file|note> [--out <path>] [--open] [--vault <path>]')
+          const root = vault.resolveVault(process.cwd(), vaultFlag)
+          const result = vault.renderTarget(root, target)
+          const outFlag = flagValue(subRest, '--out')
+          const open = subRest.includes('--open')
+          const stem = path.basename(target).replace(/\.(base|md)$/i, '') || 'rollup'
+          let outPath: string
+          if (outFlag) outPath = path.resolve(process.cwd(), outFlag)
+          else if (open) outPath = path.join(os.tmpdir(), `duo-rollup-${stem}-${Date.now()}.html`)
+          else outPath = path.join(root, 'out', `${stem}.html`)
+          fs.mkdirSync(path.dirname(outPath), { recursive: true })
+          fs.writeFileSync(outPath, result.html)
+          // `--open` is the one vault verb that reaches the running app
+          // (to surface the artifact as a tab). It fails gracefully when
+          // Duo isn't running — the file is already written either way.
+          let opened: unknown = null
+          if (open) {
+            try {
+              opened = await send('open', { path: outPath })
+            } catch (e) {
+              opened = { error: e instanceof Error ? e.message : String(e) }
+            }
+          }
+          out({
+            path: outPath,
+            sourceHash: result.sourceHash,
+            generatedAt: result.generatedAt,
+            asOf: result.asOfLabel,
+            bases: result.bases.map((b) => ({
+              label: b.label,
+              views: b.evaluated.views.map((v) => ({ name: v.name, type: v.type, rows: v.rows.length })),
+            })),
+            ...(open ? { opened } : {}),
+          })
+        } else {
+          die('Usage: duo base <lint <file|--all>|render <file|note>> [--out <path>] [--open] [--vault <path>]')
         }
         break
       }

--- a/cli/duo.ts
+++ b/cli/duo.ts
@@ -2399,12 +2399,22 @@ async function main(): Promise<void> {
           // `--open` is the one vault verb that reaches the running app
           // (to surface the artifact as a tab). It fails gracefully when
           // Duo isn't running — the file is already written either way.
+          // Payload MUST mirror the `open` verb (case 'open'): the IPC
+          // handler keys on `url` (a file:// URL via resolveOpenTarget),
+          // NOT `path`. `reveal` expands + focuses the pane so the user
+          // actually sees the rollup. Keep these two call sites in sync.
           let opened: unknown = null
           if (open) {
             try {
-              opened = await send('open', { path: outPath })
+              opened = await send('open', { url: resolveOpenTarget(outPath), mode: 'browser', reveal: true })
             } catch (e) {
               opened = { error: e instanceof Error ? e.message : String(e) }
+            }
+            // Surface an open failure on stderr too (the artifact write
+            // still succeeded, so exit stays 0) — don't let it hide in
+            // the JSON `opened.error` field where an agent would miss it.
+            if (opened && typeof opened === 'object' && 'error' in opened) {
+              process.stderr.write(`duo: base render wrote ${outPath} but --open failed: ${(opened as { error: unknown }).error}\n`)
             }
           }
           out({

--- a/core/vault/base.test.ts
+++ b/core/vault/base.test.ts
@@ -1,0 +1,152 @@
+// ENH-208 Vault — base engine + render + lint regression tests (PR2),
+// pinned to the frozen prototype vault. A fixed `asOf` keeps date-relative
+// formulas deterministic. These lock the locked expression subset: filters
+// (and/or/not, file.*), `if()` nesting, link `== this` (the one-template
+// rollup), date math + `.round()`, html()/icon(), groupBy, summaries, and
+// the child→parent backlink rollup that deliberately exceeds Obsidian.
+
+import { describe, it, expect } from 'vitest'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import * as fs from 'fs'
+import * as yaml from 'js-yaml'
+import {
+  renderTarget,
+  evaluateBaseDef,
+  readCol,
+  buildEngineFiles,
+  readNotes,
+  lintVault,
+  lintBaseDef,
+  buildCorpus,
+  isEvalError as _isEvalError,
+} from './index'
+import { isEvalError } from './engine'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const VAULT = path.resolve(HERE, '../../docs/research/graphbook-prototype')
+const AS_OF = new Date('2026-06-09T12:00:00')
+
+// Lookup a base file's parsed def.
+function loadBase(rel: string): any {
+  return yaml.load(fs.readFileSync(path.join(VAULT, rel), 'utf8'))
+}
+
+describe('render — vault-wide .base files', () => {
+  it('renders milestones.base with the right per-view row counts (templates excluded)', () => {
+    const r = renderTarget(VAULT, 'bases/milestones.base', { asOf: AS_OF })
+    const views = r.bases[0].evaluated.views
+    expect(views.find((v) => v.name === 'All milestones')!.rows).toHaveLength(6)
+    expect(views.find((v) => v.name === 'Blocked only')!.rows).toHaveLength(2)
+    expect(views.find((v) => v.name === 'Checklist')!.rows).toHaveLength(6)
+  })
+
+  it('renders portfolio.base over the two initiatives', () => {
+    const r = renderTarget(VAULT, 'bases/portfolio.base', { asOf: AS_OF })
+    const portfolio = r.bases[0].evaluated.views.find((v) => v.name === 'Portfolio')!
+    expect(portfolio.rows.map((f) => f.basename).sort()).toEqual(['Pricing Revamp', 'Q3 Launch'])
+  })
+
+  it('produces a stamped HTML artifact (build-artifact framing, D13)', () => {
+    const r = renderTarget(VAULT, 'bases/milestones.base', { asOf: AS_OF })
+    expect(r.html).toContain('BUILD ARTIFACT')
+    expect(r.html).toMatch(/source hash <strong>[0-9a-f]{12}<\/strong>/)
+    expect(r.sourceHash).toMatch(/^[0-9a-f]{12}$/)
+    expect(r.asOfLabel).toBe('2026-Jun-09')
+  })
+})
+
+describe('render — embedded `… == this` blocks (the one-template rollup, D8)', () => {
+  it('scopes Q3 Launch milestones to that initiative', () => {
+    const r = renderTarget(VAULT, 'Q3 Launch', { asOf: AS_OF })
+    expect(r.bases).toHaveLength(1)
+    expect(r.bases[0].thisFile).toBe('Q3 Launch')
+    expect(r.bases[0].evaluated.views[0].rows).toHaveLength(4)
+  })
+
+  it('the SAME block gives Pricing Revamp a different row set', () => {
+    const r = renderTarget(VAULT, 'Pricing Revamp', { asOf: AS_OF })
+    expect(r.bases[0].evaluated.views[0].rows).toHaveLength(2)
+  })
+
+  it('throws a clear error for a target with no base block', () => {
+    expect(() => renderTarget(VAULT, 'Alice Park', { asOf: AS_OF })).toThrow(/no .*base.* blocks/)
+  })
+})
+
+describe('engine — the locked expression subset evaluates without errors', () => {
+  const files = buildEngineFiles(readNotes(VAULT), AS_OF)
+
+  it('if()/html()/icon()/date-math formulas produce real values, never __error', () => {
+    const def = loadBase('bases/milestones.base')
+    const ev = evaluateBaseDef(def, files, null, AS_OF)
+    const rows = ev.views.find((v) => v.name === 'All milestones')!.rows
+    for (const row of rows) {
+      const chip = readCol('formula.chip', row, null, ev.formulas, AS_OF) as any
+      expect(isEvalError(chip)).toBe(false)
+      expect(chip.__html).toMatch(/blocked|done|on-track/) // html() chip
+      const mark = readCol('formula.mark', row, null, ev.formulas, AS_OF) as any
+      expect(mark.__html).toBeTruthy() // icon()
+      const days = readCol('formula.days_left', row, null, ev.formulas, AS_OF)
+      expect(days === null || typeof days === 'number').toBe(true) // ((due-today())/DAY).round(0)
+    }
+  })
+
+  it('child→parent backlink rollups resolve to numbers (exceeds Obsidian)', () => {
+    const def = loadBase('bases/portfolio.base')
+    const ev = evaluateBaseDef(def, files, null, AS_OF)
+    const row = ev.views[0].rows.find((f) => f.basename === 'Q3 Launch')!
+    const probeA = readCol('formula.probe_a', row, null, ev.formulas, AS_OF)
+    const probeB = readCol('formula.probe_b', row, null, ev.formulas, AS_OF)
+    const mentions = readCol('formula.mentions', row, null, ev.formulas, AS_OF)
+    expect(typeof probeA).toBe('number')
+    expect(typeof probeB).toBe('number')
+    expect(typeof mentions).toBe('number')
+  })
+
+  it('groupBy + summaries: people-load groups open milestones by owner', () => {
+    const def = loadBase('bases/people-load.base')
+    const ev = evaluateBaseDef(def, files, null, AS_OF)
+    const view = ev.views[0]
+    // every row is a non-done milestone
+    expect(view.rows.length).toBeGreaterThan(0)
+    for (const row of view.rows) {
+      expect(row.properties.type).toBe('milestone')
+      expect(row.properties.status).not.toBe('done')
+    }
+  })
+})
+
+describe('lint', () => {
+  it('the real vault lints clean (matches the prototype claim)', () => {
+    const results = lintVault(VAULT, '--all')
+    const errors = results.flatMap((r) => r.findings.filter((f) => f.severity === 'error'))
+    expect(errors).toEqual([])
+    expect(results.some((r) => r.parseError)).toBe(false)
+    // 4 .base files + 2 embedded (templates excluded)
+    expect(results).toHaveLength(6)
+  })
+
+  it('surfaces bad type / unresolved entity / off-enum / unknown fn / bad view, with suggestions', () => {
+    const corpus = buildCorpus(VAULT)
+    const broken = {
+      filters: { and: ['type == "mileston"', 'status == "blokced"', '"[[Nonexistent Person]]"'] },
+      formulas: { bad: 'iff(due, due.format("D"), "x")' },
+      views: [{ name: 'Broken', type: 'tabel', order: ['file.name'] }],
+    }
+    const findings = lintBaseDef(broken, corpus)
+    const msgs = findings.map((f) => f.message)
+    expect(findings.find((f) => /no such type/.test(f.message))?.suggestion).toBe('milestone')
+    expect(findings.find((f) => /blokced/.test(f.message))?.suggestion).toBe('blocked')
+    expect(msgs.some((m) => /unresolved entity/.test(m))).toBe(true)
+    expect(findings.find((f) => /unknown function/.test(f.message))?.suggestion).toBe('if')
+    expect(msgs.some((m) => /unknown view type "tabel"/.test(m))).toBe(true)
+    // D15: it found problems but lintBaseDef never throws — warn-and-render.
+    expect(findings.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('index re-exports isEvalError', () => {
+    expect(_isEvalError({ __error: 'x', __expr: 'y' })).toBe(true)
+    expect(_isEvalError(3)).toBe(false)
+  })
+})

--- a/core/vault/detect.ts
+++ b/core/vault/detect.ts
@@ -33,7 +33,10 @@ export function findVaultRoot(startPath: string): string | null {
   }
 }
 
-const SCAN_SKIP = new Set(['node_modules', '.git', '.obsidian', '.trash', 'out'])
+// `templates` is excluded so `vault list`'s noteCount matches what the
+// corpus / search / graph count as entities (D5 query-exclusion) — the
+// PR1 review flagged the prior inconsistency.
+const SCAN_SKIP = new Set(['node_modules', '.git', '.obsidian', '.trash', 'out', 'templates'])
 
 /** Count markdown notes under a vault root (cheap size signal). */
 function countNotes(root: string): number {

--- a/core/vault/engine.ts
+++ b/core/vault/engine.ts
@@ -1,0 +1,394 @@
+// ENH-208 Vault — the Bases expression engine (PR2). A faithful port of
+// the prototype's `render.mjs` evaluator: it implements EXACTLY the subset
+// of Obsidian Bases expressions the fixtures use (and the locked extension
+// points — `if`→ternary, link `== this`, date math, date-only = local
+// midnight, `file.name` = extension-less, child→parent backlink chains).
+// The engine and the linter (`lint.ts`) share one vocabulary; anything
+// outside it renders as a ⚠ cell rather than throwing (D15 warn-and-render).
+//
+// SECURITY / TRUST: expressions are evaluated via `new Function` + `with`.
+// `.base` files are local vault files authored by the user or Claude — the
+// same trust level as any file the user opens in the editor. The engine
+// never fetches or evaluates remote content. (Phase 3 note: if this module
+// is ever run inside the renderer, move eval into a Worker/vm sandbox; the
+// `ensureEngineGlobals` patch below is deferred to first render to keep a
+// bare import side-effect-free.)
+
+import type { VaultFile } from './types'
+
+export const DAY_MS = 86400000
+
+/** Wraps a JS Date with the Bases date API the fixtures use. */
+export class DuoDate {
+  d: Date
+  constructor(d: Date | number | string, private asOf: Date) {
+    this.d = d instanceof Date ? d : new Date(d)
+  }
+  valueOf(): number {
+    return this.d.getTime()
+  }
+  relative(): string {
+    const days = Math.round((this.d.getTime() - this.asOf.getTime()) / DAY_MS)
+    if (days === 0) return 'today'
+    if (days > 0) return 'in ' + days + (days === 1 ? ' day' : ' days')
+    return -days + (days === -1 ? ' day ago' : ' days ago')
+  }
+  format(fmt: string): string {
+    const M = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    return fmt
+      .replace('YYYY', String(this.d.getFullYear()))
+      .replace('MMM', M[this.d.getMonth()])
+      .replace('DD', String(this.d.getDate()).padStart(2, '0'))
+      .replace('D', String(this.d.getDate()))
+  }
+  toString(): string {
+    return this.format('MMM D, YYYY')
+  }
+}
+
+const DUR_UNITS: Record<string, number> = {
+  s: 1000, second: 1000, seconds: 1000,
+  m: 60000, minute: 60000, minutes: 60000,
+  h: 3600000, hour: 3600000, hours: 3600000,
+  d: DAY_MS, day: DAY_MS, days: DAY_MS,
+  w: 7 * DAY_MS, week: 7 * DAY_MS, weeks: 7 * DAY_MS,
+  M: 30 * DAY_MS, month: 30 * DAY_MS, months: 30 * DAY_MS,
+  y: 365 * DAY_MS, year: 365 * DAY_MS, years: 365 * DAY_MS,
+}
+function GB_DUR(s: unknown): number {
+  const m = String(s).trim().match(/^(\d+)\s*([A-Za-z]+)$/)
+  if (!m || !(m[2] in DUR_UNITS)) throw new Error('bad duration: ' + s)
+  return Number(m[1]) * DUR_UNITS[m[2]]
+}
+
+/** A wikilink value with an optional display alias. */
+export class Link {
+  target: string
+  display: string
+  constructor(target: string, display?: string) {
+    this.target = target
+    this.display = display || target
+  }
+  toString(): string {
+    return this.display
+  }
+}
+
+/** Convert a frontmatter scalar into engine value space: `[[X]]` → Link,
+ *  a date scalar → DuoDate (shifted UTC→local midnight so day math matches
+ *  the written date), arrays mapped recursively, everything else verbatim. */
+function parseLinkish(v: unknown, asOf: Date): unknown {
+  if (typeof v === 'string') {
+    const m = v.match(/^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/)
+    if (m) return new Link(m[1].trim(), m[2] && m[2].trim())
+    return v
+  }
+  if (Array.isArray(v)) return v.map((x) => parseLinkish(x, asOf))
+  if (v instanceof Date) {
+    return new DuoDate(new Date(v.getTime() + v.getTimezoneOffset() * 60000), asOf)
+  }
+  return v
+}
+
+function gbEq(a: unknown, b: unknown): boolean {
+  const name = (x: any) => (x instanceof Link ? x.target : x && x.name ? x.name : x)
+  return name(a) === name(b)
+}
+
+/** An engine-side note object — the shape `.base` expressions see as a row
+ *  (`file.*`) and as link targets. Mirrors render.mjs's file objects. */
+export interface EngineFile {
+  name: string
+  basename: string
+  path: string
+  folder: string
+  ext: string
+  mtime: DuoDate
+  properties: Record<string, unknown>
+  _rawLinks: string[]
+  links: EngineFile[]
+  backlinks: EngineFile[]
+  hasTag(): boolean
+  hasLink(other: unknown): boolean
+  inFolder(f: string): boolean
+  hasProperty(n: string): boolean
+  asFile(): EngineFile
+  toString(): string
+}
+
+/** Build engine files from parsed notes and wire the link graph
+ *  (links + reverse backlinks), resolving wikilinks by basename. */
+export function buildEngineFiles(notes: VaultFile[], asOf: Date): EngineFile[] {
+  const files: EngineFile[] = notes.map((n) => {
+    const properties: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(n.frontmatter)) properties[k] = parseLinkish(v, asOf)
+    const f: EngineFile = {
+      name: n.basename,
+      basename: n.basename,
+      path: n.relPath,
+      folder: n.folder,
+      ext: n.ext,
+      mtime: new DuoDate(new Date(n.mtimeMs), asOf),
+      properties,
+      _rawLinks: n.links,
+      links: [],
+      backlinks: [],
+      hasTag: () => false,
+      hasLink(other: unknown) {
+        const t = other instanceof Link ? other.target : (other as any)?.name ?? other
+        return this._rawLinks.includes(t as string)
+      },
+      inFolder(folder: string) {
+        return this.folder === folder || this.folder.startsWith(folder + '/')
+      },
+      hasProperty(name: string) {
+        return name in this.properties
+      },
+      asFile() {
+        return this
+      },
+      toString() {
+        return n.basename
+      },
+    }
+    return f
+  })
+  const byName = new Map(files.map((f) => [f.name, f]))
+  for (const f of files) {
+    f.links = f._rawLinks.map((n) => byName.get(n)).filter(Boolean) as EngineFile[]
+    for (const target of f.links) target.backlinks.push(f)
+  }
+  return files
+}
+
+// ── expression → JS source transforms (locked subset) ──────────────────────
+
+function wrapImplicitLambdas(src: string): string {
+  for (const fn of ['filter', 'map']) {
+    let i: number
+    while ((i = src.indexOf('.' + fn + '(')) !== -1) {
+      const open = i + fn.length + 2
+      let depth = 1
+      let j = open
+      while (j < src.length && depth > 0) {
+        if (src[j] === '(') depth++
+        else if (src[j] === ')') depth--
+        j++
+      }
+      const inner = src.slice(open, j - 1)
+      src = src.slice(0, open) + '(value)=>(' + inner + ')' + src.slice(j - 1)
+      src = src.slice(0, i) + '.GB_' + fn + src.slice(i + 1 + fn.length)
+    }
+    src = src.replaceAll('.GB_' + fn, '.' + fn)
+  }
+  return src
+}
+
+function splitTopLevel(s: string): string[] {
+  const parts: string[] = []
+  let depth = 0
+  let cur = ''
+  let quote: string | null = null
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i]
+    if (quote) {
+      cur += c
+      if (c === quote) quote = null
+      continue
+    }
+    if (c === '"' || c === "'") {
+      quote = c
+      cur += c
+      continue
+    }
+    if (c === '(') depth++
+    if (c === ')') depth--
+    if (c === ',' && depth === 0) {
+      parts.push(cur)
+      cur = ''
+      continue
+    }
+    cur += c
+  }
+  parts.push(cur)
+  return parts
+}
+
+function transformIfs(src: string): string {
+  const re = /(?<![\w.])if\s*\(/
+  let m: RegExpExecArray | null
+  while ((m = re.exec(src))) {
+    const open = m.index + m[0].length
+    let depth = 1
+    let j = open
+    while (j < src.length && depth > 0) {
+      if (src[j] === '(') depth++
+      else if (src[j] === ')') depth--
+      j++
+    }
+    const args = splitTopLevel(src.slice(open, j - 1))
+    const cond = args[0]
+    const a = args[1] ?? 'null'
+    const b = args[2] ?? 'null'
+    src = src.slice(0, m.index) + '((' + cond + ') ? (' + a + ') : (' + b + '))' + src.slice(j)
+  }
+  return src
+}
+
+function transform(expr: unknown): string {
+  let src = String(expr)
+  src = wrapImplicitLambdas(src)
+  src = transformIfs(src)
+  src = src.replace(/([\w.[\]"]+)\s*==\s*this\b/g, 'gbEq($1, GB_THIS)')
+  src = src.replace(/([\w.[\]"]+)\s*!=\s*this\b/g, '!gbEq($1, GB_THIS)')
+  src = src.replace(/([-+])\s*"(\d+\s*[A-Za-z]+)"/g, (mm, op, dur) => {
+    try {
+      GB_DUR(dur)
+      return op + ' GB_DUR("' + dur + '")'
+    } catch {
+      return mm
+    }
+  })
+  return src
+}
+
+export const ICONS: Record<string, string> = {
+  check: '<span style="color:#4a7d3e">✔</span>',
+  'octagon-x': '<span style="color:#b13e3a">⛔</span>',
+  'circle-dot': '<span style="color:#4a7d3e">◉</span>',
+  'alarm-clock': '<span style="color:#b07527">⏰</span>',
+  activity: '<span style="color:#3C6E93">∿</span>',
+}
+
+/** Bases gives numbers a `.round(digits)` method. Rather than mutate the
+ *  global Number prototype at import time (which would leak into a Phase-3
+ *  renderer share), we define it lazily + idempotently, non-enumerably, on
+ *  first evaluation only. */
+let globalsReady = false
+function ensureEngineGlobals(): void {
+  if (globalsReady) return
+  globalsReady = true
+  if (!('round' in Number.prototype)) {
+    Object.defineProperty(Number.prototype, 'round', {
+      value: function (this: number, digits = 0) {
+        const f = 10 ** digits
+        return Math.round(this * f) / f
+      },
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    })
+  }
+}
+
+export interface EvalError {
+  __error: string
+  __expr: unknown
+}
+export function isEvalError(v: unknown): v is EvalError {
+  return !!v && typeof v === 'object' && '__error' in (v as object)
+}
+export interface HtmlValue {
+  __html: string
+}
+
+function makeCtx(
+  file: EngineFile,
+  thisFile: EngineFile | null,
+  formulas: Record<string, unknown>,
+  asOf: Date,
+): Record<string, unknown> {
+  const formulaCache: Record<string, unknown> = {}
+  const formulaProxy = new Proxy(
+    {},
+    {
+      has: () => true,
+      get: (_t, k) => {
+        if (typeof k !== 'string') return undefined
+        if (!(k in formulaCache)) {
+          formulaCache[k] = '__evaluating__'
+          formulaCache[k] = formulas[k] ? evalExpr(formulas[k], file, thisFile, formulas, asOf) : null
+        }
+        return formulaCache[k]
+      },
+    },
+  )
+  const scope: Record<string, unknown> = {
+    file,
+    note: file.properties,
+    formula: formulaProxy,
+    GB_THIS: thisFile,
+    gbEq,
+    GB_DUR,
+    today: () => new DuoDate(midnight(asOf), asOf),
+    now: () => new DuoDate(new Date(asOf), asOf),
+    date: (s: string) => new DuoDate(new Date(s), asOf),
+    duration: GB_DUR,
+    icon: (n: string) => ({ __html: ICONS[n] || '<span title="' + n + '">◇</span>' }),
+    html: (s: unknown) => ({ __html: String(s) }),
+    list: (x: unknown) => (Array.isArray(x) ? x : [x]),
+    min: Math.min,
+    max: Math.max,
+    number: Number,
+    link: (p: string, d?: string) => new Link(p, d),
+  }
+  return new Proxy(scope, {
+    has: () => true,
+    get: (t, k) => {
+      if (typeof k !== 'string') return undefined
+      if (k in t) return t[k]
+      if (k in file.properties) return file.properties[k]
+      return null
+    },
+  })
+}
+
+function midnight(d: Date): Date {
+  const t = new Date(d)
+  t.setHours(0, 0, 0, 0)
+  return t
+}
+
+export function evalExpr(
+  expr: unknown,
+  file: EngineFile,
+  thisFile: EngineFile | null,
+  formulas: Record<string, unknown>,
+  asOf: Date,
+): unknown {
+  ensureEngineGlobals()
+  const src = transform(expr)
+  try {
+    // Function-constructor bodies are non-strict, so `with` is available.
+    // eslint-disable-next-line no-new-func
+    const fn = new Function('ctx', 'with (ctx) { return (' + src + '); }')
+    return fn(makeCtx(file, thisFile, formulas, asOf))
+  } catch (e) {
+    return { __error: e instanceof Error ? e.message : String(e), __expr: expr }
+  }
+}
+
+/** Evaluate a filter node (string expr, or `and`/`or`/`not` group). */
+export function passes(
+  filterNode: unknown,
+  file: EngineFile,
+  thisFile: EngineFile | null,
+  formulas: Record<string, unknown>,
+  asOf: Date,
+): boolean {
+  if (filterNode == null) return true
+  if (typeof filterNode === 'string') {
+    const r = evalExpr(filterNode, file, thisFile, formulas, asOf)
+    return Boolean(r) && !isEvalError(r)
+  }
+  const node = filterNode as Record<string, unknown>
+  if (node.and) return (node.and as unknown[]).every((n) => passes(n, file, thisFile, formulas, asOf))
+  if (node.or) return (node.or as unknown[]).some((n) => passes(n, file, thisFile, formulas, asOf))
+  if (node.not) return !(node.not as unknown[]).every((n) => passes(n, file, thisFile, formulas, asOf))
+  return true
+}
+
+/** Default as-of date (local midnight today) for relative formulas. */
+export function defaultAsOf(): Date {
+  return new Date()
+}

--- a/core/vault/index.ts
+++ b/core/vault/index.ts
@@ -14,3 +14,27 @@ export { isVaultRoot, findVaultRoot, listVaults, resolveVault } from './detect'
 export { buildCorpus, loadTemplates, parseBaseYaml } from './corpus'
 export { backlinks, orphans, type Backlink } from './graph'
 export { search } from './search'
+export {
+  renderTarget,
+  evaluateBaseDef,
+  readCol,
+  type RenderTargetResult,
+  type EvaluatedBase,
+  type EvaluatedView,
+  type BaseDef,
+} from './render'
+export {
+  lintVault,
+  lintBaseDef,
+  type LintFinding,
+  type LintResult,
+} from './lint'
+export {
+  buildEngineFiles,
+  evalExpr,
+  isEvalError,
+  DuoDate,
+  Link,
+  defaultAsOf,
+  type EngineFile,
+} from './engine'

--- a/core/vault/lint.ts
+++ b/core/vault/lint.ts
@@ -1,0 +1,204 @@
+// ENH-208 Vault — the `.base` linter (PR2, L1). Ported from the prototype's
+// `lint.mjs`. Derives the corpus from frontmatter (L0) and statically checks
+// a base's filter/formula expressions against it: bad types, unresolved
+// `[[entities]]`, off-enum values, unknown functions, unknown view types —
+// each with a Levenshtein "did you mean". Per D15 the findings are advisory:
+// lint NEVER blocks a render (warn-and-render).
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { load as yamlLoad } from 'js-yaml'
+import type { Corpus } from './types'
+import { buildCorpus } from './corpus'
+import { walk, readNotes } from './parse'
+
+export interface LintFinding {
+  severity: 'error' | 'warn'
+  message: string
+  /** Best-match correction, when one was found. */
+  suggestion?: string
+}
+export interface LintResult {
+  /** The base file (rel path) or the note (rel path) the def came from. */
+  source: string
+  /** For an embedded block: the host note's basename (`this` context). */
+  embeddedIn?: string
+  findings: LintFinding[]
+  /** True when YAML failed to parse (the def couldn't be linted). */
+  parseError?: string
+}
+
+// ── string distance ─────────────────────────────────────────────────────────
+function lev(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  const d: number[][] = Array.from({ length: m + 1 }, (_, i) => [i, ...Array(n).fill(0)])
+  for (let j = 0; j <= n; j++) d[0][j] = j
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      d[i][j] = Math.min(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1))
+  return d[m][n]
+}
+function suggest(word: string, candidates: string[]): string | null {
+  let best: string | null = null
+  let bestD = Infinity
+  for (const c of candidates) {
+    const dd = lev(word.toLowerCase(), c.toLowerCase())
+    if (dd < bestD) {
+      bestD = dd
+      best = c
+    }
+  }
+  return best && bestD <= Math.max(2, Math.ceil(word.length / 3)) ? best : null
+}
+
+// ── lint vocabulary (Obsidian Bases 1.13.0) ─────────────────────────────────
+// MUST track the engine's makeCtx scope (engine.ts) — same vocabulary table
+// per the PRD. Unknown names are WARNINGS (D15), never hard errors.
+const FUNCS = new Set([
+  'file.hasTag', 'file.hasLink', 'file.inFolder', 'file.hasProperty', 'file.asLink',
+  'today', 'now', 'date', 'duration', 'if', 'icon', 'html', 'list', 'min', 'max',
+  'number', 'link', 'random', 'escapeHTML',
+])
+const METHODS = new Set([
+  'relative', 'format', 'date', 'time', 'isEmpty', 'round', 'toFixed', 'abs', 'ceil', 'floor',
+  'contains', 'containsAll', 'containsAny', 'startsWith', 'endsWith', 'lower', 'title', 'trim',
+  'replace', 'split', 'join', 'reverse', 'slice', 'sort', 'unique', 'filter', 'map', 'reduce',
+  'flat', 'length', 'asFile', 'linksTo', 'keys', 'values', 'toString', 'matches', 'mean',
+])
+const VIEW_TYPES = ['table', 'cards', 'list', 'map']
+
+interface BaseDefLike {
+  filters?: unknown
+  formulas?: Record<string, unknown>
+  views?: { name?: string; type?: string; filters?: unknown }[]
+}
+
+function collectExprs(node: unknown, out: string[]): void {
+  if (node == null) return
+  if (typeof node === 'string') {
+    out.push(node)
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach((n) => collectExprs(n, out))
+    return
+  }
+  if (typeof node === 'object') {
+    const obj = node as Record<string, unknown>
+    for (const v of ['and', 'or', 'not']) if (obj[v]) collectExprs(obj[v], out)
+  }
+}
+
+/** Lint one base definition against the corpus. */
+export function lintBaseDef(def: BaseDefLike, corpus: Corpus): LintFinding[] {
+  const findings: LintFinding[] = []
+  const add = (severity: 'error' | 'warn', message: string, suggestion?: string) =>
+    findings.push(suggestion ? { severity, message, suggestion } : { severity, message })
+
+  const exprs: string[] = []
+  collectExprs(def.filters, exprs)
+  for (const v of def.views || []) collectExprs(v.filters, exprs)
+  for (const f of Object.values(def.formulas || {})) exprs.push(String(f))
+
+  const knownEntities = new Set([...corpus.entities.map((e) => e.name), ...Object.keys(corpus.aliases)])
+
+  for (const e of exprs) {
+    // type == "X"
+    for (const m of e.matchAll(/\btype\s*[=!]=\s*"([^"]+)"/g)) {
+      if (!corpus.types.includes(m[1])) {
+        const s = suggest(m[1], corpus.types)
+        add('error', `type == "${m[1]}" — no such type${s ? ` (did you mean "${s}"?)` : ''}. Known: ${corpus.types.join(', ')}`, s ?? undefined)
+      }
+    }
+    // [[Entity]]
+    for (const m of e.matchAll(/\[\[([^\]|#]+)/g)) {
+      const name = m[1].trim()
+      if (!knownEntities.has(name)) {
+        const s = suggest(name, [...knownEntities])
+        add('error', `[[${name}]] — unresolved entity${s ? ` (did you mean "${s}"?)` : ''}`, s ?? undefined)
+      }
+    }
+    // PROP == "value" — enum check when PROP is a known typed property
+    for (const m of e.matchAll(/\b(?:note\.)?(\w+)\s*==\s*"([^"]+)"/g)) {
+      const [, prop, val] = m
+      if (prop === 'type') continue
+      for (const [key, vals] of Object.entries(corpus.enumsByType)) {
+        if (key.endsWith('.' + prop) && !vals.includes(val)) {
+          const s = suggest(val, vals)
+          if (s)
+            add('warn', `${prop} == "${val}" — no ${key.split('.')[0]} has this value (observed: ${vals.join(', ')}; did you mean "${s}"?)`, s)
+        }
+      }
+    }
+    // function calls
+    for (const m of e.matchAll(/\b([a-z]\w*(?:\.\w+)?)\s*\(/gi)) {
+      const fn = m[1]
+      if (FUNCS.has(fn)) continue
+      const tail = fn.includes('.') ? fn.split('.').pop()! : fn
+      if (METHODS.has(tail)) continue
+      if (fn.includes('.')) continue // x.method() on a value — can't resolve statically
+      const s = suggest(fn, [...FUNCS])
+      add('warn', `${fn}(…) — unknown function${s ? ` (did you mean "${s}"?)` : ''}`, s ?? undefined)
+    }
+  }
+
+  // structural: view types
+  for (const v of def.views || []) {
+    if (v.type && !VIEW_TYPES.includes(v.type)) add('error', `view "${v.name || v.type}" — unknown view type "${v.type}"`)
+  }
+  return findings
+}
+
+/** Lint a target: `--all` (every `.base` file + every embedded ```base block
+ *  in every note), a `.base` file path, or a note path/name (its embedded
+ *  blocks). `corpus` is computed once and shared. */
+export function lintVault(root: string, target: '--all' | string): LintResult[] {
+  const corpus = buildCorpus(root)
+  const results: LintResult[] = []
+
+  const lintBaseFile = (abs: string) => {
+    const rel = path.relative(root, abs).split(path.sep).join('/')
+    let def: BaseDefLike
+    try {
+      def = yamlLoad(fs.readFileSync(abs, 'utf8')) as BaseDefLike
+    } catch (e) {
+      results.push({ source: rel, findings: [], parseError: e instanceof Error ? e.message : String(e) })
+      return
+    }
+    results.push({ source: rel, findings: lintBaseDef(def || {}, corpus) })
+  }
+
+  const lintNoteEmbeds = (relPath: string, basename: string, body: string) => {
+    let i = 0
+    for (const m of body.matchAll(/```base\n([\s\S]*?)```/g)) {
+      i++
+      let def: BaseDefLike
+      try {
+        def = yamlLoad(m[1]) as BaseDefLike
+      } catch (e) {
+        results.push({ source: relPath, embeddedIn: basename, findings: [], parseError: e instanceof Error ? e.message : String(e) })
+        continue
+      }
+      results.push({ source: `${relPath}${i > 1 ? ` [block ${i}]` : ''}`, embeddedIn: basename, findings: lintBaseDef(def || {}, corpus) })
+    }
+  }
+
+  if (target === '--all') {
+    for (const abs of walk(root).filter((p) => p.endsWith('.base')).sort()) lintBaseFile(abs)
+    for (const note of readNotes(root)) lintNoteEmbeds(note.relPath, note.basename, note.body)
+  } else {
+    const abs = path.isAbsolute(target) ? target : path.resolve(root, target)
+    if (target.endsWith('.base')) {
+      lintBaseFile(abs)
+    } else {
+      const notes = readNotes(root)
+      const note = fs.existsSync(abs) && abs.endsWith('.md')
+        ? notes.find((n) => n.absPath === abs)
+        : notes.find((n) => n.basename === target.replace(/\.md$/, ''))
+      if (!note) throw new Error(`lint target not found: ${target} (expected --all, a .base file, or a note path/name)`)
+      lintNoteEmbeds(note.relPath, note.basename, note.body)
+    }
+  }
+  return results
+}

--- a/core/vault/render.ts
+++ b/core/vault/render.ts
@@ -1,0 +1,453 @@
+// ENH-208 Vault — base rendering (PR2). Two layers:
+//   1. evaluateBaseDef() — pure structured evaluation (filtered rows per
+//      view + a readCol() to pull any column's value). Tests assert row
+//      counts and formula outputs against this without parsing HTML.
+//   2. the HTML emitter — Duo-owned presentation (D16: table/cards/list is
+//      never user-authored; cell styling only via html()/icon() formulas).
+//
+// Ported from the prototype's `render.mjs`. The HTML page is a stamped
+// build artifact (D13): generated-at + source hash + as-of date, so
+// staleness is detectable.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { load as yamlLoad } from 'js-yaml'
+import type { VaultFile } from './types'
+import { readNotes, parseFile } from './parse'
+import {
+  buildEngineFiles,
+  evalExpr,
+  passes,
+  DuoDate,
+  Link,
+  isEvalError,
+  defaultAsOf,
+  type EngineFile,
+} from './engine'
+
+// ── structured evaluation ──────────────────────────────────────────────────
+
+export interface BaseView {
+  name: string
+  type: string
+  order: string[]
+  groupBy?: { property: string; direction?: string }
+  summaries?: Record<string, string>
+  filters?: unknown
+}
+export interface BaseDef {
+  filters?: unknown
+  formulas?: Record<string, unknown>
+  properties?: Record<string, { displayName?: string }>
+  views?: BaseView[]
+}
+
+export interface EvaluatedView {
+  name: string
+  type: string
+  order: string[]
+  groupBy?: { property: string; direction?: string }
+  summaries?: Record<string, string>
+  rows: EngineFile[]
+}
+export interface EvaluatedBase {
+  formulas: Record<string, unknown>
+  propCfg: Record<string, { displayName?: string }>
+  views: EvaluatedView[]
+}
+
+/** Read one column's value for a row (`file.*`, `formula.*`, `note.*`, or a
+ *  bare frontmatter key). Shared by the HTML emitter and tests. */
+export function readCol(
+  prop: string,
+  file: EngineFile,
+  thisFile: EngineFile | null,
+  formulas: Record<string, unknown>,
+  asOf: Date,
+): unknown {
+  if (prop.startsWith('formula.')) {
+    return evalExpr(formulas[prop.slice(8)] ?? 'null', file, thisFile, formulas, asOf)
+  }
+  if (prop.startsWith('file.')) return (file as unknown as Record<string, unknown>)[prop.slice(5)]
+  const key = prop.startsWith('note.') ? prop.slice(5) : prop
+  return file.properties[key] ?? null
+}
+
+/** Evaluate a base definition against a file set — filter each view's rows
+ *  (base-level filters ∧ view-level filters). `thisFile` is the host note
+ *  for embedded `… == this` blocks, else null for vault-wide `.base` files. */
+export function evaluateBaseDef(
+  def: BaseDef,
+  files: EngineFile[],
+  thisFile: EngineFile | null,
+  asOf: Date,
+): EvaluatedBase {
+  const formulas = def.formulas || {}
+  const propCfg = def.properties || {}
+  const views: EvaluatedView[] = []
+  for (const view of def.views || []) {
+    const rows = files.filter(
+      (f) => passes(def.filters, f, thisFile, formulas, asOf) && passes(view.filters, f, thisFile, formulas, asOf),
+    )
+    views.push({
+      name: view.name || view.type,
+      type: view.type,
+      order: view.order || ['file.name'],
+      groupBy: view.groupBy,
+      summaries: view.summaries,
+      rows,
+    })
+  }
+  return { formulas, propCfg, views }
+}
+
+// ── HTML emitter (Duo-owned) ────────────────────────────────────────────────
+
+const esc = (s: unknown): string =>
+  String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+function cell(v: unknown): string {
+  if (v == null || v === '') return '<span class="empty">—</span>'
+  if (isEvalError(v)) return '<span class="err" title="' + esc(v.__expr) + '">⚠ ' + esc(v.__error) + '</span>'
+  if (typeof v === 'object' && v !== null && '__html' in v) return (v as { __html: string }).__html
+  if (v instanceof Link) return '<span class="wikilink">' + esc(v.display) + '</span>'
+  if (v instanceof DuoDate) return esc(v.toString())
+  if (Array.isArray(v)) return v.map(cell).join(', ')
+  if (typeof v === 'number') return String(v)
+  return esc(String(v))
+}
+
+function colLabel(prop: string, propCfg?: Record<string, { displayName?: string }>): string {
+  if (propCfg && propCfg[prop] && propCfg[prop].displayName) return propCfg[prop].displayName!
+  return prop.replace(/^(note|file|formula)\./, '')
+}
+
+const SUMMARY_FNS: Record<string, (vals: unknown[]) => unknown> = {
+  Earliest: (vals) => {
+    const ds = vals.filter((v): v is DuoDate => v instanceof DuoDate)
+    return ds.length ? ds.reduce((a, b) => (a.valueOf() < b.valueOf() ? a : b)) : null
+  },
+  Latest: (vals) => {
+    const ds = vals.filter((v): v is DuoDate => v instanceof DuoDate)
+    return ds.length ? ds.reduce((a, b) => (a.valueOf() > b.valueOf() ? a : b)) : null
+  },
+  Filled: (vals) => vals.filter((v) => v != null && v !== '').length,
+  Empty: (vals) => vals.filter((v) => v == null || v === '').length,
+  Sum: (vals) => vals.filter((v): v is number => typeof v === 'number').reduce((a, b) => a + b, 0),
+  Average: (vals) => {
+    const ns = vals.filter((v): v is number => typeof v === 'number')
+    return ns.length ? Math.round((ns.reduce((a, b) => a + b, 0) / ns.length) * 100) / 100 : null
+  },
+  Unique: (vals) => new Set(vals.map((v) => String(v))).size,
+}
+
+function summaryInline(
+  rows: EngineFile[],
+  view: EvaluatedView,
+  formulas: Record<string, unknown>,
+  thisFile: EngineFile | null,
+  asOf: Date,
+): string {
+  if (!view.summaries) return ''
+  const parts: string[] = []
+  for (const [prop, fnName] of Object.entries(view.summaries)) {
+    const fn = SUMMARY_FNS[fnName]
+    if (!fn) {
+      parts.push(esc(fnName) + ': ?')
+      continue
+    }
+    const vals = rows.map((f) => readCol(prop, f, thisFile, formulas, asOf))
+    parts.push(esc(colLabel(prop)) + ' ' + esc(fnName).toLowerCase() + ': ' + cell(fn(vals)))
+  }
+  return ' <span class="summary">' + parts.join(' · ') + '</span>'
+}
+
+function renderTable(
+  view: EvaluatedView,
+  formulas: Record<string, unknown>,
+  thisFile: EngineFile | null,
+  propCfg: Record<string, { displayName?: string }>,
+  asOf: Date,
+): string {
+  const order = view.order
+  const head = '<tr>' + order.map((p) => '<th>' + esc(colLabel(p, propCfg)) + '</th>').join('') + '</tr>'
+  const groups = new Map<string | null, EngineFile[]>()
+  if (view.groupBy) {
+    for (const f of view.rows) {
+      const v = readCol(view.groupBy.property, f, thisFile, formulas, asOf)
+      const key = v == null ? '—' : String(v instanceof Link ? v.display : v)
+      if (!groups.has(key)) groups.set(key, [])
+      groups.get(key)!.push(f)
+    }
+  } else {
+    groups.set(null, view.rows)
+  }
+  const keys = [...groups.keys()].sort((a, b) => String(a).localeCompare(String(b)))
+  if (view.groupBy && String(view.groupBy.direction).toUpperCase() === 'DESC') keys.reverse()
+
+  let html = '<table>' + head
+  for (const key of keys) {
+    const gRows = groups.get(key)!
+    if (key !== null) {
+      html +=
+        '<tr class="group"><td colspan="' +
+        order.length +
+        '">' +
+        esc(key) +
+        ' <span class="count">(' +
+        gRows.length +
+        ')</span>' +
+        summaryInline(gRows, view, formulas, thisFile, asOf) +
+        '</td></tr>'
+    }
+    for (const f of gRows) {
+      html += '<tr>' + order.map((p) => '<td>' + cell(readCol(p, f, thisFile, formulas, asOf)) + '</td>').join('') + '</tr>'
+    }
+  }
+  if (!view.groupBy && view.summaries) {
+    html +=
+      '<tr class="group"><td colspan="' +
+      order.length +
+      '">' +
+      summaryInline(view.rows, view, formulas, thisFile, asOf) +
+      '</td></tr>'
+  }
+  return html + '</table>'
+}
+
+function renderList(
+  view: EvaluatedView,
+  formulas: Record<string, unknown>,
+  thisFile: EngineFile | null,
+  asOf: Date,
+): string {
+  return (
+    '<ul class="baselist">' +
+    view.rows.map((f) => '<li>' + view.order.map((p) => cell(readCol(p, f, thisFile, formulas, asOf))).join(' ') + '</li>').join('') +
+    '</ul>'
+  )
+}
+
+function renderCards(
+  view: EvaluatedView,
+  formulas: Record<string, unknown>,
+  thisFile: EngineFile | null,
+  asOf: Date,
+): string {
+  return (
+    '<div class="cards">' +
+    view.rows
+      .map((f) => {
+        const [title, ...rest] = view.order
+        return (
+          '<div class="card"><div class="card-title">' +
+          cell(readCol(title, f, thisFile, formulas, asOf)) +
+          '</div>' +
+          rest
+            .map(
+              (p) =>
+                '<div class="card-row"><span class="card-k">' +
+                esc(colLabel(p)) +
+                '</span> ' +
+                cell(readCol(p, f, thisFile, formulas, asOf)) +
+                '</div>',
+            )
+            .join('') +
+          '</div>'
+        )
+      })
+      .join('') +
+    '</div>'
+  )
+}
+
+/** Render one evaluated base to an HTML section. */
+export function renderBaseSection(
+  evaluated: EvaluatedBase,
+  thisFile: EngineFile | null,
+  label: string,
+  asOf: Date,
+): string {
+  let html = '<section class="base"><h2>' + esc(label) + '</h2>'
+  for (const view of evaluated.views) {
+    html += '<h3>' + esc(view.name) + ' <span class="count">' + view.rows.length + ' rows</span></h3>'
+    if (view.type === 'list') html += renderList(view, evaluated.formulas, thisFile, asOf)
+    else if (view.type === 'cards') html += renderCards(view, evaluated.formulas, thisFile, asOf)
+    else html += renderTable(view, evaluated.formulas, thisFile, evaluated.propCfg, asOf)
+  }
+  return html + '</section>'
+}
+
+// ── target resolution + page assembly ──────────────────────────────────────
+
+export interface RenderTargetResult {
+  /** The full stamped HTML page. */
+  html: string
+  /** Structured evaluation per rendered base (for tests / refresh checks). */
+  bases: { label: string; evaluated: EvaluatedBase; thisFile: string | null }[]
+  /** Source hash over the vault's md + base content (staleness key). */
+  sourceHash: string
+  /** ISO generated-at. */
+  generatedAt: string
+  /** As-of date (YYYY-MMM-DD) the relative formulas were computed against. */
+  asOfLabel: string
+}
+
+function sourceHash(root: string): string {
+  const all: string[] = []
+  const stack = [root]
+  const SKIP = new Set(['.obsidian', '.trash', 'out', '.git', 'node_modules'])
+  while (stack.length) {
+    const dir = stack.pop()!
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name)
+      if (e.isDirectory()) {
+        if (!SKIP.has(e.name)) stack.push(full)
+      } else if (e.name.endsWith('.md') || e.name.endsWith('.base')) {
+        try {
+          all.push(fs.readFileSync(full, 'utf8'))
+        } catch {
+          /* race */
+        }
+      }
+    }
+  }
+  return crypto.createHash('sha256').update(all.sort().join(' ')).digest('hex').slice(0, 12)
+}
+
+/** Extract embedded ```base block YAML defs from a note's body. */
+function embeddedBaseDefs(note: VaultFile): BaseDef[] {
+  const out: BaseDef[] = []
+  for (const m of note.body.matchAll(/```base\n([\s\S]*?)```/g)) {
+    try {
+      const def = yamlLoad(m[1])
+      if (def && typeof def === 'object') out.push(def as BaseDef)
+    } catch {
+      /* malformed embedded block — skip (warn-and-render) */
+    }
+  }
+  return out
+}
+
+/** Render a target — a `.base` file path (vault-wide), or a note (path or
+ *  basename, renders its embedded ```base blocks with `this` = the note).
+ *  Returns the stamped HTML page + structured results. */
+export function renderTarget(
+  root: string,
+  target: string,
+  opts: { asOf?: Date } = {},
+): RenderTargetResult {
+  const asOf = opts.asOf ?? defaultAsOf()
+  const notes = readNotes(root)
+  const files = buildEngineFiles(notes, asOf)
+  const byName = new Map(files.map((f) => [f.name, f]))
+
+  const bases: RenderTargetResult['bases'] = []
+  const sections: string[] = []
+
+  const abs = path.isAbsolute(target) ? target : path.resolve(root, target)
+  if (target.endsWith('.base')) {
+    const def = yamlLoad(fs.readFileSync(abs, 'utf8')) as BaseDef
+    const label = path.relative(root, abs).split(path.sep).join('/')
+    const evaluated = evaluateBaseDef(def, files, null, asOf)
+    bases.push({ label, evaluated, thisFile: null })
+    sections.push(renderBaseSection(evaluated, null, label, asOf))
+  } else {
+    // Resolve a note: an existing path, else a basename in the vault.
+    let note: VaultFile | undefined
+    if (fs.existsSync(abs) && abs.endsWith('.md')) note = parseFile(abs, root)
+    else note = notes.find((n) => n.basename === target.replace(/\.md$/, ''))
+    if (!note) throw new Error(`render target not found: ${target} (expected a .base file or a note path/name)`)
+    const thisFile = byName.get(note.basename) ?? null
+    const defs = embeddedBaseDefs(note)
+    if (!defs.length) {
+      throw new Error(`no \`\`\`base blocks found in ${note.relPath} (nothing to render)`)
+    }
+    defs.forEach((def, i) => {
+      const label = `${note!.relPath}${defs.length > 1 ? ` [block ${i + 1}]` : ''}  (this = ${note!.basename})`
+      const evaluated = evaluateBaseDef(def, files, thisFile, asOf)
+      bases.push({ label, evaluated, thisFile: note!.basename })
+      sections.push(renderBaseSection(evaluated, thisFile, label, asOf))
+    })
+  }
+
+  const hash = sourceHash(root)
+  const generatedAt = new Date().toISOString()
+  const asOfLabel = new DuoDate(asOf, asOf).format('YYYY-MMM-DD')
+  const html = assemblePage(sections, {
+    sourceHash: hash,
+    generatedAt,
+    asOfLabel,
+    noteCount: notes.length,
+    baseCount: bases.length,
+    target,
+  })
+  return { html, bases, sourceHash: hash, generatedAt, asOfLabel }
+}
+
+function assemblePage(
+  sections: string[],
+  meta: { sourceHash: string; generatedAt: string; asOfLabel: string; noteCount: number; baseCount: number; target: string },
+): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Vault rollup — ${esc(meta.target)}</title>
+<style>
+:root { --paper:#fbf8f1; --paper-deep:#f3ede0; --paper-rule:#d9cea8; --ink:#2b2620;
+  --ink-soft:#4a4238; --ink-mute:#6f6557; --ink-ghost:#9a9080; --accent:#c46a1c;
+  --pass:#4a7d3e; --fail:#b13e3a; --harbor:#3C6E93; }
+* { box-sizing:border-box; }
+body { margin:0 auto; padding:32px 40px 64px; max-width:960px; background:var(--paper);
+  color:var(--ink); font:14px/1.55 -apple-system,"SF Pro Text",system-ui,sans-serif; }
+h1 { font-family:"New York","Iowan Old Style",Georgia,serif; font-style:italic; font-weight:500; font-size:22px; margin:0 0 4px; }
+.stamp { background:var(--paper-deep); border:1px solid var(--paper-rule); border-radius:6px;
+  padding:10px 14px; margin:14px 0 28px; font-size:12px; color:var(--ink-mute);
+  font-family:ui-monospace,"SF Mono",Menlo,monospace; }
+.stamp strong { color:var(--accent); }
+h2 { font-family:"New York",Georgia,serif; font-weight:600; font-size:18px;
+  border-bottom:1px solid var(--paper-rule); padding-bottom:6px; margin:34px 0 8px; }
+h3 { font-size:14px; margin:18px 0 6px; }
+.count { font-weight:400; font-size:11.5px; color:var(--ink-ghost); }
+table { border-collapse:collapse; width:100%; font-size:12.5px; margin:6px 0 14px; }
+th,td { border-bottom:1px solid var(--paper-rule); padding:6px 8px; text-align:left; vertical-align:top; }
+th { font-size:11px; text-transform:uppercase; letter-spacing:.03em; color:var(--ink-mute); }
+tr.group td { background:var(--paper-deep); font-weight:600; font-size:12px; }
+.summary { font-weight:400; color:var(--ink-mute); font-size:11.5px; }
+.wikilink { color:var(--harbor); border-bottom:1px dotted var(--harbor); }
+.empty { color:var(--ink-ghost); }
+.err { color:var(--fail); font-size:11px; }
+.baselist { margin:6px 0 14px; }
+.cards { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:10px; margin:6px 0 14px; }
+.card { background:white; border:1px solid var(--paper-rule); border-radius:6px; padding:10px 12px; }
+.card-title { font-weight:600; margin-bottom:6px; }
+.card-row { font-size:12px; color:var(--ink-soft); }
+.card-k { color:var(--ink-ghost); font-size:10.5px; text-transform:uppercase; letter-spacing:.03em; margin-right:4px; }
+footer { margin-top:40px; border-top:1px solid var(--paper-rule); padding-top:12px;
+  font-size:11.5px; color:var(--ink-mute); }
+</style>
+</head>
+<body>
+<h1>Vault rollup — ${esc(meta.target)}</h1>
+<div class="stamp"><strong>BUILD ARTIFACT</strong> — regenerate: duo base render ${esc(meta.target)} ·
+generated ${esc(meta.generatedAt)} · source hash <strong>${esc(meta.sourceHash)}</strong> ·
+date-relative formulas as of ${esc(meta.asOfLabel)} ·
+${meta.noteCount} notes, ${meta.baseCount} rendered base(s)</div>
+${sections.join('\n')}
+<footer>Duo-owned rollup render (ENH-208). Implements the locked Bases
+expression subset (filters and/or/not, link equality vs <code>this</code>,
+date math, if(), html(), icon(), backlink chains, groupBy, summaries).
+file.name is extension-less; child→parent backlink rollups always resolve
+here. Re-render to refresh; the source hash above detects staleness.</footer>
+</body>
+</html>
+`
+}

--- a/packs/duo-default/canvases/what-duo-does.html
+++ b/packs/duo-default/canvases/what-duo-does.html
@@ -969,6 +969,15 @@
   </div>
 </article>
 
+<article class="item" data-keys="vault rollup base obsidian bases render lint live html artifact milestones initiative this template formula filter groupby enh-208">
+  <div class="num">97</div>
+  <div>
+    <h3>Generate a live rollup from your notes</h3>
+    <p class="why">A <strong>rollup</strong> is a view computed from your notes' frontmatter — "every open milestone for this initiative, grouped by owner, with a due-date chip." Duo uses plain <a href="https://help.obsidian.md/bases">Obsidian Bases</a> (<code>.base</code> files + embedded <code>```base</code> blocks), so the same view also renders inside Obsidian. Describe the view in prose and Claude writes the <code>.base</code>; a linter checks every type, <code>[[entity]]</code>, enum value, and function against your live corpus (with "did you mean" fixes) before rendering. The headline pattern: an embedded block that filters <code>initiative == this</code> lives in the initiative <em>template</em>, so <strong>every</strong> initiative gets a live milestone rollup with zero per-note setup. Renders are stamped build artifacts (generated-at · source-hash · as-of date) so staleness is detectable — never a silent cache.</p>
+    <p class="how"><strong>CLI / agent</strong><code>duo base lint &lt;file|--all&gt;</code> validates; <code>duo base render &lt;file|note&gt; --open</code> evaluates it over live frontmatter and opens the result as a tab. The rendered table/cards/list is Duo-owned; cell styling comes only from <code>html()</code> / <code>icon()</code> formulas.</p>
+  </div>
+</article>
+
 <h2 class="cat">Workspace setup</h2>
 <p class="cat-tagline">Pin tabs you want always-available; install Duo's skill + agent + CLI in one click.</p>
 

--- a/skill/references/cli-reference.md
+++ b/skill/references/cli-reference.md
@@ -207,6 +207,10 @@ A **vault** is a folder containing `.obsidian/` (a strict Obsidian vault: markdo
 | `duo vault search <query> [--vault <path>]` | Case-insensitive full-text search over the vault's notes (the CLI twin of the ⌘⇧F palette). | JSON: `[{ path, absPath, line, excerpt }]` |
 | `duo graph backlinks <note> [--vault <path>]` | Every occurrence that wikilinks to `<note>` (matched by basename, so links survive file moves), scanning frontmatter relationships as well as body links. | JSON: `[{ path, absPath, line, excerpt }]` |
 | `duo graph orphans [--vault <path>]` | Notes with no inbound **and** no outbound links — a processing work-list to link or archive. | JSON: `string[]` (rel paths) |
+| `duo base lint <file\|--all> [--vault <path>]` | Validate a `.base` file (or a note's embedded ` ```base ` blocks, or every base with `--all`) against the live corpus — bad types, unresolved `[[entities]]`, off-enum values, unknown functions, unknown view types, each with a Levenshtein "did you mean". **Warn-and-render (D15): advisory, never blocks.** | JSON: `[{ source, embeddedIn?, findings:[{severity, message, suggestion?}], parseError? }]` |
+| `duo base render <file\|note> [--out <path>] [--open] [--vault <path>]` | Evaluate a base's filters/formulas over live frontmatter and emit a **Duo-owned** HTML artifact, stamped with generated-at · source-hash · as-of date (D13/D16). A `.base` file renders vault-wide; a note renders its embedded ` ```base ` blocks with `this` = the note (the one-template rollup). Default writes to the vault's `out/`; `--out` writes elsewhere; `--open` also opens it as a tab in the running app (the one vault verb that reaches the app — fails gracefully when Duo isn't running). | JSON `{ path, sourceHash, generatedAt, asOf, bases:[{label, views:[{name, type, rows}]}] }` |
+
+The rollup authoring loop: describe the view in prose → derive the corpus (`duo vault schema`) → write the `.base` (vault-wide → `bases/`; per-entity → an embedded block in the **type template** with `… == this`, so every entity inherits it) → `duo base lint` until clean → `duo base render --open`.
 
 ---
 


### PR DESCRIPTION
## ENH-208 Vault — Phase 1, PR2 of 4

Builds on PR1's `core/vault/`. Ports the prototype's Obsidian Bases engine to typed modules and ships the rollup verbs.

### Verbs
- **`duo base lint <file|--all>`** — validate a `.base` (or a note's embedded ` ```base ` blocks, or all with `--all`) against the live corpus: bad types, unresolved `[[entities]]`, off-enum values, unknown functions/view-types — each with a "did you mean". **Advisory only — warn-and-render, never blocks (D15).**
- **`duo base render <file|note> [--out p] [--open]`** — evaluate filters/formulas over live frontmatter → a stamped **Duo-owned** HTML artifact (generated-at · source-hash · as-of date, D13/D16). A note renders its embedded blocks with `this` = the note (the one-template `… == this` rollup). `--open` surfaces it as a tab (the one vault verb that reaches the app; degrades gracefully when Duo isn't running).

### New core modules (pure, fs-backed; shared with the renderer in Phase 3)
- `engine.ts` — the **locked** Bases expression subset (`if()`→ternary, link `== this`, date math + `.round()`, `html()`/`icon()`, `and/or/not`, implicit `.filter`/`.map` lambdas, child→parent backlink rollups that deliberately exceed Obsidian).
- `render.ts` — structured evaluation (testable row-counts / formula values) split from the Duo-owned HTML emitter.
- `lint.ts` — corpus-driven static checks.

### Folds in PR1 review nits
- `vault list` `noteCount` now excludes `templates/` (consistent with corpus/search/graph).
- **Arg-parse bug fixed:** a `--vault <path>` *value* was mis-read as a positional (`base lint --all --vault X` grabbed `X` as the target). Added a flag-aware `positionalArgs` helper, applied to `vault search` / `graph backlinks` / `base lint|render`.

### Security note for the reviewer
The engine evaluates base-file expressions via `new Function` + `with`. `.base` files are **local** vault files (same trust as any file the user opens). No remote fetch/eval. `Number.prototype.round` is patched **lazily + non-enumerably on first render only** (never at import) so a Phase-3 renderer share isn't polluted by a bare import. Worth a look.

### Verification
- `npm run typecheck` clean
- `npx vitest run` — **1151 passed** (12 new in `core/vault/base.test.ts`, fixed `asOf` for deterministic date formulas)
- `npm run check:skill-currency` — 0 failures
- Hand-exercised: `base lint --all` clean on the real vault (matches the prototype's verified-clean claim); a broken fixture surfaces all 5 finding classes with correct suggestions; `base render bases/milestones.base` → All milestones 6 / Blocked 2 / Checklist 6; `base render "Q3 Launch"` → 4 (the `initiative == this` embed); child→parent `probe_a`/`probe_b` resolve to numbers.

### Reviewer notes
- Row counts differ from the prototype's `out/graphbook.html` by design — the prototype leaked `templates/milestone.md` as a phantom milestone row; PR1 fixed templates-exclusion (D5).
- `cli/duo` binary rebuilt + committed.
- Stack ahead: **PR3** vault init+capture · **PR4** skill + Vault Guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)