### PR TITLE
ENH-208 Phase 1 · PR3 — vault init + capture

### DIFF
--- a/agents/duo.md
+++ b/agents/duo.md
@@ -273,7 +273,9 @@ empty.
 | `duo project unpin <name\|root>` | Remove from pin set. |
 | `duo project close <name\|root>` | Bulk close every member terminal + tab. Confirms via dialog when any member is `kind: 'claude'`. |
 | `duo workspace-pill-menu [on\|off\|toggle]` | Toggle the title-bar workspace pill click-to-open-menu (the workspace dropdown). Default OFF — pill is passive label; use File menu for workspace ops. |
+| `duo vault init <folder> [--force]` | Scaffold a new vault — `.obsidian/`, starter templates (with D19 filing rules), inbox/registry folders, `bases/processing.base`, README. Refuses to clobber unless `--force`. JSON `{root, created[], warnings[]}`. |
 | `duo vault list` | Vaults detected from the cwd (folders with `.obsidian/`). JSON `[{root, name, noteCount}]`. These vault verbs read the filesystem directly — no running app needed. |
+| `duo vault capture [--template t] [--text "…"] [--title "…"] [--open] [--vault p]` | Drop a timestamped inbox note (D6). Untyped by default; `--template` stamps a type + seeds its fields. `--text`=body, `--open` opens it. JSON `{path, absPath, type}`. |
 | `duo vault schema [--vault <path>]` | The vault corpus (types, entities, aliases, props-per-type, observed enums, templates) — a live function over frontmatter, never cached. JSON `Corpus`. |
 | `duo vault search <query> [--vault <path>]` | Full-text search over the vault (CLI twin of ⌘⇧F). JSON `[{path, absPath, line, excerpt}]`. |
 | `duo graph backlinks <note> [--vault <path>]` | Notes linking to `<note>` (basename-resolved; scans frontmatter + body). JSON `[{path, absPath, line, excerpt}]`. |

--- a/cli/duo
+++ b/cli/duo
@@ -24,9 +24,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 
 // cli/duo.ts
 var net = __toESM(require("net"));
-var os = __toESM(require("os"));
-var path8 = __toESM(require("path"));
-var fs8 = __toESM(require("fs"));
+var os2 = __toESM(require("os"));
+var path9 = __toESM(require("path"));
+var fs9 = __toESM(require("fs"));
 var import_crypto = require("crypto");
 
 // core/vault/parse.ts
@@ -2786,6 +2786,7 @@ function loadTemplates(root) {
   } catch {
     return [];
   }
+  const META_KEYS = /* @__PURE__ */ new Set(["type", "folder", "filingParent", "filingLoose", "folderNote"]);
   const out2 = [];
   for (const f of entries.sort()) {
     const abs = import_node_path3.default.join(dir, f);
@@ -2793,11 +2794,17 @@ function loadTemplates(root) {
     const { frontmatter, body } = splitFrontmatter(raw);
     const type2 = typeof frontmatter.type === "string" ? frontmatter.type : import_node_path3.default.basename(f, ".md");
     const folder = typeof frontmatter.folder === "string" ? frontmatter.folder : null;
-    const fields = Object.keys(frontmatter).filter((k) => k !== "type" && k !== "folder");
+    const filingParent = typeof frontmatter.filingParent === "string" ? frontmatter.filingParent : null;
+    const filingLoose = typeof frontmatter.filingLoose === "boolean" ? frontmatter.filingLoose : null;
+    const folderNote = frontmatter.folderNote === true;
+    const fields = Object.keys(frontmatter).filter((k) => !META_KEYS.has(k));
     const block = body.match(/```base\n([\s\S]*?)```/);
     out2.push({
       type: type2,
       folder,
+      filingParent,
+      filingLoose,
+      folderNote,
       fields,
       frontmatter,
       relPath: `templates/${f}`,
@@ -2929,9 +2936,229 @@ function search(root, query, limit = 200) {
   return hits;
 }
 
-// core/vault/render.ts
+// core/vault/scaffold.ts
 var import_node_fs6 = __toESM(require("node:fs"));
 var import_node_path6 = __toESM(require("node:path"));
+var import_node_os = __toESM(require("node:os"));
+var TB = "`".repeat(3);
+var APP_JSON = JSON.stringify({ promptDelete: false, alwaysUpdateLinks: true }, null, 2);
+var PERSON_TPL = ["---", "type: person", "folder: people", "role:", "team:", "aliases: []", "---", ""].join("\n");
+var THEME_TPL = ["---", "type: theme", "folder: themes", "summary:", "---", ""].join("\n");
+var MILESTONE_TPL = [
+  "---",
+  "type: milestone",
+  "filingParent: initiative",
+  "filingLoose: true",
+  "initiative:",
+  "owner:",
+  "status: on-track",
+  "due:",
+  "---",
+  ""
+].join("\n");
+var MEETING_TPL = [
+  "---",
+  "type: meeting",
+  "filingParent: initiative",
+  "filingLoose: false",
+  "initiative:",
+  "date:",
+  "attendees: []",
+  "themes: []",
+  "---",
+  ""
+].join("\n");
+var INITIATIVE_TPL = [
+  "---",
+  "type: initiative",
+  "folder: initiatives",
+  "folderNote: true",
+  "owner:",
+  "status: active",
+  "due:",
+  "themes: []",
+  "---",
+  "",
+  "## Current state",
+  "",
+  "## Milestones",
+  "",
+  TB + "base",
+  "filters:",
+  "  and:",
+  '    - type == "milestone"',
+  "    - initiative == this",
+  "formulas:",
+  `  when: 'if(due, due.format("MMM D") + " \xB7 " + due.relative(), "\u2014 no due date \u2014")'`,
+  `  flag: 'if(status != "done" && due && due < today(), icon("alarm-clock"), "")'`,
+  "views:",
+  "  - type: table",
+  "    name: Milestones",
+  "    order:",
+  "      - file.name",
+  "      - status",
+  "      - owner",
+  "      - formula.when",
+  "      - formula.flag",
+  "    summaries:",
+  "      due: Earliest",
+  "      status: Filled",
+  TB,
+  ""
+].join("\n");
+var PROCESSING_BASE = [
+  "# The processing dashboard \u2014 each view is a work-list for the processing",
+  "# pass. One base, several lenses.",
+  "filters:",
+  "  and:",
+  '    - file.ext == "md"',
+  `    - '!file.inFolder("templates")'`,
+  '    - file.name != "README"',
+  "views:",
+  "  - type: table",
+  "    name: Stale inbox",
+  "    filters:",
+  "      and:",
+  '        - file.inFolder("inbox")',
+  `        - captured < today() - "1 week"`,
+  "    order:",
+  "      - file.name",
+  "      - captured",
+  "  - type: table",
+  "    name: Untyped notes",
+  "    filters:",
+  "      and:",
+  "        - not:",
+  '            - file.hasProperty("type")',
+  "        - not:",
+  '            - file.inFolder("inbox")',
+  "    order:",
+  "      - file.name",
+  "      - file.folder",
+  "  - type: table",
+  "    name: Milestones missing due",
+  "    filters:",
+  "      and:",
+  '        - type == "milestone"',
+  "        - not:",
+  '            - file.hasProperty("due")',
+  "    order:",
+  "      - file.name",
+  "      - initiative",
+  ""
+].join("\n");
+function readmeText(name) {
+  return [
+    `# ${name} \u2014 a Duo vault`,
+    "",
+    "A strict [Obsidian](https://obsidian.md) vault of work-notes: plain",
+    "markdown + `[[wikilinks]]` + YAML frontmatter + `.base` rollups. It opens",
+    "correctly in Obsidian proper at all times; Duo adds capture, search, and",
+    "an agent layer (linking, filing, rollups) on top. Managed via the `duo",
+    "vault` / `duo graph` / `duo base` CLI verbs and the vault skill.",
+    "",
+    "## Layout",
+    "",
+    "- `templates/` \u2014 soft schemas (one per type). The template declares the",
+    "  `type`, its filing rule, and the `fields` an entity of that type",
+    "  expects. **Query-excluded** (not entities).",
+    "- `inbox/` \u2014 atomic captures land here untyped; the processing pass files",
+    "  them.",
+    "- `people/`, `themes/` \u2014 registry folders for the parentless types.",
+    "- `initiatives/<name>/` \u2014 each initiative is a folder-note that owns a",
+    "  folder; its milestones/meetings file underneath it.",
+    "- `notes/` \u2014 time-bucketed residue (`notes/YYYY/MM/`) for parented notes",
+    "  whose parent is not yet known.",
+    "- `bases/` \u2014 vault-wide rollups (`processing.base` is the work-list",
+    "  dashboard).",
+    "- `out/` \u2014 rendered rollup artifacts (regenerable; safe to delete).",
+    "",
+    "## Filing rules (D19)",
+    "",
+    "Folder layout is ergonomics only \u2014 every query is frontmatter-driven, so",
+    "links are never lost when a note moves. Parentless types (person, theme)",
+    "file in their registry folder. Parented types (milestone, meeting)",
+    "designate one frontmatter attribute as the filing parent (e.g. milestone",
+    "\u2192 `initiative:`) and live under that parent. Only folder-note types",
+    "(initiative) can be parents.",
+    ""
+  ].join("\n");
+}
+function initVault(folder, opts = {}) {
+  const root = import_node_path6.default.resolve(folder);
+  if (isVaultRoot(root) && !opts.force) {
+    throw new Error(`${root} is already a vault (has .obsidian/). Pass --force to add missing scaffold files.`);
+  }
+  const created = [];
+  const warnings = [];
+  const mkdir = (rel) => {
+    const abs = import_node_path6.default.join(root, rel);
+    if (!import_node_fs6.default.existsSync(abs)) {
+      import_node_fs6.default.mkdirSync(abs, { recursive: true });
+      created.push(rel + "/");
+    }
+  };
+  const writeFile = (rel, content) => {
+    const abs = import_node_path6.default.join(root, rel);
+    if (import_node_fs6.default.existsSync(abs) && !opts.force) return;
+    import_node_fs6.default.mkdirSync(import_node_path6.default.dirname(abs), { recursive: true });
+    import_node_fs6.default.writeFileSync(abs, content);
+    created.push(rel);
+  };
+  for (const d of [".obsidian", "templates", "inbox", "people", "themes", "initiatives", "notes", "bases", "out"]) mkdir(d);
+  writeFile(".obsidian/app.json", APP_JSON + "\n");
+  writeFile("templates/person.md", PERSON_TPL);
+  writeFile("templates/theme.md", THEME_TPL);
+  writeFile("templates/initiative.md", INITIATIVE_TPL);
+  writeFile("templates/milestone.md", MILESTONE_TPL);
+  writeFile("templates/meeting.md", MEETING_TPL);
+  writeFile("bases/processing.base", PROCESSING_BASE);
+  writeFile("README.md", readmeText(import_node_path6.default.basename(root)));
+  const docs = import_node_path6.default.join(import_node_os.default.homedir(), "Documents");
+  if (root === docs || root.startsWith(docs + import_node_path6.default.sep)) {
+    warnings.push(
+      'This vault is under ~/Documents. If iCloud Drive "Optimize Mac Storage" is ON, macOS can evict note bytes to cloud-only under disk pressure. Consider a non-iCloud location, or disable Optimize Storage for reliable local access.'
+    );
+  }
+  return { root, created, warnings };
+}
+function pad(n) {
+  return String(n).padStart(2, "0");
+}
+function slugify(s) {
+  return s.trim().replace(/[\\/:*?"<>|]/g, "").replace(/\s+/g, " ").slice(0, 60);
+}
+function captureNote(root, opts = {}) {
+  const now = opts.date ?? /* @__PURE__ */ new Date();
+  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}${pad(now.getMinutes())}`;
+  const titlePart = opts.title ? " " + slugify(opts.title) : "";
+  const rel = import_node_path6.default.join("inbox", `${stamp}${titlePart}.md`);
+  const abs = import_node_path6.default.join(root, rel);
+  const fmLines = ["---", `captured: ${now.toISOString().slice(0, 10)}`];
+  let type2 = null;
+  if (opts.template) {
+    const tpl = loadTemplates(root).find((t) => t.type === opts.template);
+    if (!tpl) {
+      const known = loadTemplates(root).map((t) => t.type).join(", ");
+      throw new Error(`unknown template "${opts.template}" (known: ${known || "none"})`);
+    }
+    type2 = tpl.type;
+    fmLines.push(`type: ${tpl.type}`);
+    for (const field of tpl.fields) {
+      const def = tpl.frontmatter[field];
+      fmLines.push(`${field}:${Array.isArray(def) ? " []" : ""}`);
+    }
+  }
+  fmLines.push("---", "");
+  const body = opts.text ? opts.text + "\n" : "";
+  import_node_fs6.default.mkdirSync(import_node_path6.default.dirname(abs), { recursive: true });
+  import_node_fs6.default.writeFileSync(abs, fmLines.join("\n") + "\n" + body);
+  return { path: rel, absPath: abs, type: type2 };
+}
+
+// core/vault/render.ts
+var import_node_fs7 = __toESM(require("node:fs"));
+var import_node_path7 = __toESM(require("node:path"));
 var import_node_crypto = __toESM(require("node:crypto"));
 
 // core/vault/engine.ts
@@ -3378,17 +3605,17 @@ function sourceHash(root) {
     const dir = stack.pop();
     let entries;
     try {
-      entries = import_node_fs6.default.readdirSync(dir, { withFileTypes: true });
+      entries = import_node_fs7.default.readdirSync(dir, { withFileTypes: true });
     } catch {
       continue;
     }
     for (const e of entries) {
-      const full = import_node_path6.default.join(dir, e.name);
+      const full = import_node_path7.default.join(dir, e.name);
       if (e.isDirectory()) {
         if (!SKIP.has(e.name)) stack.push(full);
       } else if (e.name.endsWith(".md") || e.name.endsWith(".base")) {
         try {
-          all.push(import_node_fs6.default.readFileSync(full, "utf8"));
+          all.push(import_node_fs7.default.readFileSync(full, "utf8"));
         } catch {
         }
       }
@@ -3414,16 +3641,16 @@ function renderTarget(root, target, opts = {}) {
   const byName = new Map(files.map((f) => [f.name, f]));
   const bases = [];
   const sections = [];
-  const abs = import_node_path6.default.isAbsolute(target) ? target : import_node_path6.default.resolve(root, target);
+  const abs = import_node_path7.default.isAbsolute(target) ? target : import_node_path7.default.resolve(root, target);
   if (target.endsWith(".base")) {
-    const def = load(import_node_fs6.default.readFileSync(abs, "utf8"));
-    const label = import_node_path6.default.relative(root, abs).split(import_node_path6.default.sep).join("/");
+    const def = load(import_node_fs7.default.readFileSync(abs, "utf8"));
+    const label = import_node_path7.default.relative(root, abs).split(import_node_path7.default.sep).join("/");
     const evaluated = evaluateBaseDef(def, files, null, asOf);
     bases.push({ label, evaluated, thisFile: null });
     sections.push(renderBaseSection(evaluated, null, label, asOf));
   } else {
     let note;
-    if (import_node_fs6.default.existsSync(abs) && abs.endsWith(".md")) note = parseFile(abs, root);
+    if (import_node_fs7.default.existsSync(abs) && abs.endsWith(".md")) note = parseFile(abs, root);
     else note = notes.find((n) => n.basename === target.replace(/\.md$/, ""));
     if (!note) throw new Error(`render target not found: ${target} (expected a .base file or a note path/name)`);
     const thisFile = byName.get(note.basename) ?? null;
@@ -3509,8 +3736,8 @@ here. Re-render to refresh; the source hash above detects staleness.</footer>
 }
 
 // core/vault/lint.ts
-var import_node_fs7 = __toESM(require("node:fs"));
-var import_node_path7 = __toESM(require("node:path"));
+var import_node_fs8 = __toESM(require("node:fs"));
+var import_node_path8 = __toESM(require("node:path"));
 function lev(a, b) {
   const m = a.length;
   const n = b.length;
@@ -3661,10 +3888,10 @@ function lintVault(root, target) {
   const corpus = buildCorpus(root);
   const results = [];
   const lintBaseFile = (abs) => {
-    const rel = import_node_path7.default.relative(root, abs).split(import_node_path7.default.sep).join("/");
+    const rel = import_node_path8.default.relative(root, abs).split(import_node_path8.default.sep).join("/");
     let def;
     try {
-      def = load(import_node_fs7.default.readFileSync(abs, "utf8"));
+      def = load(import_node_fs8.default.readFileSync(abs, "utf8"));
     } catch (e) {
       results.push({ source: rel, findings: [], parseError: e instanceof Error ? e.message : String(e) });
       return;
@@ -3689,12 +3916,12 @@ function lintVault(root, target) {
     for (const abs of walk(root).filter((p) => p.endsWith(".base")).sort()) lintBaseFile(abs);
     for (const note of readNotes(root)) lintNoteEmbeds(note.relPath, note.basename, note.body);
   } else {
-    const abs = import_node_path7.default.isAbsolute(target) ? target : import_node_path7.default.resolve(root, target);
+    const abs = import_node_path8.default.isAbsolute(target) ? target : import_node_path8.default.resolve(root, target);
     if (target.endsWith(".base")) {
       lintBaseFile(abs);
     } else {
       const notes = readNotes(root);
-      const note = import_node_fs7.default.existsSync(abs) && abs.endsWith(".md") ? notes.find((n) => n.absPath === abs) : notes.find((n) => n.basename === target.replace(/\.md$/, ""));
+      const note = import_node_fs8.default.existsSync(abs) && abs.endsWith(".md") ? notes.find((n) => n.absPath === abs) : notes.find((n) => n.basename === target.replace(/\.md$/, ""));
       if (!note) throw new Error(`lint target not found: ${target} (expected --all, a .base file, or a note path/name)`);
       lintNoteEmbeds(note.relPath, note.basename, note.body);
     }
@@ -4116,8 +4343,8 @@ var VERBS = [
   {
     name: "vault",
     group: "Vault",
-    args: "<list|schema|search> [args]",
-    summary: "Work-notes vault (a strict Obsidian vault). list: vaults detected from the cwd (JSON). schema [--vault p]: the live corpus \u2014 types / entities / aliases / properties-per-type / observed enums, a pure function over frontmatter (the vault IS the schema; never cached). search <query> [--vault p]: full-text hits (file, line, excerpt) \u2014 the CLI twin of \u2318\u21E7F."
+    args: "<init|list|schema|capture|search> [args]",
+    summary: 'Work-notes vault (a strict Obsidian vault). init <folder> [--force]: scaffold .obsidian/ + starter templates (person/initiative/milestone/meeting/theme, with D19 filing rules) + inbox/ + bases/processing.base + README. list: vaults detected from the cwd (JSON). schema [--vault p]: the live corpus \u2014 types/entities/aliases/props-per-type/observed-enums, a pure function over frontmatter (the vault IS the schema; never cached). capture [--template t] [--text "\u2026"] [--title "\u2026"] [--open]: drop a timestamped inbox note (untyped by default; --template stamps a type). search <query> [--vault p]: full-text hits (file, line, excerpt) \u2014 the CLI twin of \u2318\u21E7F.'
   },
   {
     name: "graph",
@@ -4132,8 +4359,8 @@ var VERBS = [
     summary: "Obsidian Bases rollups. lint <file|--all> [--vault p]: validate a .base file (or a note's embedded ```base blocks, or every base with --all) against the live corpus \u2014 bad types / unresolved [[entities]] / off-enum values / unknown functions, each with a \"did you mean\" (JSON; warn-and-render, never blocks). render <file|note> [--out p] [--open]: evaluate filters/formulas over live frontmatter and emit a stamped Duo-owned HTML artifact (generated-at \xB7 source-hash \xB7 as-of). Default writes to the vault's out/; --out writes elsewhere; --open also opens it as a tab in the running app."
   }
 ];
-var SOCKET_PATH = process.env.DUO_SOCKET ?? path8.join(os.homedir(), "Library", "Application Support", "duo", "duo.sock");
-var PORT_FILE = process.env.DUO_PORT_FILE ?? path8.join(os.homedir(), "Library", "Application Support", "duo", "duo.port");
+var SOCKET_PATH = process.env.DUO_SOCKET ?? path9.join(os2.homedir(), "Library", "Application Support", "duo", "duo.sock");
+var PORT_FILE = process.env.DUO_PORT_FILE ?? path9.join(os2.homedir(), "Library", "Application Support", "duo", "duo.port");
 var windowOverride;
 function resolveWindowId() {
   if (windowOverride != null) return windowOverride;
@@ -4150,7 +4377,7 @@ var PER_CMD_TIMEOUT_MS = {
 };
 function readPortFile() {
   try {
-    const raw = fs8.readFileSync(PORT_FILE, "utf8");
+    const raw = fs9.readFileSync(PORT_FILE, "utf8");
     const parsed = JSON.parse(raw);
     if (typeof parsed.port === "number" && typeof parsed.token === "string") {
       return { port: parsed.port, token: parsed.token };
@@ -4216,7 +4443,7 @@ var FALLBACK_CONNECT_CODES = /* @__PURE__ */ new Set([
 ]);
 async function send(cmd, args = {}, opts = {}) {
   const timeoutMs = opts.timeoutMs ?? PER_CMD_TIMEOUT_MS[cmd] ?? TIMEOUT_MS;
-  if (process.env.DUO_TCP_ONLY !== "1" && fs8.existsSync(SOCKET_PATH)) {
+  if (process.env.DUO_TCP_ONLY !== "1" && fs9.existsSync(SOCKET_PATH)) {
     try {
       return await sendOver(
         () => ({ socket: net.createConnection(SOCKET_PATH) }),
@@ -4231,7 +4458,7 @@ async function send(cmd, args = {}, opts = {}) {
   }
   const portInfo = readPortFile();
   if (!portInfo) {
-    if (!fs8.existsSync(SOCKET_PATH)) {
+    if (!fs9.existsSync(SOCKET_PATH)) {
       die("Cannot connect: Duo app is not running.\nLaunch Duo.app first.");
     }
     die("Cannot connect: Unix socket failed and no TCP fallback available.\nRun `duo doctor` for details.");
@@ -4248,7 +4475,7 @@ async function send(cmd, args = {}, opts = {}) {
 }
 function sendStreamed(cmd, args, onAck, onEvent) {
   const factory = () => {
-    if (process.env.DUO_TCP_ONLY !== "1" && fs8.existsSync(SOCKET_PATH)) {
+    if (process.env.DUO_TCP_ONLY !== "1" && fs9.existsSync(SOCKET_PATH)) {
       return { socket: net.createConnection(SOCKET_PATH) };
     }
     const portInfo = readPortFile();
@@ -4552,8 +4779,8 @@ async function main() {
         const selector = selectorIdx !== -1 ? rest[selectorIdx + 1] : void 0;
         const b64 = await send("screenshot", { selector });
         if (outputPath) {
-          const abs = path8.resolve(outputPath);
-          fs8.writeFileSync(abs, Buffer.from(b64, "base64"));
+          const abs = path9.resolve(outputPath);
+          fs9.writeFileSync(abs, Buffer.from(b64, "base64"));
           out(`Saved to ${abs}`);
         } else {
           out(b64);
@@ -4768,7 +4995,7 @@ To confirm, re-run:
         if (sub === "open") {
           const p = rest[1];
           if (!p) die("Usage: duo split-view open <path>");
-          const resolved = path8.isAbsolute(p) ? p : path8.resolve(process.cwd(), p);
+          const resolved = path9.isAbsolute(p) ? p : path9.resolve(process.cwd(), p);
           out(await send("split-view", { op: "open", path: resolved }));
           break;
         }
@@ -4908,9 +5135,9 @@ To confirm, re-run:
           if (caseSensitive) payload["case-sensitive"] = true;
           out(await send("doc-find", payload));
         } else if (sub === "conflict-log") {
-          const logPath = path8.join(os.homedir(), ".claude", "duo", "logs", "last-conflict.log");
+          const logPath = path9.join(os2.homedir(), ".claude", "duo", "logs", "last-conflict.log");
           try {
-            const raw = fs8.readFileSync(logPath, "utf8");
+            const raw = fs9.readFileSync(logPath, "utf8");
             process.stdout.write(raw);
             if (!raw.endsWith("\n")) process.stdout.write("\n");
           } catch (err) {
@@ -5311,7 +5538,7 @@ To confirm, re-run:
           const resolvedPatch = resolveFilePath(patchPath);
           let mergeJson;
           try {
-            mergeJson = fs8.readFileSync(resolvedPatch, "utf8");
+            mergeJson = fs9.readFileSync(resolvedPatch, "utf8");
           } catch (err) {
             die(`Could not read patch file ${resolvedPatch}: ${err?.message ?? err}`);
           }
@@ -5400,18 +5627,18 @@ To confirm, re-run:
         }
         if (sub === "save") {
           const subRest = rest.slice(1);
-          const path9 = subRest.find((a) => !a.startsWith("-"));
+          const path10 = subRest.find((a) => !a.startsWith("-"));
           const name = flagValue(subRest, "--name");
           const saveAs = subRest.includes("--save-as");
           const payload = { op: "save" };
-          if (path9) payload.path = path9;
+          if (path10) payload.path = path10;
           if (name) payload.name = name;
           if (saveAs) payload["save-as"] = true;
           out(await send("workspace", payload));
         } else if (sub === "open") {
-          const path9 = rest[1];
-          if (!path9) die("Usage: duo workspace open <path>");
-          out(await send("workspace", { op: "open", path: path9 }));
+          const path10 = rest[1];
+          if (!path10) die("Usage: duo workspace open <path>");
+          out(await send("workspace", { op: "open", path: path10 }));
         } else if (sub === "list-recent") {
           out(await send("workspace", { op: "list-recent" }));
         } else if (sub === "current") {
@@ -5478,17 +5705,42 @@ To confirm, re-run:
         const sub = rest[0];
         const subRest = rest.slice(1);
         const vaultFlag = flagValue(subRest, "--vault");
-        if (sub === "list") {
+        if (sub === "init") {
+          const folder = positionalArgs(subRest, [])[0];
+          if (!folder) die("Usage: duo vault init <folder> [--force]");
+          const result = initVault(path9.resolve(process.cwd(), folder), { force: subRest.includes("--force") });
+          for (const w of result.warnings) process.stderr.write(`duo: warning \u2014 ${w}
+`);
+          out(result);
+        } else if (sub === "list") {
           out(listVaults(process.cwd()));
         } else if (sub === "schema") {
           out(buildCorpus(resolveVault(process.cwd(), vaultFlag)));
+        } else if (sub === "capture") {
+          const root = resolveVault(process.cwd(), vaultFlag);
+          const result = captureNote(root, {
+            template: flagValue(subRest, "--template"),
+            text: flagValue(subRest, "--text"),
+            title: flagValue(subRest, "--title")
+          });
+          let opened = null;
+          if (subRest.includes("--open")) {
+            try {
+              opened = await send("view", { path: result.absPath });
+            } catch (e) {
+              opened = { error: e instanceof Error ? e.message : String(e) };
+              process.stderr.write(`duo: captured ${result.path} but --open failed: ${opened.error}
+`);
+            }
+          }
+          out(subRest.includes("--open") ? { ...result, opened } : result);
         } else if (sub === "search") {
           const query = positionalArgs(subRest, ["--vault"])[0];
           if (!query) die("Usage: duo vault search <query> [--vault <path>]");
           out(search(resolveVault(process.cwd(), vaultFlag), query));
         } else {
           die(
-            "Usage: duo vault <list|schema|search> [args]\n  list                  vaults detected from the cwd (JSON)\n  schema [--vault p]    the L0 corpus (JSON)\n  search <query>        full-text hits (JSON)"
+            'Usage: duo vault <init|list|schema|capture|search> [args]\n  init <folder> [--force]   scaffold a new vault\n  list                      vaults detected from the cwd (JSON)\n  schema [--vault p]        the L0 corpus (JSON)\n  capture [--template t] [--text "\u2026"] [--title "\u2026"] [--open]   new inbox note\n  search <query>            full-text hits (JSON)'
           );
         }
         break;
@@ -5524,13 +5776,13 @@ To confirm, re-run:
           const result = renderTarget(root, target);
           const outFlag = flagValue(subRest, "--out");
           const open = subRest.includes("--open");
-          const stem = path8.basename(target).replace(/\.(base|md)$/i, "") || "rollup";
+          const stem = path9.basename(target).replace(/\.(base|md)$/i, "") || "rollup";
           let outPath;
-          if (outFlag) outPath = path8.resolve(process.cwd(), outFlag);
-          else if (open) outPath = path8.join(os.tmpdir(), `duo-rollup-${stem}-${Date.now()}.html`);
-          else outPath = path8.join(root, "out", `${stem}.html`);
-          fs8.mkdirSync(path8.dirname(outPath), { recursive: true });
-          fs8.writeFileSync(outPath, result.html);
+          if (outFlag) outPath = path9.resolve(process.cwd(), outFlag);
+          else if (open) outPath = path9.join(os2.tmpdir(), `duo-rollup-${stem}-${Date.now()}.html`);
+          else outPath = path9.join(root, "out", `${stem}.html`);
+          fs9.mkdirSync(path9.dirname(outPath), { recursive: true });
+          fs9.writeFileSync(outPath, result.html);
           let opened = null;
           if (open) {
             try {
@@ -5581,41 +5833,41 @@ function readStdin() {
 }
 function resolveFilePath(input) {
   if (input.startsWith("~/") || input === "~") {
-    return path8.resolve(input.replace(/^~/, os.homedir()));
+    return path9.resolve(input.replace(/^~/, os2.homedir()));
   }
-  if (path8.isAbsolute(input)) return input;
-  return path8.resolve(process.cwd(), input);
+  if (path9.isAbsolute(input)) return input;
+  return path9.resolve(process.cwd(), input);
 }
 function resolveOpenTarget(target) {
   if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return target;
   let absolute;
   if (target.startsWith("~/") || target === "~") {
-    absolute = path8.resolve(target.replace(/^~/, os.homedir()));
+    absolute = path9.resolve(target.replace(/^~/, os2.homedir()));
   } else {
-    absolute = path8.resolve(process.cwd(), target);
+    absolute = path9.resolve(process.cwd(), target);
   }
   const encoded = absolute.split("/").map((seg) => encodeURIComponent(seg).replace(/%2F/g, "/")).join("/");
   return "file://" + encoded;
 }
 function runInstall(opts = {}) {
-  const self = fs8.realpathSync(process.argv[1]);
+  const self = fs9.realpathSync(process.argv[1]);
   const targets = [];
   if (opts.system) {
     targets.push("/usr/local/bin/duo");
   } else {
-    targets.push(path8.join(os.homedir(), ".claude", "duo", "bin", "duo"));
-    targets.push(path8.join(os.homedir(), ".local", "bin", "duo"));
+    targets.push(path9.join(os2.homedir(), ".claude", "duo", "bin", "duo"));
+    targets.push(path9.join(os2.homedir(), ".local", "bin", "duo"));
   }
   for (const target of targets) {
     try {
-      fs8.mkdirSync(path8.dirname(target), { recursive: true });
+      fs9.mkdirSync(path9.dirname(target), { recursive: true });
       try {
-        fs8.unlinkSync(target);
+        fs9.unlinkSync(target);
       } catch {
       }
-      fs8.symlinkSync(self, target);
+      fs9.symlinkSync(self, target);
       out(`Installed: ${target} \u2192 ${self}`);
-      const dir = path8.dirname(target);
+      const dir = path9.dirname(target);
       const userPath = (process.env.PATH ?? "").split(":");
       if (!userPath.includes(dir)) {
         out("");
@@ -5641,7 +5893,7 @@ async function runDoctor() {
   let unixErr = null;
   let appVersion = null;
   let windowCount = null;
-  if (fs8.existsSync(SOCKET_PATH)) {
+  if (fs9.existsSync(SOCKET_PATH)) {
     try {
       const res = await probe(() => ({ socket: net.createConnection(SOCKET_PATH) }));
       unixOk = true;
@@ -5708,25 +5960,25 @@ async function runDoctor() {
   const cliPath = process.argv[1];
   let cliReal = null;
   try {
-    cliReal = fs8.realpathSync(cliPath);
+    cliReal = fs9.realpathSync(cliPath);
   } catch {
   }
   lines.push(`  CLI invoked as: ${cliPath}${cliReal && cliReal !== cliPath ? ` \u2192 ${cliReal}` : ""}`);
   const knownInstallTargets = [
     // ENH-141 — SHIM_DIR (auto-prepended to PTY $PATH; primary target).
-    path8.join(os.homedir(), ".claude", "duo", "bin", "duo"),
+    path9.join(os2.homedir(), ".claude", "duo", "bin", "duo"),
     // Pre-ENH-141 sandbox-writable target (still listed for diagnosing
     // stale installs — the dir was never on PATH so the symlink was
     // effectively dead).
-    path8.join(os.homedir(), ".claude", "bin", "duo"),
-    path8.join(os.homedir(), ".local", "bin", "duo"),
+    path9.join(os2.homedir(), ".claude", "bin", "duo"),
+    path9.join(os2.homedir(), ".local", "bin", "duo"),
     "/usr/local/bin/duo"
   ];
   for (const t of knownInstallTargets) {
-    if (!fs8.existsSync(t)) continue;
+    if (!fs9.existsSync(t)) continue;
     let real = null;
     try {
-      real = fs8.realpathSync(t);
+      real = fs9.realpathSync(t);
     } catch {
     }
     const matches = real && cliReal && real === cliReal;
@@ -5734,10 +5986,10 @@ async function runDoctor() {
   }
   lines.push("");
   lines.push("Skill");
-  const skillFile = path8.join(os.homedir(), ".claude", "skills", "duo", "SKILL.md");
-  const agentFile = path8.join(os.homedir(), ".claude", "agents", "duo.md");
-  lines.push(`  ${fs8.existsSync(skillFile) ? "\u2713" : "\u2717"} ${skillFile}`);
-  lines.push(`  ${fs8.existsSync(agentFile) ? "\u2713" : "\u2717"} ${agentFile}`);
+  const skillFile = path9.join(os2.homedir(), ".claude", "skills", "duo", "SKILL.md");
+  const agentFile = path9.join(os2.homedir(), ".claude", "agents", "duo.md");
+  lines.push(`  ${fs9.existsSync(skillFile) ? "\u2713" : "\u2717"} ${skillFile}`);
+  lines.push(`  ${fs9.existsSync(agentFile) ? "\u2713" : "\u2717"} ${agentFile}`);
   lines.push("");
   lines.push("Locale");
   const localeVars = ["LC_ALL", "LC_CTYPE", "LANG"];

--- a/cli/duo
+++ b/cli/duo
@@ -3087,7 +3087,9 @@ function readmeText(name) {
 function initVault(folder, opts = {}) {
   const root = import_node_path6.default.resolve(folder);
   if (isVaultRoot(root) && !opts.force) {
-    throw new Error(`${root} is already a vault (has .obsidian/). Pass --force to add missing scaffold files.`);
+    throw new Error(
+      `${root} is already a vault (has .obsidian/). Pass --force to (re)write the starter scaffold files \u2014 it overwrites edited starter templates / processing.base / README, but never touches your own notes.`
+    );
   }
   const created = [];
   const warnings = [];
@@ -3130,9 +3132,13 @@ function slugify(s) {
 }
 function captureNote(root, opts = {}) {
   const now = opts.date ?? /* @__PURE__ */ new Date();
-  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}${pad(now.getMinutes())}`;
+  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
   const titlePart = opts.title ? " " + slugify(opts.title) : "";
-  const rel = import_node_path6.default.join("inbox", `${stamp}${titlePart}.md`);
+  const base = `${stamp}${titlePart}`;
+  let rel = import_node_path6.default.join("inbox", `${base}.md`);
+  for (let n = 2; import_node_fs6.default.existsSync(import_node_path6.default.join(root, rel)); n++) {
+    rel = import_node_path6.default.join("inbox", `${base} ${n}.md`);
+  }
   const abs = import_node_path6.default.join(root, rel);
   const fmLines = ["---", `captured: ${now.toISOString().slice(0, 10)}`];
   let type2 = null;

--- a/cli/duo.ts
+++ b/cli/duo.ts
@@ -490,9 +490,9 @@ const VERBS: VerbSpec[] = [
   {
     name: 'vault',
     group: 'Vault',
-    args: '<list|schema|search> [args]',
+    args: '<init|list|schema|capture|search> [args]',
     summary:
-      'Work-notes vault (a strict Obsidian vault). list: vaults detected from the cwd (JSON). schema [--vault p]: the live corpus — types / entities / aliases / properties-per-type / observed enums, a pure function over frontmatter (the vault IS the schema; never cached). search <query> [--vault p]: full-text hits (file, line, excerpt) — the CLI twin of ⌘⇧F.'
+      'Work-notes vault (a strict Obsidian vault). init <folder> [--force]: scaffold .obsidian/ + starter templates (person/initiative/milestone/meeting/theme, with D19 filing rules) + inbox/ + bases/processing.base + README. list: vaults detected from the cwd (JSON). schema [--vault p]: the live corpus — types/entities/aliases/props-per-type/observed-enums, a pure function over frontmatter (the vault IS the schema; never cached). capture [--template t] [--text "…"] [--title "…"] [--open]: drop a timestamped inbox note (untyped by default; --template stamps a type). search <query> [--vault p]: full-text hits (file, line, excerpt) — the CLI twin of ⌘⇧F.'
   },
   {
     name: 'graph',
@@ -2339,21 +2339,47 @@ async function main(): Promise<void> {
         const sub = rest[0]
         const subRest = rest.slice(1)
         const vaultFlag = flagValue(subRest, '--vault')
-        if (sub === 'list') {
+        if (sub === 'init') {
+          const folder = positionalArgs(subRest, [])[0]
+          if (!folder) die('Usage: duo vault init <folder> [--force]')
+          const result = vault.initVault(path.resolve(process.cwd(), folder), { force: subRest.includes('--force') })
+          for (const w of result.warnings) process.stderr.write(`duo: warning — ${w}\n`)
+          out(result)
+        } else if (sub === 'list') {
           // Vaults detected from the cwd (enclosing + nested).
           out(vault.listVaults(process.cwd()))
         } else if (sub === 'schema') {
           out(vault.buildCorpus(vault.resolveVault(process.cwd(), vaultFlag)))
+        } else if (sub === 'capture') {
+          const root = vault.resolveVault(process.cwd(), vaultFlag)
+          const result = vault.captureNote(root, {
+            template: flagValue(subRest, '--template'),
+            text: flagValue(subRest, '--text'),
+            title: flagValue(subRest, '--title'),
+          })
+          let opened: unknown = null
+          if (subRest.includes('--open')) {
+            // Mirror the `view` verb — opens the .md in the working pane.
+            try {
+              opened = await send('view', { path: result.absPath })
+            } catch (e) {
+              opened = { error: e instanceof Error ? e.message : String(e) }
+              process.stderr.write(`duo: captured ${result.path} but --open failed: ${(opened as { error: unknown }).error}\n`)
+            }
+          }
+          out(subRest.includes('--open') ? { ...result, opened } : result)
         } else if (sub === 'search') {
           const query = positionalArgs(subRest, ['--vault'])[0]
           if (!query) die('Usage: duo vault search <query> [--vault <path>]')
           out(vault.search(vault.resolveVault(process.cwd(), vaultFlag), query))
         } else {
           die(
-            'Usage: duo vault <list|schema|search> [args]\n' +
-              '  list                  vaults detected from the cwd (JSON)\n' +
-              '  schema [--vault p]    the L0 corpus (JSON)\n' +
-              '  search <query>        full-text hits (JSON)',
+            'Usage: duo vault <init|list|schema|capture|search> [args]\n' +
+              '  init <folder> [--force]   scaffold a new vault\n' +
+              '  list                      vaults detected from the cwd (JSON)\n' +
+              '  schema [--vault p]        the L0 corpus (JSON)\n' +
+              '  capture [--template t] [--text "…"] [--title "…"] [--open]   new inbox note\n' +
+              '  search <query>            full-text hits (JSON)',
           )
         }
         break

--- a/core/vault/corpus.ts
+++ b/core/vault/corpus.ts
@@ -24,6 +24,8 @@ export function loadTemplates(root: string): TypeTemplate[] {
   } catch {
     return []
   }
+  // Meta keys configure the TYPE (kept out of an entity's `fields`).
+  const META_KEYS = new Set(['type', 'folder', 'filingParent', 'filingLoose', 'folderNote'])
   const out: TypeTemplate[] = []
   for (const f of entries.sort()) {
     const abs = path.join(dir, f)
@@ -31,13 +33,17 @@ export function loadTemplates(root: string): TypeTemplate[] {
     const { frontmatter, body } = splitFrontmatter(raw)
     const type = typeof frontmatter.type === 'string' ? frontmatter.type : path.basename(f, '.md')
     const folder = typeof frontmatter.folder === 'string' ? frontmatter.folder : null
-    // Expected fields = declared frontmatter keys other than the meta keys
-    // (`type`/`folder`), in declaration order.
-    const fields = Object.keys(frontmatter).filter((k) => k !== 'type' && k !== 'folder')
+    const filingParent = typeof frontmatter.filingParent === 'string' ? frontmatter.filingParent : null
+    const filingLoose = typeof frontmatter.filingLoose === 'boolean' ? frontmatter.filingLoose : null
+    const folderNote = frontmatter.folderNote === true
+    const fields = Object.keys(frontmatter).filter((k) => !META_KEYS.has(k))
     const block = body.match(/```base\n([\s\S]*?)```/)
     out.push({
       type,
       folder,
+      filingParent,
+      filingLoose,
+      folderNote,
       fields,
       frontmatter,
       relPath: `templates/${f}`,

--- a/core/vault/index.ts
+++ b/core/vault/index.ts
@@ -14,6 +14,7 @@ export { isVaultRoot, findVaultRoot, listVaults, resolveVault } from './detect'
 export { buildCorpus, loadTemplates, parseBaseYaml } from './corpus'
 export { backlinks, orphans, type Backlink } from './graph'
 export { search } from './search'
+export { initVault, captureNote, type InitResult, type CaptureResult } from './scaffold'
 export {
   renderTarget,
   evaluateBaseDef,

--- a/core/vault/scaffold.test.ts
+++ b/core/vault/scaffold.test.ts
@@ -1,0 +1,125 @@
+// ENH-208 Vault — write-verb tests (PR3): vault init scaffold + capture.
+// Each test inits into a throwaway tmpdir so nothing touches the repo.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { initVault, captureNote, isVaultRoot, buildCorpus, loadTemplates, lintVault, renderTarget } from './index'
+
+let root: string
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'duo-vault-init-'))
+})
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('vault init', () => {
+  it('scaffolds a recognizable vault with the starter set', () => {
+    const r = initVault(path.join(root, 'v'))
+    expect(isVaultRoot(r.root)).toBe(true)
+    for (const f of [
+      '.obsidian/app.json',
+      'templates/person.md',
+      'templates/initiative.md',
+      'templates/milestone.md',
+      'templates/meeting.md',
+      'templates/theme.md',
+      'bases/processing.base',
+      'README.md',
+    ]) {
+      expect(fs.existsSync(path.join(r.root, f))).toBe(true)
+    }
+    for (const d of ['inbox', 'people', 'themes', 'initiatives', 'notes', 'bases']) {
+      expect(fs.statSync(path.join(r.root, d)).isDirectory()).toBe(true)
+    }
+  })
+
+  it('refuses to clobber an existing vault unless --force', () => {
+    const v = path.join(root, 'v')
+    initVault(v)
+    expect(() => initVault(v)).toThrow(/already a vault/)
+    expect(() => initVault(v, { force: true })).not.toThrow()
+  })
+
+  it('templates carry D19 filing rules readable by the corpus', () => {
+    const v = initVault(path.join(root, 'v')).root
+    const templates = loadTemplates(v)
+    const initiative = templates.find((t) => t.type === 'initiative')!
+    expect(initiative.folder).toBe('initiatives')
+    expect(initiative.folderNote).toBe(true)
+    expect(initiative.embeddedBase).toContain('initiative == this')
+    const milestone = templates.find((t) => t.type === 'milestone')!
+    expect(milestone.filingParent).toBe('initiative')
+    expect(milestone.filingLoose).toBe(true)
+    expect(milestone.folder).toBeNull()
+    const person = templates.find((t) => t.type === 'person')!
+    expect(person.folder).toBe('people')
+    expect(person.filingParent).toBeNull()
+    // meta keys are NOT leaked into the entity field list
+    expect(initiative.fields).not.toContain('folderNote')
+    expect(milestone.fields).not.toContain('filingParent')
+  })
+
+  it('the scaffolded vault lints clean and yields a 5-type corpus', () => {
+    const v = initVault(path.join(root, 'v')).root
+    expect(buildCorpus(v).types).toEqual(['initiative', 'meeting', 'milestone', 'person', 'theme'])
+    const errors = lintVault(v, '--all').flatMap((r) => r.findings.filter((f) => f.severity === 'error'))
+    expect(errors).toEqual([])
+  })
+
+  it('warns when the vault lives under ~/Documents (iCloud-eviction trap)', () => {
+    // Simulate by initting under a path we control vs. the real ~/Documents
+    // — we just assert no spurious warning for a /tmp vault.
+    const r = initVault(path.join(root, 'v'))
+    expect(r.warnings).toEqual([])
+  })
+})
+
+describe('vault capture', () => {
+  it('drops an untyped, captured-stamped inbox note by default', () => {
+    const v = initVault(path.join(root, 'v')).root
+    const c = captureNote(v, { text: 'a quick thought', date: new Date('2026-06-09T14:32:00') })
+    expect(c.path).toMatch(/^inbox\/2026-06-09 1432\.md$/)
+    expect(c.type).toBeNull()
+    const content = fs.readFileSync(c.absPath, 'utf8')
+    expect(content).toContain('captured: 2026-06-09')
+    expect(content).not.toContain('type:')
+    expect(content).toContain('a quick thought')
+  })
+
+  it('stamps the type + expected fields when --template is given', () => {
+    const v = initVault(path.join(root, 'v')).root
+    const c = captureNote(v, { template: 'meeting', title: 'kickoff sync', date: new Date('2026-06-09T14:32:00') })
+    expect(c.type).toBe('meeting')
+    expect(c.path).toContain('kickoff sync')
+    const content = fs.readFileSync(c.absPath, 'utf8')
+    expect(content).toContain('type: meeting')
+    expect(content).toContain('attendees: []') // array field seeded empty
+    expect(content).toContain('initiative:')
+  })
+
+  it('throws a clear error for an unknown template', () => {
+    const v = initVault(path.join(root, 'v')).root
+    expect(() => captureNote(v, { template: 'nope' })).toThrow(/unknown template "nope"/)
+  })
+
+  it('end-to-end: a captured-then-filed note renders in its parent rollup', () => {
+    const v = initVault(path.join(root, 'v')).root
+    // Seed an initiative folder-note (with the embedded rollup) + a milestone.
+    const initDir = path.join(v, 'initiatives', 'Q4 Roadmap')
+    fs.mkdirSync(initDir, { recursive: true })
+    const tplBody = fs.readFileSync(path.join(v, 'templates', 'initiative.md'), 'utf8').split('---').slice(2).join('---')
+    fs.writeFileSync(
+      path.join(initDir, 'Q4 Roadmap.md'),
+      '---\ntype: initiative\nowner: "[[Dana Wu]]"\nstatus: active\n---\n' + tplBody,
+    )
+    fs.writeFileSync(
+      path.join(initDir, 'Draft deck.md'),
+      '---\ntype: milestone\ninitiative: "[[Q4 Roadmap]]"\nstatus: on-track\ndue: 2026-09-15\n---\n',
+    )
+    const r = renderTarget(v, 'Q4 Roadmap', { asOf: new Date('2026-06-09') })
+    expect(r.bases[0].evaluated.views[0].rows).toHaveLength(1)
+  })
+})

--- a/core/vault/scaffold.test.ts
+++ b/core/vault/scaffold.test.ts
@@ -80,8 +80,8 @@ describe('vault init', () => {
 describe('vault capture', () => {
   it('drops an untyped, captured-stamped inbox note by default', () => {
     const v = initVault(path.join(root, 'v')).root
-    const c = captureNote(v, { text: 'a quick thought', date: new Date('2026-06-09T14:32:00') })
-    expect(c.path).toMatch(/^inbox\/2026-06-09 1432\.md$/)
+    const c = captureNote(v, { text: 'a quick thought', date: new Date('2026-06-09T14:32:05') })
+    expect(c.path).toMatch(/^inbox\/2026-06-09 143205\.md$/)
     expect(c.type).toBeNull()
     const content = fs.readFileSync(c.absPath, 'utf8')
     expect(content).toContain('captured: 2026-06-09')
@@ -103,6 +103,21 @@ describe('vault capture', () => {
   it('throws a clear error for an unknown template', () => {
     const v = initVault(path.join(root, 'v')).root
     expect(() => captureNote(v, { template: 'nope' })).toThrow(/unknown template "nope"/)
+  })
+
+  it('never overwrites a same-second / same-title capture (collision guard)', () => {
+    const v = initVault(path.join(root, 'v')).root
+    const when = new Date('2026-06-09T14:32:05')
+    const a = captureNote(v, { text: 'FIRST', title: 'sync', date: when })
+    const b = captureNote(v, { text: 'SECOND', title: 'sync', date: when })
+    const c = captureNote(v, { text: 'THIRD', title: 'sync', date: when })
+    // three distinct files, all on disk, none clobbered
+    expect(new Set([a.path, b.path, c.path]).size).toBe(3)
+    expect(b.path).toMatch(/ 2\.md$/)
+    expect(c.path).toMatch(/ 3\.md$/)
+    expect(fs.readFileSync(a.absPath, 'utf8')).toContain('FIRST')
+    expect(fs.readFileSync(b.absPath, 'utf8')).toContain('SECOND')
+    expect(fs.readFileSync(c.absPath, 'utf8')).toContain('THIRD')
   })
 
   it('end-to-end: a captured-then-filed note renders in its parent rollup', () => {

--- a/core/vault/scaffold.ts
+++ b/core/vault/scaffold.ts
@@ -187,7 +187,11 @@ export interface InitResult {
 export function initVault(folder: string, opts: { force?: boolean } = {}): InitResult {
   const root = path.resolve(folder)
   if (isVaultRoot(root) && !opts.force) {
-    throw new Error(`${root} is already a vault (has .obsidian/). Pass --force to add missing scaffold files.`)
+    throw new Error(
+      `${root} is already a vault (has .obsidian/). Pass --force to (re)write the starter scaffold ` +
+        `files — it overwrites edited starter templates / processing.base / README, but never touches ` +
+        `your own notes.`,
+    )
   }
   const created: string[] = []
   const warnings: string[] = []
@@ -248,15 +252,25 @@ function slugify(s: string): string {
 
 /** Create an atomic inbox note (D6). Untyped by default; `--template <type>`
  *  stamps that type's frontmatter from the template registry. `text`
- *  becomes the body. The filename is timestamped so captures never collide. */
+ *  becomes the body. The filename is timestamped to the SECOND, and a
+ *  collision guard appends ` 2`, ` 3`, … if a note with the same stamp +
+ *  title already exists — so rapid same-second/same-title captures never
+ *  silently overwrite each other. */
 export function captureNote(
   root: string,
   opts: { template?: string; text?: string; title?: string; date?: Date } = {},
 ): CaptureResult {
   const now = opts.date ?? new Date()
-  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}${pad(now.getMinutes())}`
+  const stamp =
+    `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ` +
+    `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
   const titlePart = opts.title ? ' ' + slugify(opts.title) : ''
-  const rel = path.join('inbox', `${stamp}${titlePart}.md`)
+  const base = `${stamp}${titlePart}`
+  // Disambiguate against an existing file rather than clobbering it.
+  let rel = path.join('inbox', `${base}.md`)
+  for (let n = 2; fs.existsSync(path.join(root, rel)); n++) {
+    rel = path.join('inbox', `${base} ${n}.md`)
+  }
   const abs = path.join(root, rel)
 
   const fmLines: string[] = ['---', `captured: ${now.toISOString().slice(0, 10)}`]

--- a/core/vault/scaffold.ts
+++ b/core/vault/scaffold.ts
@@ -1,0 +1,283 @@
+// ENH-208 Vault — write verbs (PR3): `vault init` scaffolds a strict
+// Obsidian vault; `vault capture` drops a templated inbox note. Both are
+// pure fs operations (no socket). Starter file contents are embedded as
+// line arrays joined by '\n' — NOT one big template literal — so the
+// ```base fences inside the initiative template don't terminate a JS
+// backtick string (the no-backticks-in-template-literals trap).
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { isVaultRoot } from './detect'
+import { loadTemplates } from './corpus'
+
+const TB = '`'.repeat(3) // ``` — the markdown code fence
+
+// ── starter content ─────────────────────────────────────────────────────────
+
+const APP_JSON = JSON.stringify({ promptDelete: false, alwaysUpdateLinks: true }, null, 2)
+
+// Parentless types file in their registry folder (D19).
+const PERSON_TPL = ['---', 'type: person', 'folder: people', 'role:', 'team:', 'aliases: []', '---', ''].join('\n')
+
+const THEME_TPL = ['---', 'type: theme', 'folder: themes', 'summary:', '---', ''].join('\n')
+
+// Parented types designate ONE frontmatter attribute as the filing parent
+// (D19) and live under that parent's folder. milestone → loose; meeting →
+// in a `notes/` subfolder.
+const MILESTONE_TPL = [
+  '---',
+  'type: milestone',
+  'filingParent: initiative',
+  'filingLoose: true',
+  'initiative:',
+  'owner:',
+  'status: on-track',
+  'due:',
+  '---',
+  '',
+].join('\n')
+
+const MEETING_TPL = [
+  '---',
+  'type: meeting',
+  'filingParent: initiative',
+  'filingLoose: false',
+  'initiative:',
+  'date:',
+  'attendees: []',
+  'themes: []',
+  '---',
+  '',
+].join('\n')
+
+// Folder-note parent type (D19): owns a folder; carries the one-template
+// `initiative == this` milestone rollup (D8) so every initiative inherits it.
+const INITIATIVE_TPL = [
+  '---',
+  'type: initiative',
+  'folder: initiatives',
+  'folderNote: true',
+  'owner:',
+  'status: active',
+  'due:',
+  'themes: []',
+  '---',
+  '',
+  '## Current state',
+  '',
+  '## Milestones',
+  '',
+  TB + 'base',
+  'filters:',
+  '  and:',
+  '    - type == "milestone"',
+  '    - initiative == this',
+  'formulas:',
+  `  when: 'if(due, due.format("MMM D") + " · " + due.relative(), "— no due date —")'`,
+  `  flag: 'if(status != "done" && due && due < today(), icon("alarm-clock"), "")'`,
+  'views:',
+  '  - type: table',
+  '    name: Milestones',
+  '    order:',
+  '      - file.name',
+  '      - status',
+  '      - owner',
+  '      - formula.when',
+  '      - formula.flag',
+  '    summaries:',
+  '      due: Earliest',
+  '      status: Filled',
+  TB,
+  '',
+].join('\n')
+
+// The processing dashboard — every view is a work-list for the processing
+// pass (human or Claude). Templates + README are query-excluded.
+const PROCESSING_BASE = [
+  '# The processing dashboard — each view is a work-list for the processing',
+  '# pass. One base, several lenses.',
+  'filters:',
+  '  and:',
+  '    - file.ext == "md"',
+  `    - '!file.inFolder("templates")'`,
+  '    - file.name != "README"',
+  'views:',
+  '  - type: table',
+  '    name: Stale inbox',
+  '    filters:',
+  '      and:',
+  '        - file.inFolder("inbox")',
+  `        - captured < today() - "1 week"`,
+  '    order:',
+  '      - file.name',
+  '      - captured',
+  '  - type: table',
+  '    name: Untyped notes',
+  '    filters:',
+  '      and:',
+  '        - not:',
+  '            - file.hasProperty("type")',
+  '        - not:',
+  '            - file.inFolder("inbox")',
+  '    order:',
+  '      - file.name',
+  '      - file.folder',
+  '  - type: table',
+  '    name: Milestones missing due',
+  '    filters:',
+  '      and:',
+  '        - type == "milestone"',
+  '        - not:',
+  '            - file.hasProperty("due")',
+  '    order:',
+  '      - file.name',
+  '      - initiative',
+  '',
+].join('\n')
+
+function readmeText(name: string): string {
+  return [
+    `# ${name} — a Duo vault`,
+    '',
+    'A strict [Obsidian](https://obsidian.md) vault of work-notes: plain',
+    'markdown + `[[wikilinks]]` + YAML frontmatter + `.base` rollups. It opens',
+    'correctly in Obsidian proper at all times; Duo adds capture, search, and',
+    'an agent layer (linking, filing, rollups) on top. Managed via the `duo',
+    'vault` / `duo graph` / `duo base` CLI verbs and the vault skill.',
+    '',
+    '## Layout',
+    '',
+    '- `templates/` — soft schemas (one per type). The template declares the',
+    '  `type`, its filing rule, and the `fields` an entity of that type',
+    '  expects. **Query-excluded** (not entities).',
+    '- `inbox/` — atomic captures land here untyped; the processing pass files',
+    '  them.',
+    '- `people/`, `themes/` — registry folders for the parentless types.',
+    '- `initiatives/<name>/` — each initiative is a folder-note that owns a',
+    '  folder; its milestones/meetings file underneath it.',
+    '- `notes/` — time-bucketed residue (`notes/YYYY/MM/`) for parented notes',
+    '  whose parent is not yet known.',
+    '- `bases/` — vault-wide rollups (`processing.base` is the work-list',
+    '  dashboard).',
+    '- `out/` — rendered rollup artifacts (regenerable; safe to delete).',
+    '',
+    '## Filing rules (D19)',
+    '',
+    'Folder layout is ergonomics only — every query is frontmatter-driven, so',
+    'links are never lost when a note moves. Parentless types (person, theme)',
+    'file in their registry folder. Parented types (milestone, meeting)',
+    'designate one frontmatter attribute as the filing parent (e.g. milestone',
+    '→ `initiative:`) and live under that parent. Only folder-note types',
+    '(initiative) can be parents.',
+    '',
+  ].join('\n')
+}
+
+// ── vault init ──────────────────────────────────────────────────────────────
+
+export interface InitResult {
+  root: string
+  created: string[]
+  warnings: string[]
+}
+
+/** Scaffold a vault at `folder`. Refuses to clobber an existing vault
+ *  unless `force`. Returns created paths + any advisory warnings. */
+export function initVault(folder: string, opts: { force?: boolean } = {}): InitResult {
+  const root = path.resolve(folder)
+  if (isVaultRoot(root) && !opts.force) {
+    throw new Error(`${root} is already a vault (has .obsidian/). Pass --force to add missing scaffold files.`)
+  }
+  const created: string[] = []
+  const warnings: string[] = []
+
+  const mkdir = (rel: string) => {
+    const abs = path.join(root, rel)
+    if (!fs.existsSync(abs)) {
+      fs.mkdirSync(abs, { recursive: true })
+      created.push(rel + '/')
+    }
+  }
+  const writeFile = (rel: string, content: string) => {
+    const abs = path.join(root, rel)
+    if (fs.existsSync(abs) && !opts.force) return // never overwrite without --force
+    fs.mkdirSync(path.dirname(abs), { recursive: true })
+    fs.writeFileSync(abs, content)
+    created.push(rel)
+  }
+
+  for (const d of ['.obsidian', 'templates', 'inbox', 'people', 'themes', 'initiatives', 'notes', 'bases', 'out']) mkdir(d)
+
+  writeFile('.obsidian/app.json', APP_JSON + '\n')
+  writeFile('templates/person.md', PERSON_TPL)
+  writeFile('templates/theme.md', THEME_TPL)
+  writeFile('templates/initiative.md', INITIATIVE_TPL)
+  writeFile('templates/milestone.md', MILESTONE_TPL)
+  writeFile('templates/meeting.md', MEETING_TPL)
+  writeFile('bases/processing.base', PROCESSING_BASE)
+  writeFile('README.md', readmeText(path.basename(root)))
+
+  // iCloud-eviction trap (PRD risk): warn if the vault lives under
+  // ~/Documents (where macOS Optimize Storage can evict file bytes).
+  const docs = path.join(os.homedir(), 'Documents')
+  if (root === docs || root.startsWith(docs + path.sep)) {
+    warnings.push(
+      'This vault is under ~/Documents. If iCloud Drive "Optimize Mac Storage" is ON, ' +
+        'macOS can evict note bytes to cloud-only under disk pressure. Consider a non-iCloud location, ' +
+        'or disable Optimize Storage for reliable local access.',
+    )
+  }
+  return { root, created, warnings }
+}
+
+// ── vault capture ───────────────────────────────────────────────────────────
+
+export interface CaptureResult {
+  path: string
+  absPath: string
+  type: string | null
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+function slugify(s: string): string {
+  return s.trim().replace(/[\\/:*?"<>|]/g, '').replace(/\s+/g, ' ').slice(0, 60)
+}
+
+/** Create an atomic inbox note (D6). Untyped by default; `--template <type>`
+ *  stamps that type's frontmatter from the template registry. `text`
+ *  becomes the body. The filename is timestamped so captures never collide. */
+export function captureNote(
+  root: string,
+  opts: { template?: string; text?: string; title?: string; date?: Date } = {},
+): CaptureResult {
+  const now = opts.date ?? new Date()
+  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}${pad(now.getMinutes())}`
+  const titlePart = opts.title ? ' ' + slugify(opts.title) : ''
+  const rel = path.join('inbox', `${stamp}${titlePart}.md`)
+  const abs = path.join(root, rel)
+
+  const fmLines: string[] = ['---', `captured: ${now.toISOString().slice(0, 10)}`]
+  let type: string | null = null
+  if (opts.template) {
+    const tpl = loadTemplates(root).find((t) => t.type === opts.template)
+    if (!tpl) {
+      const known = loadTemplates(root).map((t) => t.type).join(', ')
+      throw new Error(`unknown template "${opts.template}" (known: ${known || 'none'})`)
+    }
+    type = tpl.type
+    fmLines.push(`type: ${tpl.type}`)
+    // Seed the type's expected fields empty so the user/processing fills them.
+    for (const field of tpl.fields) {
+      const def = tpl.frontmatter[field]
+      fmLines.push(`${field}:${Array.isArray(def) ? ' []' : ''}`)
+    }
+  }
+  fmLines.push('---', '')
+  const body = opts.text ? opts.text + '\n' : ''
+  fs.mkdirSync(path.dirname(abs), { recursive: true })
+  fs.writeFileSync(abs, fmLines.join('\n') + '\n' + body)
+  return { path: rel, absPath: abs, type }
+}

--- a/core/vault/types.ts
+++ b/core/vault/types.ts
@@ -35,14 +35,30 @@ export interface VaultFile {
   mtimeMs: number
 }
 
-/** A `templates/<type>.md` soft schema (D5). Templates are query-excluded:
- *  they declare what a type expects, they are not entities themselves. */
+/** A `templates/<type>.md` soft schema (D5) + filing rule (D19). Templates
+ *  are query-excluded: they declare what a type expects + where its entities
+ *  file, but are not entities themselves. The *meta* keys (`type`, `folder`,
+ *  `filingParent`, `filingLoose`, `folderNote`) configure the type; the
+ *  remaining keys are the entity's expected `fields`. */
 export interface TypeTemplate {
   /** The `type:` this template defines (also its filename stem). */
   type: string
-  /** Destination folder for entities of this type, when declared. */
+  /** For PARENTLESS types (person, theme): the type's registry folder
+   *  (`people`, `themes`). Null for parented types (D19). */
   folder: string | null
-  /** Expected field names (frontmatter keys minus the `type` marker). */
+  /** For PARENTED types (milestone, meeting): the frontmatter attribute
+   *  whose value is the filing parent — e.g. milestone → `"initiative"`,
+   *  so a milestone files under its initiative's folder (D19). Null for
+   *  parentless types. */
+  filingParent: string | null
+  /** For parented types: true → entities sit loose in the parent's folder;
+   *  false → in a per-type subfolder (e.g. `notes/`). Null when N/A. */
+  filingLoose: boolean | null
+  /** True for a folder-note type (initiative): its entity owns a folder
+   *  named after it, and ONLY folder-note types may be filing parents
+   *  (D19). */
+  folderNote: boolean
+  /** Expected entity field names (frontmatter keys minus the meta keys). */
   fields: string[]
   /** Full parsed template frontmatter (authoritative field defaults). */
   frontmatter: Record<string, unknown>

--- a/docs/CLI-COVERAGE.md
+++ b/docs/CLI-COVERAGE.md
@@ -205,15 +205,18 @@ shared with the renderer in Phase 3).
 
 | Verb | What it does | Output |
 |---|---|---|
+| `duo vault init <folder> [--force]` | Scaffold a vault: `.obsidian/` + starter templates (D19 filing rules) + inbox/registry folders + `bases/processing.base` + README | JSON `{root, created[], warnings[]}` |
 | `duo vault list` | Vaults detected from the cwd (enclosing + nested) | JSON `[{root, name, noteCount}]` |
 | `duo vault schema [--vault p]` | The L0 corpus — types/entities/aliases/props-per-type/observed-enums/templates; a live function over frontmatter, never cached (no-sidecar) | JSON `Corpus` |
+| `duo vault capture [--template t] [--text …] [--title …] [--open]` | Timestamped inbox note (D6); untyped by default, `--template` stamps a type | JSON `{path, absPath, type}` |
 | `duo vault search <query> [--vault p]` | Case-insensitive full-text search (CLI twin of ⌘⇧F, D22) | JSON `[{path, absPath, line, excerpt}]` |
 | `duo graph backlinks <note> [--vault p]` | Notes linking to `<note>` (basename-resolved, scans frontmatter + body) | JSON `[{path, absPath, line, excerpt}]` |
 | `duo graph orphans [--vault p]` | Notes with no inbound and no outbound links (a processing work-list) | JSON `string[]` |
+| `duo base lint <file\|--all> [--vault p]` | Validate a base against the corpus (bad types / unresolved `[[entities]]` / off-enum / unknown fns), each with a "did you mean"; advisory, never blocks (D15) | JSON `[{source, findings[]}]` |
+| `duo base render <file\|note> [--out p] [--open]` | Evaluate filters/formulas over live frontmatter → a stamped Duo-owned HTML artifact (D13/D16); `--open` surfaces it as a tab | JSON `{path, sourceHash, bases[]}` |
 
-Phase 1 still to land: `duo base lint` / `duo base render` (PR2),
-`duo vault init` / `duo vault capture` (PR3). Phase 2 adds `duo vault
-default` (the settings default-vault CLI twin).
+Phase 2 adds `duo vault default` (the settings default-vault CLI twin)
++ the capture chord (⇧⌘N), `@today` smart tokens, and ⌘⇧F vault search.
 
 ---
 

--- a/packs/duo-default/canvases/what-duo-does.html
+++ b/packs/duo-default/canvases/what-duo-does.html
@@ -951,6 +951,15 @@
 <h2 class="cat">Working in a vault</h2>
 <p class="cat-tagline">Keep networked work-notes — people, initiatives, themes, meetings — as plain markdown in a strict Obsidian vault. Duo reads the graph; Claude does the filing, linking, and rollups. (ENH-208 Phase 1 — agent + CLI first; capture UX is the fast-follow.)</p>
 
+<article class="item" data-keys="vault init capture inbox scaffold templates filing rules obsidian setup new note timestamped enh-208">
+  <div class="num">94</div>
+  <div>
+    <h3>Set up a vault and capture notes into it</h3>
+    <p class="why">Spin up a ready-to-use vault in one command — Claude scaffolds <code>.obsidian/</code>, starter templates for the everyday types (person, initiative, milestone, meeting, theme — each with its filing rule baked in), an <code>inbox/</code>, a processing dashboard, and a README. Then capture is friction-free: a thought becomes a timestamped note in the inbox (untyped by default — a later processing pass files and links it), or a templated note when you name the type. The whole thing is just files: it opens in Obsidian, syncs over git, and survives Duo entirely.</p>
+    <p class="how"><strong>CLI / agent</strong><code>duo vault init ~/work/notes</code> scaffolds it; <code>duo vault capture --text "note from the pricing sync…"</code> drops an inbox note (add <code>--template meeting</code> to stamp a type, <code>--open</code> to open it in the editor). In v1 you narrate to Claude and it captures + links for you; the ⇧⌘N quick-capture chord is the fast-follow.</p>
+  </div>
+</article>
+
 <article class="item" data-keys="vault obsidian work notes wikilinks frontmatter graph corpus schema entities types aliases enums enh-208">
   <div class="num">95</div>
   <div>

--- a/skill/references/cli-reference.md
+++ b/skill/references/cli-reference.md
@@ -202,8 +202,10 @@ A **vault** is a folder containing `.obsidian/` (a strict Obsidian vault: markdo
 
 | Command | What it does | Output |
 | --- | --- | --- |
+| `duo vault init <folder> [--force]` | Scaffold a new vault: `.obsidian/`, starter `templates/` (person / initiative / milestone / meeting / theme, each carrying its D19 filing rule), `inbox/`, registry + `notes/` folders, `bases/processing.base` (the work-list dashboard), and a README. Refuses to clobber an existing vault unless `--force`. Warns if the target is under `~/Documents` (iCloud-eviction trap). | JSON: `{ root, created[], warnings[] }` |
 | `duo vault list` | Vaults detected from the cwd (the enclosing vault plus any nested under it). | JSON: `[{ root, name, noteCount }]` |
 | `duo vault schema [--vault <path>]` | The **L0 corpus** — types, entities, aliases, properties-per-type, observed enum values, and the template registry. A pure function over frontmatter ("the vault IS the schema"); computed live, never cached to disk. Feed it to lint/processing as the resolution table. | JSON `Corpus` |
+| `duo vault capture [--template <type>] [--text "…"] [--title "…"] [--open] [--vault <path>]` | Drop an atomic, timestamped note into `inbox/` (D6 — processing files it later). Untyped by default (just a `captured:` stamp); `--template <type>` stamps that type's frontmatter + seeds its expected fields empty. `--text` becomes the body; `--title` adds a slug to the filename; `--open` opens it in the editor. | JSON: `{ path, absPath, type }` |
 | `duo vault search <query> [--vault <path>]` | Case-insensitive full-text search over the vault's notes (the CLI twin of the ⌘⇧F palette). | JSON: `[{ path, absPath, line, excerpt }]` |
 | `duo graph backlinks <note> [--vault <path>]` | Every occurrence that wikilinks to `<note>` (matched by basename, so links survive file moves), scanning frontmatter relationships as well as body links. | JSON: `[{ path, absPath, line, excerpt }]` |
 | `duo graph orphans [--vault <path>]` | Notes with no inbound **and** no outbound links — a processing work-list to link or archive. | JSON: `string[]` (rel paths) |


### PR DESCRIPTION
## ENH-208 Vault — Phase 1, PR3 of 4

The write verbs — stand up a real vault and capture into it.

### Verbs
- **`duo vault init <folder> [--force]`** — scaffold a strict Obsidian vault: `.obsidian/`, starter templates (person/initiative/milestone/meeting/theme), `inbox/` + registry folders (people, themes, initiatives, notes) + `bases/processing.base` (work-list dashboard) + README. Refuses to clobber an existing vault unless `--force`; warns when the target is under `~/Documents` (iCloud-eviction trap, a PRD risk).
- **`duo vault capture [--template t] [--text "…"] [--title "…"] [--open]`** — drop an atomic, timestamped inbox note (D6). Untyped by default (just a `captured:` stamp — processing types + files it later); `--template` stamps the type + seeds its fields; `--open` opens it in the editor (mirrors the `view` verb).

### D19 filing model, encoded in templates
Starter templates carry the filing rule as template **meta keys**: `folder` (parentless registry types), `filingParent` + `filingLoose` (parented types — milestone loose under its initiative, meeting in a subfolder), `folderNote` (initiative owns a folder and is the only valid filing parent). The corpus now parses these (kept **out** of an entity's `fields`) and exposes them on `TypeTemplate`, so the processing skill (PR4) can read the filing rules. The initiative template carries the one-template `initiative == this` rollup (D8).

### Verified end-to-end on a freshly-`init`'d vault (not just the prototype)
- `vault schema` → all 5 types with correct filing rules (initiative `folderNote`, milestone/meeting `filingParent: initiative`, person/theme registry folders)
- `vault capture --template meeting` → correctly-stamped inbox note (`captured` + `type` + seeded fields + body)
- `base lint --all` → clean
- a seeded initiative + milestone → the embedded `== this` rollup renders 1 scoped row

### Implementation note for the reviewer
Starter content is built as **line arrays joined by `\n`** — never one big backtick template literal — so the ` ```base ` fences inside the initiative template don't terminate a JS string (a known trap in this repo). The initiative template's embedded block was verified byte-correct.

### Verification
- `npm run typecheck` clean · `npx vitest run` **1160 passed** (9 new in `core/vault/scaffold.test.ts`) · `npm run check:skill-currency` 0 failures
- 4 doc surfaces updated (init/capture rows in cli-reference / agents / CLI-COVERAGE + a what-duo-does card)

### Reviewer notes
- `corpus.ts loadTemplates` change is backward-compatible: the prototype templates (no filing meta) still load fine — the PR2 base.test.ts on main is unaffected (1160 incl. it).
- `cli/duo` binary rebuilt + committed.
- Stack ahead: **PR4** — the "Working in a vault" skill section + the Vault Guide + vocabulary term (the last Phase-1 PR), then Phase 2 capture UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)