### PR TITLE
docs: ENH-208 sprint bookkeeping — Phase 1 shipped + Phase 2 started

### DIFF
--- a/docs/dev/RESUME.md
+++ b/docs/dev/RESUME.md
@@ -1,6 +1,22 @@
-# Resume after compaction — ENH-191 multi-window SHIPPED (v0.10.0); v0.10.1-dev in-flight
+# Resume after compaction — ENH-208 Vault: Phase 1 SHIPPED + Phase 2 in flight (v0.10.0 released)
 
-**🛑 READ FIRST — current state (2026-06-08):**
+**🛑 MOST RECENT — current initiative (2026-06-09): ENH-208 "vault".** Phase 1
+(skill-first slice) is **COMPLETE + on `main`** — the `duo vault` / `graph` /
+`base` CLI cluster, the `skill/references/vault.md` agent how-to, and the
+10-chapter Vault Guide (`docs/guide/vault-guide.html`) — PRs #83 #84 #85 #86.
+Phase 2 (capture UX) is **started**: #87 (`duo vault default` + default-vault
+pref) and #88 (the `@today` smart-token model + `duo vault stub` / D19 filing
+model) merged. **Remaining = renderer/keyboard UI** (Settings picker · ⇧⌘N chord ·
+⌘⇧F palette · `@today` AtMention wiring · silent-stub type-picker) — each needs a
+dev build + an **owner smoke-walk** per PR (NOT auto-mergeable); tasks #6–#10; the
+`enh-208-vault` worktree is parked for them. No version cut yet (owner holding for
+some UI, then likely v0.11.0). Full detail: top of `active-sprint.md` + the
+2026-06-09 `session-log.md` entry. PRD: `docs/prd/enh-208-vault.md`. The
+ENH-191 detail below remains valid history.
+
+---
+
+**🛑 PRIOR — ENH-191 multi-window SHIPPED (v0.10.0), current state (2026-06-08):**
 ENH-191 **multi-window is SHIPPED in v0.10.0** (tagged 2026-06-08, signed + notarized, 1119 tests green). Window 2 is **real and functional** — File → New Window (⌥⌘N) or `duo window new` opens a BLANK second window (does NOT clone window 1's pins — NFR-6.2). Each window owns its workspace/browser/navigator/terminals/geometry, all restored across relaunches (N-window restore, ascending-id). Gated by an **"Allow Multiple Windows"** setting (Settings menu), **default ON**; when OFF the New Window item is disabled, `duo window new` exits non-zero, and only window 1 restores. Cross-window CLI is live: every Duo terminal carries `DUO_WINDOW`; `duo --window N <verb>` addresses window N (stale id → primary fallback); `duo windows` lists `[{id, primary, focused, activeWorkspace}]`; `duo doctor` reports the live window count. Session file is now `{version:2, windows:[...]}` (lossless forward-migration + one-time `.v1.bak`; downgrade boots empty gracefully; byte-identical at N=1). Default app-level resolution is by IDENTITY (lowest-id primary), never focus.
 - **Also shipped v0.10.0:** **ENH-204** (#79) — a new terminal opened outside the focused project reverts the rail filter to "All". **ENH-207** (#81) — drag a navigator file/folder onto the terminal column inserts absolute POSIX-quoted path(s) at the cursor.
 - **Live follow-ups (next agent's queue):** **PR #80** (P1 per-request-window-target concurrency-interleaving test + 4 P3 edges), **FOLLOWUP-043** (drag onto a COLLAPSED rail spawns a tab instead of inserting), **BUG-198** (screenshot). Per-item detail in [`tasks.md`](../../tasks.md).

--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -1,4 +1,31 @@
-# Active sprint state — v0.10.0 SHIPPED (multi-window + ENH-204 + ENH-207) → carry-forward below
+# Active sprint state — ENH-208 Vault: Phase 1 SHIPPED + Phase 2 in flight (v0.10.0 carry-forward below)
+
+## ENH-208 Vault — Phase 1 SHIPPED, Phase 2 started (2026-06-09)
+
+> **CURRENT (2026-06-09):** **ENH-208 "vault"** (networked work-notes on plain
+> Obsidian conventions) — **Phase 1 is complete + on `main`** (PRs **#83 #84 #85
+> #86**): the full `duo vault` / `graph` / `base` CLI cluster, the
+> `skill/references/vault.md` agent how-to, and the 10-chapter Vault Guide
+> (`docs/guide/vault-guide.html`). **Phase 2 (capture UX) started** — **#87**
+> (`duo vault default` + default-vault pref) and **#88** (the `@today` smart-token
+> model + `duo vault stub` / D19 filing model) merged. Each PR was built on the
+> `enh-208-vault` worktree and **merged by a reviewer agent on main** (no self-
+> merge); the reviewer caught two real bugs (the `base render --open` IPC key, and
+> silent same-minute capture overwrite) before merge. 1189 tests green.
+>
+> **NEXT — the remaining Phase-2 work is all renderer/keyboard UI** (needs a dev
+> build + an **owner smoke-walk** per PR; NOT auto-mergeable): the Settings
+> default-vault **picker**, the **⇧⌘N** capture chord, the **⌘⇧F** vault-search
+> palette (clones the ⌘⇧A TabSearchPalette wiring), wiring the `@today` tokens
+> into the AtMention popover, and the silent-stub **type-picker**
+> (`WikilinkSuggestion`/`wikilinkCreate`). Tracked as tasks #6–#10; the model
+> layers they sit on are already merged (#88). **No version cut yet** — owner is
+> holding until some capture-UX UI lands, then one release (likely v0.11.0). PRD:
+> `docs/prd/enh-208-vault.md`. The `enh-208-vault` worktree is parked for the UI.
+>
+> **Owner note:** verifying the UI needs a worktree dev build, which means closing
+> the running packaged Duo — coordinate before taking it (another agent may be
+> using it).
 
 ## v0.10.0 SHIPPED (2026-06-08) — multi-window window-2 real, signed DMG + GitHub Release
 

--- a/docs/dev/session-log.md
+++ b/docs/dev/session-log.md
@@ -18,6 +18,54 @@
 
 ---
 
+## 2026-06-09 (ENH-208 Vault — Phase 1 SHIPPED + Phase 2 started, 6 PRs merged to main)
+
+**ENH-208 "vault" — networked work-notes on plain Obsidian conventions.** Built
+on a dedicated worktree (`.claude/worktrees/enh-208-vault`), delivered as a stack
+of small PRs each opened to `main` and **merged by a separate reviewer agent on
+main** (the author never self-merged). The reviewer re-ran every check in an
+isolated worktree and **caught two real bugs** that would otherwise have shipped.
+
+**Phase 1 (skill-first, zero new UI) — COMPLETE:**
+- **#83** — `core/vault/` (pure, fs-backed, no Electron deps; bundles into the CLI
+  *and* runs under vitest; shared with the renderer in Phase 3) + read verbs:
+  `duo vault list/schema/search`, `duo graph backlinks/orphans`. The L0 corpus is
+  a live function over frontmatter ("the vault IS the schema"), never cached.
+  Correctness fix over the loose prototype: `templates/` is query-excluded (D5).
+- **#84** — `duo base lint` + `duo base render` (the Obsidian Bases engine ported
+  to typed modules; the locked subset — `if()`, link `== this`, date math,
+  `html()`/`icon()`, `groupBy`, summaries, child→parent backlink rollups; warn-
+  and-render, D15). Renders are stamped build artifacts (D13/D16). *Reviewer
+  caught:* `base render --open` sent the wrong IPC key (`path` vs `url`) → fixed +
+  verified live before merge.
+- **#85** — `duo vault init` (scaffold + starter templates encoding the D19 filing
+  rules) + `duo vault capture`. *Reviewer caught:* minute-granular capture
+  filenames silently overwrote same-minute notes → second-precision + collision
+  guard + regression test before merge.
+- **#86** — the vault skill (`skill/references/vault.md`) + the owner-mandated
+  10-chapter **Vault Guide** (`docs/guide/vault-guide.html`, Atelier-styled, actor
+  lifecycle lanes + flow/rollup mocks) + the "vault" vocabulary term. A 4-lens
+  workflow review (accuracy-vs-shipped-code / PRD §6 completeness / HTML / voice)
+  found 0 blockers; nits folded.
+
+**Phase 2 (capture UX) — STARTED (headless slices only; UI is owner-smoke-walk-gated):**
+- **#87** — `duo vault default` + the default-vault pref (`~/.claude/duo/vault.json`,
+  read by CLI + main). Every vault verb now resolves `--vault` → enclosing vault →
+  default → error, so they run from outside any vault. Stale pointer self-heals.
+- **#88** — the two Phase-2 model layers: `renderer/.../smartTokens.ts` (the
+  `@today` date-token registry, D21 — pure, no UI consumer yet) and
+  `core/vault/filing.ts` (D19 stub paths) exposed as `duo vault stub <type>
+  <name>` (the CLI twin of the silent-stub `[[New Name]]`⇥ gesture; idempotent).
+
+**Still owed (all renderer/keyboard UI — needs a dev build + an owner smoke-walk,
+so NOT auto-mergeable):** the Settings default-vault **picker**, the **⇧⌘N**
+capture chord, the **⌘⇧F** vault-search palette, wiring `@today` into the
+AtMention popover, and the silent-stub **type-picker**. Tracked tasks #6–#10.
+The `enh-208-vault` worktree is parked for them. **No version cut yet** (owner:
+hold until some capture-UX UI lands, then cut one release — likely v0.11.0). 1189
+tests green at Phase-2-models. The ENH-208 PRD is `docs/prd/enh-208-vault.md`; the
+agent how-to is `skill/references/vault.md`.
+
 ## 2026-06-08 (v0.10.0 cut — Multi-window: a real second window · ENH-204 revert-to-All · ENH-207 drag-path)
 
 Cut **v0.10.0** — the multi-window payoff. Merged the two clean all-dark interims (PR #78 P4 session-envelope, PR #73 P5a/P5b window-2 machinery — adversarially reviewed: grep-verified zero residual fail-loud resolution points, 1093 tests, 8/8 smoke), then two standalone navigator/terminal UX features cut from parallel-agent PRs: **#79 ENH-204** (a new terminal opened outside the focused project reverts to "All" — extracted+tested `newTerminalMembershipsSince`, owner-waived smoke) and **#81 ENH-207** (drag a navigator file/folder into the terminal to insert its path — control-char-stripped + shell-quoted + newline-free; renumbered from a colliding ENH-204). Resolved the `tasks.md` top-insertion conflicts across both PRs (twice for #81, after #79 landed first); each merge typecheck-verified. Cut: signed + notarized DMG + GitHub Release. Bumped to v0.10.1. Open follow-ups (filed PR #80): per-request-window-target concurrency hardening (P1) + 4 P3 multi-window edges. Carried known issues: FOLLOWUP-043 (drag onto a collapsed rail), the v2-format downgrade caveat, BUG-198 (`duo screenshot` timeout).


### PR DESCRIPTION
Flips the stale sprint docs to reflect ENH-208 (they still read "ENH-191 v0.10.0 → carry-forward"). The owner flagged this as a loose end.

- **session-log.md** — a 2026-06-09 entry covering the 6-PR vault delivery (#83–#88), the worktree + reviewer-agent-merge model, the two real bugs the reviewer caught, and the owed renderer-UI work.
- **active-sprint.md** — new header + current-state block: Phase 1 shipped, Phase 2 started, the smoke-walk-gated UI queue, no-cut-yet, the coordinate-before-taking-the-app note.
- **RESUME.md** — a MOST-RECENT banner so a cold-start lands on ENH-208; the ENH-191 detail stays below as history.

**Deliberately does NOT touch `tasks.md`** — it has uncommitted owner edits on the main checkout, so the owner should fold the ENH-208 status flip into those.

Docs-only; no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)