### PR TITLE
fix: collapsing the terminal pane no longer kills all sessions (BUG-200)

### DIFF
--- a/core/constants.ts
+++ b/core/constants.ts
@@ -51,3 +51,15 @@ export const TERMINAL_DEFAULTS = {
   rows: 24,
   scrollback: 10_000
 }
+
+// BUG-200 (2026-06-10) — the smallest column count PtyManager.resize will
+// forward to a live PTY. The terminal-pane collapse fix hides the xterm host
+// via display:none (a true 0×0 box, already caught by the BUG-156 guard), but
+// this floors cols as defense-in-depth against any future hide that merely
+// clips the host to a narrow strip (e.g. the 36px collapse rail) instead of
+// zeroing it: a ~4-col fit would otherwise reflow the live Claude TUI. The
+// floor sits safely between that artifact (~4–7 cols) and any real terminal
+// (≥~12 cols even at the 900px window minWidth / 20% min split). Rows are NOT
+// floored — a legitimately short terminal (small window height) is plausible;
+// a 4-col-wide one never is.
+export const TERMINAL_MIN_COLS = 8

--- a/core/pty-manager.test.ts
+++ b/core/pty-manager.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi } from 'vitest'
 // vi.hoisted so the (hoisted) mock factory shares the capture array with tests.
 const h = vi.hoisted(() => ({
   calls: [] as Array<{ shell: string; opts: { env: Record<string, string> } }>,
+  resizes: [] as Array<{ cols: number; rows: number }>,
 }))
 vi.mock('node-pty', () => ({
   spawn: (shell: string, _args: string[], opts: { env: Record<string, string> }) => {
@@ -17,7 +18,7 @@ vi.mock('node-pty', () => ({
       onData: () => {},
       onExit: () => {},
       write: () => {},
-      resize: () => {},
+      resize: (cols: number, rows: number) => { h.resizes.push({ cols, rows }) },
       kill: () => {},
       pid: 4242,
     }
@@ -25,6 +26,7 @@ vi.mock('node-pty', () => ({
 }))
 
 import { PtyManager } from './pty-manager'
+import { TERMINAL_MIN_COLS } from './constants'
 
 describe('PtyManager — dormant DUO_WINDOW env stamp (ENH-191 P3-S4)', () => {
   it('stamps DUO_WINDOW with the owner window id (+ keeps DUO_SESSION)', () => {
@@ -44,5 +46,38 @@ describe('PtyManager — dormant DUO_WINDOW env stamp (ENH-191 P3-S4)', () => {
     const mgr = new PtyManager('9.9.9')
     mgr.create('t2', '/bin/zsh', '/tmp', 13)
     expect(h.calls[0].opts.env.DUO_WINDOW).toBe('13')
+  })
+})
+
+describe('PtyManager.resize — size guards (BUG-156 + BUG-200)', () => {
+  it('forwards a normal resize to the PTY', () => {
+    h.resizes.length = 0
+    const mgr = new PtyManager('9.9.9')
+    mgr.create('r1', '/bin/zsh', '/tmp')
+    mgr.resize('r1', 80, 24)
+    expect(h.resizes).toEqual([{ cols: 80, rows: 24 }])
+  })
+
+  it('drops a 0×0 / negative resize (BUG-156 SIGHUP guard)', () => {
+    h.resizes.length = 0
+    const mgr = new PtyManager('9.9.9')
+    mgr.create('r2', '/bin/zsh', '/tmp')
+    mgr.resize('r2', 0, 0)
+    mgr.resize('r2', 80, 0)
+    mgr.resize('r2', -5, 24)
+    expect(h.resizes).toEqual([])
+  })
+
+  it('drops a sub-floor cols resize so a clipped/collapsed host cannot reflow the live PTY (BUG-200)', () => {
+    h.resizes.length = 0
+    const mgr = new PtyManager('9.9.9')
+    mgr.create('r3', '/bin/zsh', '/tmp')
+    // ~4-col fit produced by a 36px rail-clipped host — must NOT reach the PTY.
+    mgr.resize('r3', 4, 30)
+    mgr.resize('r3', TERMINAL_MIN_COLS - 1, 30)
+    expect(h.resizes).toEqual([])
+    // At/above the floor a real resize still goes through.
+    mgr.resize('r3', TERMINAL_MIN_COLS, 30)
+    expect(h.resizes).toEqual([{ cols: TERMINAL_MIN_COLS, rows: 30 }])
   })
 })

--- a/core/pty-manager.ts
+++ b/core/pty-manager.ts
@@ -1,5 +1,5 @@
 import * as pty from 'node-pty'
-import { DEFAULT_SHELL, DEFAULT_CWD, TERMINAL_DEFAULTS, SOCKET_PATH, SHIM_DIR } from './constants'
+import { DEFAULT_SHELL, DEFAULT_CWD, TERMINAL_DEFAULTS, TERMINAL_MIN_COLS, SOCKET_PATH, SHIM_DIR } from './constants'
 import { resolveExistingCwd } from './cwd-utils'
 import { IPC } from '../shared/types'
 import { routeSend, disposeForWindow as disposeSessionsForWindow, listIdsByCwdOwned } from './pty-owner'
@@ -169,7 +169,15 @@ export class PtyManager {
     // during SessionHeader layout reflow; the ResizeObserver
     // path didn't have a size guard. Defense-in-depth: guard the
     // renderer call sites AND this main-side entry point.
-    if (cols < 1 || rows < 1) return
+    //
+    // BUG-200 (2026-06-10) — floor cols at TERMINAL_MIN_COLS too. The
+    // terminal-collapse fix hides the xterm host via display:none (0×0,
+    // caught above), but as a backstop against a future hide that clips
+    // the host to a narrow strip (the 36px collapse rail) instead of
+    // zeroing it: a ~4-col fit would reflow the live TUI. See the
+    // TERMINAL_MIN_COLS constant for why the floor is safe. Rows keep
+    // only the < 1 guard (a short terminal is legitimate).
+    if (cols < TERMINAL_MIN_COLS || rows < 1) return
     this.sessions.get(id)?.pty.resize(cols, rows)
   }
 

--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -1,5 +1,21 @@
 # Active sprint state — ENH-208 Vault: Phase 1 SHIPPED + Phase 2 in flight (v0.10.0 carry-forward below)
 
+## BUG-200 — terminal-collapse data-loss fix (in flight, this branch, 2026-06-10)
+
+> **Owner-initiated, parallel to ENH-208.** Collapsing the terminal pane was
+> terminating ALL shell / live-Claude sessions (it UNMOUNTED the pane, and
+> `TerminalInstance`'s cleanup unconditionally `pty.kill`s). Root-caused via a
+> multi-agent investigation (4 readers → synthesis → 3 adversarial verifiers).
+> **Surgical fix implemented on `claude/practical-jones-a07605`:** collapse now
+> hides the pane via a true `display:none` (kept mounted) instead of unmounting,
+> plus a `TERMINAL_MIN_COLS` floor in `PtyManager.resize` as a reflow backstop;
+> 3 new pty-manager tests, typecheck clean. **Owner decision (2026-06-10):** ship
+> option (a) surgical now; the robust decouple-kill-from-unmount is deferred to
+> **ENH-209**. Discovered the canvas pane shares the same unmount pattern →
+> **FOLLOWUP-044**. **Owed:** owner smoke-walk (needs a dev build of THIS
+> worktree — the currently-running dev is the `enh-208-vault` worktree) → then a
+> cut. Full writeup: `tasks.md` BUG-200.
+
 ## ENH-208 Vault — Phase 1 SHIPPED, Phase 2 started (2026-06-09)
 
 > **CURRENT (2026-06-09):** **ENH-208 "vault"** (networked work-notes on plain

--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -4259,13 +4259,31 @@ export function App() {
             }}
             aria-label="Terminal column"
           >
-            {isTerminalCollapsed ? (
+            {/* BUG-200 (2026-06-10) — collapse must HIDE, not UNMOUNT, the
+                terminal column. The prior ternary swapped this whole subtree
+                for the rail, which unmounted every TerminalInstance and fired
+                its cleanup pty.kill — terminating EVERY shell on collapse
+                (TerminalPane gets the full `tabs` array, so all sessions died,
+                not just the active one). Now the rail renders as a sibling and
+                the TabBar + TerminalPane stay mounted under a display:none
+                wrapper, so PTYs + scrollback survive collapse/expand. The hide
+                MUST be a true display:none (zero box), NOT the 36px column
+                clip: xterm's resize guards key off zero size, so a clipped
+                (non-zero) host would let the ResizeObserver fit to ~4 cols and
+                reflow the live PTY (BUG-156 class — PtyManager.resize now also
+                floors cols as a backstop). On expand the host regains size and
+                the ResizeObserver refits. Robust decouple-kill-from-unmount is
+                tracked as ENH-209. */}
+            {isTerminalCollapsed && (
               <CollapsedPaneRail
                 kind="terminal"
                 onExpand={toggleCollapseTerminal}
               />
-            ) : (
-              <>
+            )}
+            <div
+              className="flex flex-col flex-1 min-h-0 overflow-hidden"
+              style={{ display: isTerminalCollapsed ? 'none' : 'flex' }}
+            >
                 <TabBar
                   // ENH-182 Phase 2 — only render visible (= focused-
                   // project member) tabs in the strip. The full `tabs`
@@ -4325,8 +4343,7 @@ export function App() {
                     onTerminalFocus={() => setFocusedColumnSilent('terminal')}
                   />
                 </div>
-              </>
-            )}
+            </div>
           </div>
 
           <div

--- a/tasks.md
+++ b/tasks.md
@@ -3,6 +3,73 @@
 > **Scope.** Engineering ledger — open work + root-cause writeups for closed bugs. **Canonical version-by-version inventory lives in [CHANGELOG.md](CHANGELOG.md)** and the prose log in docs/RELEASES.md; this file is the running notebook with the "why did this break, what did we learn" detail those don't carry. \*\***Reading guide.** Status field on each entry: `🆕 Filed` / `🟡` / `⏳ Open` (active work) vs. `✅ Shipped vX.Y.Z` (closed; kept for historical reference). To find what's actively open at a glance: `grep -B1 "Status:\*\* (🆕\|🟡\|⏳)"`. \*\***Closed-work archive (ENH-191 / D1, 2026-05-31).** Closed entries (✅ shipped · ❌ won't-do · 🟢 done) now live in [tasks-archive.md](tasks-archive.md) — this file had grown to an 11k-line / 1.2 MB monolith (Duo's own editor worst-case). The cut-version skill moves newly-closed entries to the archive on each cut so this stays lean. \*\***Status legend.** OPEN (stay here): 🆕 filed · 🟡 awaiting-decision · ⏳ open · 🚧 in-progress · 🔴 blocker · ⬜ draft · ⚠️ / 🔵 see entry. CLOSED (archived): ✅ shipped · ❌ won't-do · 🟢 done.
 
 
+### BUG-200: Collapsing the terminal pane terminates ALL terminal sessions
+
+**Status:** 🚧 In progress — surgical fix implemented + **live-verified** on `claude/practical-jones-a07605` (this branch); awaiting owner smoke-walk + cut. **Priority:** P0 (data loss — kills running shells / live Claude sessions). **Effort:** S (surgical) · robust hardening split to ENH-209.
+
+**Symptom (owner report, 2026-06-10).** Collapsing the terminal pane (the collapse control, or `duo split 0`) appears to terminate every terminal session rather than hide it. Expanding spawns fresh shells; the prior processes, scrollback, and any running Claude sessions are gone.
+
+**Root cause (multi-agent code investigation + 3 adversarial verifiers, confidence high).** Collapse UNMOUNTED the terminal subtree instead of hiding it, and `TerminalInstance`'s mount-effect cleanup unconditionally kills its PTY:
+1. Collapse sets `splitPct → 0` (`App.tsx` `toggleCollapseTerminal`); `isTerminalCollapsed = splitPct === 0`.
+2. The render ternary swapped the entire `<TabBar/> + <TerminalPane/>` subtree for `<CollapsedPaneRail/>` — a real React unmount.
+3. `TerminalPane` receives the FULL `tabs` array, so the unmount tears down EVERY `<TerminalInstance>`, not just the active one — this is why ALL sessions die.
+4. Each instance's `useEffect` cleanup calls `window.electron.pty.kill(tab.id)` with no collapse-vs-close guard → `PTY_KILL` IPC → `PtyManager.kill()` → node-pty `IPty.kill()` + session delete. Permanent; no detach path exists.
+5. On expand, the remount calls `pty.create()` → a brand-new shell in the tab's launch cwd.
+
+Violated the in-code contract at `TerminalPane.tsx` ("hidden — not unmounted — when inactive so the PTY session and scroll buffer survive"); tab-switching already honored it via `display:none`, collapse did not. Note `closeTab` itself never calls `pty.kill` — the unmount cleanup is the SOLE kill path, which is exactly why it couldn't distinguish "collapse" from "close."
+
+**Fix (this branch — option (a), surgical).**
+- `renderer/App.tsx` — stop swapping the subtree. Render `CollapsedPaneRail` as a sibling; keep `TabBar + TerminalPane` mounted under a wrapper hidden with a TRUE `display:none` when collapsed (zero box), so PTYs + scrollback survive. On expand the host regains size and the existing `ResizeObserver` refits.
+- `core/pty-manager.ts` + `core/constants.ts` — `PtyManager.resize` now floors cols at `TERMINAL_MIN_COLS` (8) as a backstop so even a future hide that clips the host to a narrow strip (vs zeroing it) can't fit to ~4 cols and reflow the live TUI (the BUG-156 reflow class). Grounded by the 900px window `minWidth` (a real terminal is ≥~12 cols even at the 20% min split). 3 new unit tests in `core/pty-manager.test.ts`.
+
+**Why display:none and NOT the 36px column clip.** An adversarial verifier caught that the naive "keep mounted inside the 36px collapsed column" would re-introduce BUG-156: the host would be ~36px (non-zero), the `ResizeObserver`'s zero-size guard wouldn't trip, fit → ~4 cols, `pty.resize(4, …)` reflows the live Claude TUI. The fix MUST hide via a true `display:none` (the existing zero-size guards then no-op cleanly); the cols floor is the structural backstop.
+
+**Verified (live, 2026-06-10 — this worktree's dev build).** Drove the real collapse → expand via the TabBar control (clicked through `duo dom --js`). The 6 `.xterm-host` instances stayed MOUNTED through collapse (pre-fix they'd unmount → 0); every host's `offsetParent` went `null` when collapsed (a true `display:none` ancestor, so the resize guards no-op — no reflow), and on expand the active host regained layout (ResizeObserver refits). The active shell's PID was IDENTICAL before and after the cycle (same `/bin/zsh` process survived; not a fresh spawn). `splitPct` round-tripped 55 → 0 → 55. Typecheck + full suite (1192) green.
+
+**Deferred (owner-approved 2026-06-10).** The robust architecture — decouple PTY-kill from component unmount so NO accidental unmount can destroy a session — is tracked as **ENH-209**. **FOLLOWUP-044** tracks the parallel canvas-pane collapse pattern.
+
+**Cross-refs.** `renderer/App.tsx` (terminal-column render site), `renderer/components/TerminalPane.tsx` (`TerminalInstance` cleanup `pty.kill`; the `display:none` hide pattern; the `ResizeObserver`), `electron/preload.ts` (`PTY_KILL` bridge), `electron/main.ts` (`PTY_KILL` handler), `core/pty-manager.ts` (`kill`/`resize`), `core/constants.ts` (`TERMINAL_MIN_COLS`). Related: BUG-156 (the resize-to-zero SIGHUP class this guards against), ENH-066 (the collapse-rail feature whose ternary introduced the unmount).
+
+---
+
+### ENH-209: Decouple PTY-kill from TerminalInstance unmount (collapse-safety by construction)
+
+**Status:** 🆕 Filed 2026-06-10 (owner-approved deferral from BUG-200). **Priority:** P2. **Effort:** M.
+
+**Ask.** Make it structurally impossible for an accidental React unmount to terminate a shell. Today `TerminalInstance`'s mount-effect cleanup is the *sole* PTY-kill path — `closeTab` / `closeOtherTabs` kill only as an unmount side effect. BUG-200's surgical fix stops *collapse* from unmounting, but any future code that unmounts the pane (a refactor, a new layout mode, an error-boundary remount) would silently kill every session again.
+
+**Approach (sketch — needs a PRD).**
+- Move `pty.kill` OUT of the `TerminalInstance` unmount cleanup; on unmount only detach listeners + `term.dispose()` the local xterm view, leaving the PTY alive in main.
+- Call `pty.kill` EXPLICITLY from every real close path: `closeTab`, `closeOtherTabs`, the ⌘Z-restore eviction, and window/workspace teardown (cross-check `PtyManager.disposeForWindow`).
+- On remount, REATTACH to the surviving session (`PtyManager.create` already no-ops if the session exists) — requires a scrollback/replay path, since the disposed xterm view comes back blank. This is the larger part.
+- Remove/repair the stale `renderer/hooks/useTerminal.ts` (`useTerminalIPC` — zero consumers today, also kills on cleanup) so it can't be wired up later and silently reintroduce the bug.
+
+**Why deferred.** Larger surface + reattach/replay semantics + its own tests; BUG-200's surgical fix already resolves the reported data loss. This is the durable hardening.
+
+**Cross-refs.** BUG-200 (parent), FOLLOWUP-044 (canvas parallel), `renderer/components/TerminalPane.tsx`, `renderer/App.tsx` (`closeTab` / `closeOtherTabs`), `core/pty-manager.ts`, `renderer/hooks/useTerminal.ts`.
+
+---
+
+### FOLLOWUP-044: Canvas pane collapse uses the same unmount pattern — verify it doesn't lose editor/browser state
+
+**Status:** 🆕 Filed 2026-06-10. **Priority:** P2. **Effort:** S (investigate) + TBD. **Parent:** BUG-200.
+
+Discovered while fixing BUG-200: the canvas (working-pane) collapse uses the identical render shape — `App.tsx` does `{isCanvasCollapsed ? <CollapsedPaneRail/> : <WorkingPane/>}`, so collapsing the canvas UNMOUNTS `WorkingPane` and all its children (editors, pages, browsers). Unverified whether this loses state: markdown/canvas editors may persist via disk autosave + lifted tab state, and browser tabs are main-process `WebContentsView`s (the renderer unmount may or may not destroy them). **Action:** verify empirically (open an editor with unsaved edits + a browser tab with scroll/form state → collapse canvas → expand → check survival). If state is lost, the fix mirrors BUG-200's `display:none` approach (and folds into ENH-209's decouple work); if `WebContentsView`s are destroyed on collapse, that's the higher-severity case.
+
+**Cross-refs.** BUG-200 (parent — terminal side), ENH-209, `renderer/App.tsx` (canvas-column render site), `renderer/components/WorkingPane.tsx`.
+
+---
+
+### FOLLOWUP-045: No CLI verb fully collapses/expands a pane (splitPct 0/100) — `duo split` clamps to 20–80
+
+**Status:** 🆕 Filed 2026-06-10. **Priority:** P2. **Effort:** S. **Source:** discovered verifying BUG-200.
+
+CLI-parity gap (CLAUDE.md § 4). The human can fully COLLAPSE the terminal (or canvas) pane to `splitPct` 0 (or 100) via the TabBar collapse button / `CollapsedPaneRail` / ⌘⌥0 / ⌘⌥9, but the agent cannot: `duo split <pct>` clamps numerics to 20–80 and none of its presets hit 0/100, and there is no `duo collapse` verb. So collapse/expand is effectively UI-only — verifying BUG-200 required clicking the button through `duo dom --js "…click()"` rather than a first-class verb. **Fix:** add a collapse affordance to the CLI — e.g. `duo split collapse-terminal | collapse-canvas | expand` (routing through `toggleCollapseTerminal` / `toggleCollapseCanvas`), or let `duo split 0|100` bypass the clamp. Then sync the 4 CLI surfaces (`cli/duo.ts`, `skill/SKILL.md`, `agents/duo.md`, `docs/CLI-COVERAGE.md`) per the plumbing checklist.
+
+**Cross-refs.** `cli/duo.ts` (`split` verb + its socket handler's clamp), `renderer/App.tsx` (`toggleCollapseTerminal` / `toggleCollapseCanvas`), BUG-200 (the fix whose verification surfaced this).
+
+---
+
 ### ENH-207: Drag a file/folder from the navigator to insert its path into the active terminal
 
 **Status:** ✅ **Shipped v0.10.0 (2026-06-08, PR #81)** — owner-requested; smoke-walked 7/8 PASS (one non-blocking FAIL — collapsed-rail drop — deferred to FOLLOWUP-043). Renumbered from a colliding ENH-204 (which #79 holds). **Priority:** Medium. **Effort:** S. *(archive-move deferred to next sweep.)*


### PR DESCRIPTION
## BUG-200 — collapsing the terminal pane terminated every terminal session

### Symptom
Collapsing the terminal pane (the "Hide terminal column" control) appeared to **terminate every terminal session** — running shells, live Claude sessions, scrollback, all gone. Expanding spawned fresh shells.

### Root cause
Collapse swapped the entire `<TabBar/> + <TerminalPane/>` subtree for `<CollapsedPaneRail/>` (a React **unmount**). `TerminalPane` is passed the **full `tabs` array**, so the unmount tore down *every* `TerminalInstance`. Each instance's mount-effect cleanup calls `window.electron.pty.kill(tab.id)` with no collapse-vs-close guard → `PtyManager.kill()` → node-pty `IPty.kill()` + session delete. Permanent. On expand, the remount calls `pty.create()` → a brand-new shell.

> Root-caused via a multi-agent investigation (4 parallel readers → synthesis → 3 adversarial verifiers). The fix-soundness verifier caught that a naive "keep it mounted inside the 36px collapsed column" would re-introduce the **BUG-156** reflow class — hence the *true* `display:none` plus the resize floor.

### Fix (surgical — `renderer/App.tsx`)
Render `CollapsedPaneRail` as a **sibling** and keep `TabBar + TerminalPane` **mounted** under a wrapper hidden with a true `display:none` when collapsed. PTYs + scrollback survive; on expand the host regains size and the existing `ResizeObserver` refits.

Backstop (`core/pty-manager.ts` + `core/constants.ts`): `PtyManager.resize` now floors cols at `TERMINAL_MIN_COLS` (8), so any *future* hide that clips the host to a narrow strip (rather than zeroing it) still can't reflow the live TUI. Safe between the ~4–7 col rail-clip artifact and any real terminal (≥~12 cols even at the 900px window `minWidth` / 20% min split).

### Verification
Live, on a dev build of this branch (via `duo` CLI/DOM probes — the running app couldn't be reached by computer-use in this worktree):
- `.xterm-host` count held **6 → 6** through collapse (pre-fix: would drop to 0) — instances stay mounted, so the cleanup `pty.kill` never fires
- Active shell **PID identical** before/after collapse+expand — same process, not a respawn
- True `display:none` hide (`offsetParent: null` when collapsed → resize guards no-op); `splitPct` round-tripped 55 → 0 → 55
- **typecheck clean · full suite 1192/1192** (3 new `pty-manager.test.ts` regression tests)

### Editor/canvas parity
**(c) Deferred** — the canvas (working) pane uses the identical unmount-on-collapse pattern (`{isCanvasCollapsed ? <CollapsedPaneRail/> : <WorkingPane/>}`). Whether it loses editor/browser state is unverified, tracked as **FOLLOWUP-044**.

### Follow-ups filed (tasks.md)
- **ENH-209** — decouple `pty.kill` from `TerminalInstance` unmount so no accidental unmount can ever kill a session (the robust architecture; owner-approved deferral).
- **FOLLOWUP-044** — canvas pane shares the unmount-on-collapse pattern (above).
- **FOLLOWUP-045** — CLI-parity gap: `duo split` clamps to 20–80, so no CLI verb fully collapses a pane.

### Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run` — 1192 passed
- [x] Live collapse/expand on a dev build — sessions survive (see Verification)
- [ ] Owner smoke walk (`docs/dev/smoke-walks/v0.10.1-bug200.html`) — optional; mechanics already CLI-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
