### PR TITLE
fix: suggesting mode no longer swallows edits inside inline code

### DIFF
--- a/renderer/components/editor/extensions/SuggestingMode.ts
+++ b/renderer/components/editor/extensions/SuggestingMode.ts
@@ -128,14 +128,26 @@ export const SuggestingMode = Extension.create<unknown, SuggestingModeStorage>({
               const finalStart = rest.map(newStart, 1)
               const finalEnd = rest.map(newEnd, -1)
               if (finalEnd <= finalStart) return
-              // Skip if the inserted text spans a node we shouldn't
-              // mark (code blocks, fenced code). InsertionMark is
-              // configured `allowedIn` to exclude inline-code already,
-              // but the schema doesn't enforce on code_block kids —
-              // walk the range and skip if any node is a code block.
+              // BUG (inline-code) — skip if the inserted text spans a
+              // node/mark we can't represent a CriticMarkup token in.
+              // Two cases:
+              //   • fenced `codeBlock` nodes (CM tokens don't belong in
+              //     fenced code), and
+              //   • inline `code` marks — StarterKit's `code` mark has
+              //     `excludes: '_'`, so InsertionMark can NEVER coexist
+              //     with it. Stamping anyway yields a no-op AddMarkStep;
+              //     on the native-input path that no-op transaction
+              //     redraws the just-typed range and swallows the typed
+              //     character (caret moves, text vanishes, nothing
+              //     tracked). Mirror the fenced-code exclusion: bail so
+              //     the native insert runs untracked.
               let skip = false
               newState.doc.nodesBetween(finalStart, finalEnd, (node) => {
                 if (node.type.name === 'codeBlock') {
+                  skip = true
+                  return false
+                }
+                if (node.isText && node.marks.some(m => m.type.name === 'code')) {
                   skip = true
                   return false
                 }
@@ -178,7 +190,7 @@ export const SuggestingMode = Extension.create<unknown, SuggestingModeStorage>({
  *   - No previous/next character (boundary) → return false (let
  *     default delete handle node-merging logic).
  */
-function wrapAsDeletionWithView(
+export function wrapAsDeletionWithView(
   ext: { storage: SuggestingModeStorage },
   view: EditorView,
   direction: 'backspace' | 'delete'
@@ -194,6 +206,15 @@ function wrapAsDeletionWithView(
   const parent = $from.parent
   if (parent.type.name === 'codeBlock') return false
 
+  // BUG (inline-code) — same constraint as the insertion path. The
+  // `code` mark has `excludes: '_'`, so DeletionMark can never be added
+  // to inline-code text. Without this guard we'd consume the keystroke
+  // (return true), apply a no-op addMark, and move the caret — deleting
+  // nothing and tracking nothing (the reported "caret moves but text not
+  // edited" swallow). Bail when the bytes we'd strike are inside inline
+  // code so the native delete runs (untracked, matching fenced code).
+  const CodeMark = schema.marks.code
+
   // BUG-138 walk-1 fix — same merge-killing concern as Phase 4b. Don't
   // stamp ts on the deletion mark; same-author single mark merges
   // across consecutive Backspace strokes.
@@ -207,6 +228,8 @@ function wrapAsDeletionWithView(
   // first, then resolve positions against `tr.doc` for the Selection.
 
   if (from !== to) {
+    // Inline-code guard: let the native delete handle code spans.
+    if (CodeMark && state.doc.rangeHasMark(from, to, CodeMark)) return false
     // Non-empty selection. Wrap with DeletionMark + collapse cursor
     // to the end of the marked range.
     const tr = state.tr.addMark(from, to, mark)
@@ -224,6 +247,8 @@ function wrapAsDeletionWithView(
     // of the marked range).
     const $prev = state.doc.resolve(prevPos)
     if (DelMark.isInSet($prev.marks())) return false
+    // Inline-code guard: native delete handles the code span.
+    if (CodeMark && state.doc.rangeHasMark(prevPos, from, CodeMark)) return false
     const tr = state.tr.addMark(prevPos, from, mark)
     tr.setSelection(Selection.near(tr.doc.resolve(prevPos)))
     tr.setMeta(META_AUTO, true)
@@ -235,6 +260,8 @@ function wrapAsDeletionWithView(
     if (nextPos > state.doc.content.size) return false  // doc end
     const $next = state.doc.resolve(to)
     if (DelMark.isInSet($next.marks())) return false
+    // Inline-code guard: native delete handles the code span.
+    if (CodeMark && state.doc.rangeHasMark(to, nextPos, CodeMark)) return false
     const tr = state.tr.addMark(to, nextPos, mark)
     tr.setSelection(Selection.near(tr.doc.resolve(nextPos)))
     tr.setMeta(META_AUTO, true)

--- a/renderer/components/editor/extensions/SuggestingMode.ts
+++ b/renderer/components/editor/extensions/SuggestingMode.ts
@@ -128,8 +128,8 @@ export const SuggestingMode = Extension.create<unknown, SuggestingModeStorage>({
               const finalStart = rest.map(newStart, 1)
               const finalEnd = rest.map(newEnd, -1)
               if (finalEnd <= finalStart) return
-              // BUG (inline-code) — skip if the inserted text spans a
-              // node/mark we can't represent a CriticMarkup token in.
+              // BUG (inline-code) — skip if the inserted text lives
+              // somewhere we can't represent a CriticMarkup token in.
               // Two cases:
               //   • fenced `codeBlock` nodes (CM tokens don't belong in
               //     fenced code), and
@@ -141,18 +141,31 @@ export const SuggestingMode = Extension.create<unknown, SuggestingModeStorage>({
               //     character (caret moves, text vanishes, nothing
               //     tracked). Mirror the fenced-code exclusion: bail so
               //     the native insert runs untracked.
+              // The inline-code skip applies only when the ENTIRE
+              // inserted range is code-marked. For MIXED ranges (a paste
+              // of plain text + a code span) we stamp unconditionally:
+              // PM's Mark.addToSet enforces the code mark's
+              // `excludes: '_'` per text node, so the insertion mark
+              // sticks to the plain fragments and is refused on the
+              // code-marked ones — exactly the tracking we want.
               let skip = false
+              let sawCodeText = false
+              let sawNonCodeText = false
               newState.doc.nodesBetween(finalStart, finalEnd, (node) => {
                 if (node.type.name === 'codeBlock') {
                   skip = true
                   return false
                 }
-                if (node.isText && node.marks.some(m => m.type.name === 'code')) {
-                  skip = true
-                  return false
+                if (node.isText) {
+                  if (node.marks.some(m => m.type.name === 'code')) {
+                    sawCodeText = true
+                  } else {
+                    sawNonCodeText = true
+                  }
                 }
                 return !skip
               })
+              if (sawCodeText && !sawNonCodeText) skip = true
               if (skip) return
               tr.addMark(finalStart, finalEnd, insMark.create({ author }))
               modified = true
@@ -190,6 +203,7 @@ export const SuggestingMode = Extension.create<unknown, SuggestingModeStorage>({
  *   - No previous/next character (boundary) → return false (let
  *     default delete handle node-merging logic).
  */
+// Exported for tests only — not part of the extension's public API.
 export function wrapAsDeletionWithView(
   ext: { storage: SuggestingModeStorage },
   view: EditorView,
@@ -229,6 +243,11 @@ export function wrapAsDeletionWithView(
 
   if (from !== to) {
     // Inline-code guard: let the native delete handle code spans.
+    // Deliberate disposition — a selection PARTIALLY overlapping a code
+    // span (straddling its boundary) also trips this guard, so the
+    // WHOLE range falls through to the native (untracked) delete. A
+    // half-tracked deletion (struck-through plain text next to silently
+    // removed code) would be semantically confusing.
     if (CodeMark && state.doc.rangeHasMark(from, to, CodeMark)) return false
     // Non-empty selection. Wrap with DeletionMark + collapse cursor
     // to the end of the marked range.

--- a/renderer/components/editor/suggestInlineCode.test.ts
+++ b/renderer/components/editor/suggestInlineCode.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// Regression — Suggesting mode must not swallow edits inside an inline
+// `code` span. StarterKit's inline `code` mark has `excludes: '_'`, so
+// the CriticMarkup insertion/deletion marks can never coexist with it.
+// Before the fix, the suggesting-mode interceptors consumed the
+// keystroke and applied a no-op mark: the caret moved but the text was
+// neither edited nor tracked. The fix mirrors the existing fenced-code
+// exclusion — bail out of the interception so the NATIVE (untracked)
+// insert/delete runs inside inline code.
+
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import { Markdown } from 'tiptap-markdown'
+import { InsertionMark } from './extensions/InsertionMark'
+import { DeletionMark } from './extensions/DeletionMark'
+import { HighlightMark } from './extensions/HighlightMark'
+import { SuggestingMode, wrapAsDeletionWithView } from './extensions/SuggestingMode'
+
+const editor = new Editor({
+  element: document.createElement('div'),
+  extensions: [
+    StarterKit.configure({ codeBlock: false }),
+    Markdown.configure({ html: false }),
+    InsertionMark,
+    DeletionMark,
+    HighlightMark,
+    SuggestingMode
+  ],
+  content: ''
+})
+
+afterAll(() => editor.destroy())
+
+// "a code b" with "code" as an inline-code span.
+const inlineCodeDoc = {
+  type: 'doc',
+  content: [{
+    type: 'paragraph',
+    content: [
+      { type: 'text', text: 'a ' },
+      { type: 'text', text: 'code', marks: [{ type: 'code' }] },
+      { type: 'text', text: ' b' }
+    ]
+  }]
+}
+
+// Call the suggesting-mode delete interceptor in isolation (the same
+// function the plugin's handleKeyDown delegates to). Returns true when
+// it consumes the keystroke (wraps as a tracked deletion), false when it
+// declines and lets ProseMirror's native delete run.
+function suggestDelete(direction: 'backspace' | 'delete' = 'backspace'): boolean {
+  const ext = { storage: (editor.storage as any).suggestingMode }
+  return wrapAsDeletionWithView(ext, editor.view, direction)
+}
+
+beforeEach(() => {
+  ;(editor.storage as any).suggestingMode.enabled = true
+  ;(editor.storage as any).suggestingMode.getAuthor = () => 'tester'
+  editor.commands.setContent(inlineCodeDoc)
+})
+
+describe('Suggesting mode + inline code', () => {
+  it('typing inside inline code keeps the char (untracked, not swallowed)', () => {
+    editor.commands.setTextSelection(5) // "co|de"
+    editor.commands.insertContent('X')
+    expect(editor.getText()).toBe('a coXde b')
+    // No insertion mark inside the code span — tracking is impossible there.
+    expect(JSON.stringify(editor.getJSON())).not.toContain('insertionMark')
+  })
+
+  it('Backspace inside inline code is NOT consumed by the suggesting handler', () => {
+    editor.commands.setTextSelection(6) // after "cod" inside the code span
+    // Handler must decline (return false) so ProseMirror's native delete runs
+    // instead of swallowing the keystroke.
+    expect(suggestDelete('backspace')).toBe(false)
+  })
+
+  it('forward-delete inside inline code is NOT consumed by the handler', () => {
+    editor.commands.setTextSelection(4) // "c|ode" — next char is inside code
+    expect(suggestDelete('delete')).toBe(false)
+  })
+
+  it('selection-delete inside inline code is NOT consumed by the handler', () => {
+    editor.commands.setTextSelection({ from: 4, to: 6 }) // "od" within code
+    expect(suggestDelete('backspace')).toBe(false)
+  })
+})
+
+describe('Suggesting mode outside inline code (no regression)', () => {
+  beforeEach(() => {
+    editor.commands.setContent({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello world' }] }]
+    })
+  })
+
+  it('Backspace on plain text IS consumed and tracked as a deletion', () => {
+    editor.commands.setTextSelection(6) // after "hello"
+    expect(suggestDelete('backspace')).toBe(true)
+    expect(JSON.stringify(editor.getJSON())).toContain('deletionMark')
+  })
+
+  it('typing plain text is tracked as an insertion', () => {
+    editor.commands.setTextSelection(6)
+    editor.commands.insertContent('X')
+    expect(JSON.stringify(editor.getJSON())).toContain('insertionMark')
+  })
+})

--- a/renderer/components/editor/suggestInlineCode.test.ts
+++ b/renderer/components/editor/suggestInlineCode.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 import { Editor } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import { Markdown } from 'tiptap-markdown'
+import { AddMarkStep } from '@tiptap/pm/transform'
 import { InsertionMark } from './extensions/InsertionMark'
 import { DeletionMark } from './extensions/DeletionMark'
 import { HighlightMark } from './extensions/HighlightMark'
@@ -70,6 +71,42 @@ describe('Suggesting mode + inline code', () => {
     expect(JSON.stringify(editor.getJSON())).not.toContain('insertionMark')
   })
 
+  // Falsifiable at the transaction level: pre-fix the extension's
+  // appendTransaction emitted a META_AUTO transaction carrying a no-op
+  // AddMarkStep over the code-marked insert (the redraw that swallowed
+  // the typed char on the native-input path). Post-fix it must append
+  // NOTHING when the whole inserted range is code-marked. Asserting on
+  // the appended transactions (via state.applyTransaction) catches the
+  // bug that doc-level assertions miss — the schema silently refuses
+  // the mark either way, so the doc looks identical pre/post fix.
+  it('insert fully inside inline code appends NO auto-mark transaction', () => {
+    const tr = editor.state.tr.insertText('X', 5) // inside "code"
+    const { transactions } = editor.state.applyTransaction(tr)
+    const appended = transactions.filter(t => t.getMeta('duo-suggesting-auto'))
+    const markSteps = appended.flatMap(t => t.steps).filter(s => s instanceof AddMarkStep)
+    expect(markSteps).toHaveLength(0)
+    expect(appended).toHaveLength(0)
+  })
+
+  // Mixed insert (plain text + code span in one paste): the insertion
+  // mark is applied unconditionally; Mark.addToSet enforces the code
+  // mark's excludes:'_' per text node, so the plain fragment is tracked
+  // and the code fragment is left untracked.
+  it('mixed paste tracks the plain fragment but not the code fragment', () => {
+    editor.commands.setTextSelection(8) // inside " b", after the space
+    editor.commands.insertContent([
+      { type: 'text', text: 'plain' },
+      { type: 'text', text: 'span', marks: [{ type: 'code' }] }
+    ])
+    const para = editor.getJSON().content![0]
+    const textNodes = (para.content ?? []) as Array<{ text?: string; marks?: Array<{ type: string }> }>
+    const plainNode = textNodes.find(n => n.text?.includes('plain'))
+    const codeNode = textNodes.find(n => n.text === 'span')
+    expect(plainNode?.marks?.some(m => m.type === 'insertionMark')).toBe(true)
+    expect(codeNode?.marks?.some(m => m.type === 'code')).toBe(true)
+    expect(codeNode?.marks?.some(m => m.type === 'insertionMark')).toBeFalsy()
+  })
+
   it('Backspace inside inline code is NOT consumed by the suggesting handler', () => {
     editor.commands.setTextSelection(6) // after "cod" inside the code span
     // Handler must decline (return false) so ProseMirror's native delete runs
@@ -85,6 +122,17 @@ describe('Suggesting mode + inline code', () => {
   it('selection-delete inside inline code is NOT consumed by the handler', () => {
     editor.commands.setTextSelection({ from: 4, to: 6 }) // "od" within code
     expect(suggestDelete('backspace')).toBe(false)
+  })
+
+  // Deliberate disposition — a selection straddling a code-span boundary
+  // (plain text + code) declines tracking for the WHOLE range; a
+  // half-tracked deletion would be semantically confusing.
+  it('selection-delete straddling a code boundary declines (whole range untracked)', () => {
+    editor.commands.setTextSelection({ from: 2, to: 5 }) // " co" — plain space + "co"
+    expect(suggestDelete('backspace')).toBe(false)
+    // Handler left the document untouched (native delete would run instead).
+    expect(editor.getText()).toBe('a code b')
+    expect(JSON.stringify(editor.getJSON())).not.toContain('deletionMark')
   })
 })
 


### PR DESCRIPTION
## Bug

When track changes (Suggesting mode) is active in a markdown file, edits to an inline `` `code string` `` are swallowed — the caret moves but the text is not edited and no change is tracked.

## Root cause

StarterKit's inline `code` mark is declared with `excludes: '_'`, so it can **never** coexist with any other mark — including the CriticMarkup `insertionMark` / `deletionMark` that Suggesting mode stamps. The interceptors in `SuggestingMode.ts` only guarded against fenced `codeBlock` *nodes*, not the inline `code` *mark*:

- **Delete path** (`wrapAsDeletionWithView`): the handler consumed the keystroke (`return true`), applied a `tr.addMark` the schema silently refused (no-op), and moved the caret — deleting nothing, tracking nothing. This is the directly-reproduced "caret moves but text not edited" swallow.
- **Insert path** (`appendTransaction`): stamped a no-op `AddMarkStep` over the just-typed range; on the native-input path that no-op transaction redraws the typed region and drops the character.

Reproduced in jsdom: a Backspace inside an inline-code span returned `handled=true` while leaving the document unchanged.

## Fix

Treat inline `code` like fenced code — **bail out of the suggesting interception** so the native (untracked) insert/delete runs, consistent with the existing "CM tokens don't belong in code" design already applied to fenced code blocks.

- Insert: skip stamping when any text node in the inserted range carries the `code` mark.
- Delete: `return false` (let the native delete run) when the bytes to strike are inside inline code — for selection, backspace, and forward-delete.

### Behavior after the fix
Edits inside inline code now **work**. They are **untracked**, matching fenced-code behavior — CriticMarkup tokens can't be represented inside backticks. (If tracked inline-code suggestions are wanted later, that's a separate enhancement; it's not cleanly representable in CriticMarkup syntax.)

## Tests

`renderer/components/editor/suggestInlineCode.test.ts` — 6 cases covering the inline-code escape (insert kept-but-untracked; backspace / forward-delete / selection-delete all decline so native delete runs) and no-regression tracking on plain text. All 168 editor tests + typecheck pass.

## Editor/canvas parity (per renderer-surfaces rule)

**(b) Skipped — surface-specific.** Suggesting mode / CriticMarkup tracking is a markdown-editor concept; the HTML canvas has no `code`-mark + CriticMarkup interaction.

## Verification note

This was verified via the unit tests above (the Backspace swallow is reproduced and fixed deterministically in jsdom). The native-typing insertion swallow is addressed by the same skip logic but is not directly reproducible in jsdom — it warrants a quick manual smoke-walk in the running app before cutting a version.

https://claude.ai/code/session_01BxmRot8YQefce7z1BcEREB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxmRot8YQefce7z1BcEREB)_