### PR TITLE
feat(install): managed-block guidance for batched approvals + scoped permissions

### DIFF
--- a/electron/install-service.test.ts
+++ b/electron/install-service.test.ts
@@ -51,6 +51,18 @@ describe('composeManagedClaudeMdBlock', () => {
     expect(block).toContain('enterprise-deployments.md')
   })
 
+  it('tells the agent to batch approval requests on managed installs (auto-approve off)', () => {
+    const block = composeManagedClaudeMdBlock('1.2.3')
+    expect(block).toMatch(/auto-approve/i)
+    expect(block).toMatch(/whole directory or repository/i)
+  })
+
+  it('tells the agent to stay scoped and not request unrelated apps\' data', () => {
+    const block = composeManagedClaudeMdBlock('1.2.3')
+    expect(block).toMatch(/unrelated applications' data/i)
+    expect(block).toMatch(/Music library/i)
+  })
+
   it('surfaces the version in the rendered body so a plain read post-install confirms which Duo wrote it', () => {
     const block = composeManagedClaudeMdBlock('1.2.3')
     // BUG-125 follow-up: the HTML-comment marker is invisible in

--- a/electron/install-service.ts
+++ b/electron/install-service.ts
@@ -241,6 +241,11 @@ export function composeManagedClaudeMdBlock(version: string): string {
     '',
     'Duo (https://github.com/dudgeon/duo) is installed on this machine — a desktop app pairing Claude Code terminals with an embedded browser, file tree, markdown editor, and HTML canvas. When the user references Duo\'s surfaces ("the browser pane", "the editor", "what\'s selected", a `duo` CLI verb), reach for the **`duo` skill** at `~/.claude/skills/duo/SKILL.md` or delegate multi-step CLI sequences to the **`duo` subagent**. If a `duo` command hangs or returns `ECONNREFUSED`, see `~/.claude/skills/duo/references/sandbox-troubleshooting.md`. For enterprise / managed Claude Code installs (hooks disabled, restrictive permissions), see `~/.claude/skills/duo/references/enterprise-deployments.md`.',
     '',
+    '**Permission requests — batch within the task, stay scoped to it.** Matters most on managed / enterprise installs, where auto-approve is usually off and even reading a single file prompts the user:',
+    '',
+    '- *Batch approvals.* When work spans many files in the project, request the broadest scope the task legitimately needs in one prompt — ask to read the whole directory or repository rather than prompting file-by-file — so the user approves once instead of dozens of times.',
+    '- *Stay scoped.* Request access only to what the current task touches. Don\'t ask to read unrelated applications\' data or OS surfaces (e.g. the macOS Music library) the work doesn\'t require. Narrow scope when IT policy demands it, but don\'t self-clamp below what the task legitimately needs.',
+    '',
     `*Auto-managed by Duo v${version}. Re-runs on every Duo install/upgrade; the version above is the source of truth for whether the latest block landed.*`,
     '<!-- duo:end -->'
   ].join('\n')

--- a/skill/references/enterprise-deployments.md
+++ b/skill/references/enterprise-deployments.md
@@ -14,6 +14,7 @@
 ## Contents
 
 - [Mechanism dependency map](#mechanism-dependency-map)
+- [Permission prompts in managed installs](#permission-prompts-in-managed-installs)
 - [Common enterprise restrictions](#common-enterprise-restrictions)
 - [What still works (the hook-free path)](#what-still-works-the-hook-free-path)
 - [Reporting a Duo issue from a managed install](#reporting-a-duo-issue-from-a-managed-install)
@@ -44,6 +45,56 @@ of policy.
 in-Duo PTYs) and the PATH shim (load-bearing for in-Duo PTYs only).
 Both fail open — if they don't run, Duo still works; the agent just
 doesn't get the priming context until it triggers a skill load.
+
+---
+
+## Permission prompts in managed installs
+
+Managed Claude Code installs commonly disable auto-approve, so the
+agent must get explicit user (or policy) sign-off for actions that
+run silently elsewhere — reading a file, listing a directory,
+running a `duo` verb. Two behaviors keep that from becoming death
+by a thousand prompts. Both are also stated in the managed
+`~/.claude/CLAUDE.md` block so they reach every session, hooks or
+no hooks.
+
+### Batch approval requests
+
+When a task spans many files in the project, ask for the broadest
+scope the work *legitimately* needs in a single request, instead of
+prompting once per file:
+
+- Prefer "read everything under `src/`" or "read this repository"
+  over a file-by-file walk that fires a fresh prompt for each path.
+- Plan the read set before you start — enumerate the directory, then
+  request the directory, rather than discovering and re-prompting as
+  you go.
+- The same applies to `duo` verbs: if the admin allowlists
+  `Bash(duo:*)` once, every verb is covered; a per-verb allowlist
+  (`Bash(duo url:*)`, `Bash(duo edit:*)`) trades fewer privileges
+  for more prompts. Recommend the broadest entry the org will accept.
+
+The goal is one informed approval over a coherent scope, not dozens
+of trivial ones the user rubber-stamps without reading.
+
+### Don't request unrelated apps' or OS data
+
+The flip side of batching: breadth applies *within the task's
+surface*, never beyond it. Request access only to what the current
+work touches.
+
+- Don't ask to read unrelated applications' data or OS surfaces —
+  the macOS Music library, Photos, Mail, other apps' Application
+  Support directories — when the task doesn't involve them. Reports
+  of Duo sessions prompting for arbitrary app data trace to agent
+  behavior, not to Duo itself.
+- Stay inside the working tree / project the user pointed you at
+  unless the task genuinely requires reaching outside it; if it
+  does, say why before requesting.
+- This is about not *self-broadening*, not about clamping down.
+  Where enterprise IT enforces narrower limits, honor them — but
+  Duo doesn't add restrictions beyond what the task needs and what
+  policy already imposes.
 
 ---
 


### PR DESCRIPTION
## What

Two surgical additions to the Duo **managed block** pushed into `~/.claude/CLAUDE.md` (`composeManagedClaudeMdBlock`) and its enterprise reference doc, driven by user reports from enterprise / managed installs.

1. **Batch approval requests** — on managed installs auto-approve is usually off, so even reading a single file prompts the user. The block now tells the agent to request the broadest scope the task *legitimately* needs in one prompt (whole directory / repository) rather than file-by-file.
2. **Stay scoped** — don't request access to unrelated applications' data / OS surfaces (calls out the macOS Music library by name) the task doesn't touch — while explicitly **not** self-clamping below what the task needs or what IT policy already enforces.

The two guidelines are worded so they don't contradict: breadth applies *within* the task's surface, never beyond it.

## Where

- `electron/install-service.ts` — two bullets added to `composeManagedClaudeMdBlock` (the generated block; lands in every user's `~/.claude/CLAUDE.md` on next install/upgrade).
- `skill/references/enterprise-deployments.md` — fuller "Permission prompts in managed installs" section (new TOC entry + batch / scope subsections + the `Bash(duo:*)` vs per-verb allowlist breadth trade-off).
- `electron/install-service.test.ts` — 2 new assertions locking the new wording.

## Verification

- `install-service.test.ts` — 21/21 pass (incl. 2 new).
- `npm run typecheck` clean.
- `npm run sync:claude` ran; new reference section confirmed live at `~/.claude/skills/duo/references/enterprise-deployments.md`.

Note: the live `~/.claude/CLAUDE.md` block regenerates on the next Duo install/upgrade (single source of truth is the install service) — not hand-edited here, to avoid drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)