### PR TITLE
chore(tooling): detect iCloud sync-conflict duplicates in materialization check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,14 @@ cloud-only (the `dataless` flag) under disk pressure. Symptoms: `git status` →
 input`; `git rev-parse HEAD` → `fatal: ambiguous argument 'HEAD'`. The
 `predev`/`pretest` hooks warn once via `scripts/check-materialization.sh`;
 recovery is `npm run materialize`. (Fired once Sprint 22 with 13k+ dataless
-files including `.git/refs/heads/main`.)
+files including `.git/refs/heads/main`.) **Second variant — sync-conflict
+duplicates:** iCloud can also drop a *copy* named `<file> 2.ts` (space +
+digit) next to the real file. These are **untracked**, but `tsconfig`'s
+`core/**`/`renderer/**` globs pick them up → spurious `TS6307` typecheck
+errors on files you never touched (155 of them blocked the v0.11.1 cut). `npm
+run materialize` does NOT clean these — the same `predev`/`pretest` check now
+warns about them, and `bash scripts/materialize.sh --dedup` (or
+`check-materialization.sh --fix`) moves them to `$TMPDIR`.
 
 ---
 

--- a/scripts/check-materialization.sh
+++ b/scripts/check-materialization.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 # scripts/check-materialization.sh
 #
-# Pre-flight: warn loudly if any tracked working-tree files have been
-# evicted to iCloud Drive cloud-only state (the "dataless" attribute).
-# This shape of file-loss breaks `git status`, `npm run dev`, vitest,
-# and pretty much every dev tool — the file is zero-bytes on disk
-# even though metadata claims a non-zero size.
+# Pre-flight for TWO shapes of the macOS iCloud "Optimize Mac Storage" trap:
+#
+#   1. EVICTION (dataless) — iCloud evicts tracked file *bytes* to cloud-only
+#      (the BSD `dataless` flag). The file is zero-bytes on disk even though
+#      metadata claims a non-zero size, which breaks `git status`, `npm run
+#      dev`, vitest, and basically every dev tool. Recovered by re-reading
+#      the bytes (`scripts/materialize.sh`).
+#
+#   2. SYNC-CONFLICT DUPLICATES — iCloud drops a conflict copy named
+#      `<file> 2.ts` (space + digit + dot + ext) next to the real file. These
+#      are UNTRACKED, but tsconfig's `core/**` + `renderer/**` include globs
+#      pick them up and they cause spurious TS6307 typecheck failures on files
+#      nobody touched (155 of them blocked the v0.11.1 cut, 2026-06-18).
+#      `npm run materialize` does NOT clean these — they're moved aside, not
+#      re-read.
 #
 # Triggered by the Sprint 22 session-start emergency 2026-05-25:
 # macOS's "Optimize Mac Storage" feature, combined with disk pressure
@@ -16,10 +26,12 @@
 # Usage:
 #   bash scripts/check-materialization.sh           # exit 0 if clean, 1 if dataless
 #   bash scripts/check-materialization.sh --quiet   # silent on success
-#   bash scripts/check-materialization.sh --fix     # auto-invoke materialize.sh
+#   bash scripts/check-materialization.sh --fix     # re-download dataless +
+#                                                   #   move duplicates aside
+#   bash scripts/check-materialization.sh --strict  # exit 1 if dataless (NOT on dups)
 #
 # See also:
-#   scripts/materialize.sh  (the recovery pass)
+#   scripts/materialize.sh           (eviction recovery; `--dedup` for duplicates)
 #   CLAUDE.md § iCloud Drive trap
 
 set -euo pipefail
@@ -31,8 +43,9 @@ for arg in "$@" ; do
   case "$arg" in
     --quiet)  QUIET=1 ;;
     --fix)    FIX=1 ;;
-    # --strict turns the warning into a fatal exit-1. Default is
-    # warn-and-continue so `predev` hooks don't block dev launches.
+    # --strict turns the EVICTION warning into a fatal exit-1. Default is
+    # warn-and-continue so `predev` hooks don't block dev launches. The
+    # DUPLICATE warning is always warn-only (see below).
     --strict) STRICT=1 ;;
     *) echo "unknown flag: $arg" >&2 ; exit 2 ;;
   esac
@@ -51,6 +64,7 @@ for p in "${PROBE_PATHS[@]}" ; do
   if [ -e "$p" ] ; then EXISTING+=("$p") ; fi
 done
 
+# ── Variant 1: EVICTION (dataless) ──────────────────────────
 # ls -lO is macOS's way to surface BSD file flags. The `dataless`
 # flag is the smoking gun — set by Apple's file provider when a
 # file's content has been evicted but the inode metadata remains.
@@ -58,39 +72,91 @@ DATALESS_FILES=$(find "${EXISTING[@]}" -type f -print0 2>/dev/null \
   | xargs -0 ls -lO 2>/dev/null \
   | grep dataless || true)
 
-if [ -z "$DATALESS_FILES" ] ; then
-  [ "$QUIET" -eq 1 ] || echo "✓ check-materialization: all critical files materialized"
+# ── Variant 2: SYNC-CONFLICT DUPLICATES ─────────────────────
+# Untracked `<file> 2.ts` copies under source dirs (where a name like
+# `foo 2.ts` is never legitimate). `git ls-files --others` honors
+# .gitignore, so node_modules / dist / out are already excluded. We use a
+# bash `case` glob, NOT `grep -zE`: macOS ships BSD grep, whose `-z` does
+# not behave like GNU grep's and would silently match nothing here.
+DUP_DIRS=(core renderer shared electron cli)
+DUP_FILES=()
+while IFS= read -r dupf ; do
+  case "$dupf" in
+    *" "[0-9].*) DUP_FILES+=("$dupf") ;;
+  esac
+done < <(git ls-files --others --exclude-standard -- "${DUP_DIRS[@]}" 2>/dev/null || true)
+
+# ── Clean? (both variants) ──────────────────────────────────
+if [ -z "$DATALESS_FILES" ] && [ "${#DUP_FILES[@]}" -eq 0 ] ; then
+  [ "$QUIET" -eq 1 ] || echo "✓ check-materialization: all critical files materialized; no iCloud duplicates"
   exit 0
 fi
 
-COUNT=$(echo "$DATALESS_FILES" | wc -l | tr -d ' ')
-
-echo ""
-echo "⚠️  $COUNT files are 'dataless' (evicted by macOS Optimize Mac Storage)."
-echo ""
-echo "    First 5 affected:"
-echo "$DATALESS_FILES" | head -5 | awk '{for (i=10;i<=NF;i++) printf "%s%s", $i, (i<NF?" ":"\n")}' | sed 's/^/      /'
-echo ""
-echo "    What happened: iCloud Drive's 'Optimize Mac Storage' (System"
-echo "    Settings → Apple ID → iCloud → iCloud Drive) evicted files"
-echo "    locally to free disk space. The file metadata still claims"
-echo "    a non-zero size, but the bytes are gone (or in the cloud)."
-echo "    'git status' reports 'short read while indexing'; vitest /"
-echo "    npm run dev hit 'Unexpected end of JSON input' on stub"
-echo "    package.json files."
-echo ""
-if [ "$FIX" -eq 1 ] ; then
-  echo "    --fix specified, invoking materialize.sh..."
-  exec bash "$(dirname "$0")/materialize.sh"
-else
-  echo "    Fix options:"
-  echo "      1.  bash scripts/materialize.sh     (force re-download from iCloud)"
-  echo "      2.  System Settings → Apple ID → iCloud Drive → turn OFF"
-  echo "          'Optimize Mac Storage' (prevents recurrence)"
-  echo "      3.  For files iCloud can't recover, restore via:"
-  echo "             git checkout HEAD -- <path>"
+# ── Report variant 2 (DUPLICATES) — always warn-only ────────
+# Warn-only even under --strict: a sync-conflict duplicate is a transient,
+# trivially-cleaned local artifact, and the predev/pretest hooks must not
+# block on it. (The eviction variant below is the one that can fail --strict.)
+if [ "${#DUP_FILES[@]}" -gt 0 ] ; then
   echo ""
-  # Default is warn-and-continue so `npm run dev` isn't blocked by a
-  # transient eviction. Pass --strict for CI / pre-commit use.
-  if [ "$STRICT" -eq 1 ] ; then exit 1 ; else exit 0 ; fi
+  echo "⚠️  ${#DUP_FILES[@]} untracked iCloud sync-conflict DUPLICATE file(s) under source dirs."
+  echo ""
+  echo "    First 5:"
+  printf '      %s\n' "${DUP_FILES[@]:0:5}"
+  echo ""
+  echo "    What happened: iCloud Drive created conflict copies named"
+  echo "    '<file> 2.ts' (space + digit) next to the real files. They are"
+  echo "    untracked, but tsconfig's core/** + renderer/** globs pick them"
+  echo "    up → spurious TS6307 typecheck failures on files you never"
+  echo "    touched. 'npm run materialize' does NOT clean these."
+  echo ""
+  if [ "$FIX" -eq 1 ] ; then
+    DEST="${TMPDIR:-/tmp}/duo-icloud-dupes"
+    for dupf in "${DUP_FILES[@]}" ; do
+      mkdir -p "$DEST/$(dirname "$dupf")"
+      mv "$dupf" "$DEST/$dupf"
+    done
+    echo "    --fix: moved ${#DUP_FILES[@]} duplicate(s) to $DEST"
+    echo ""
+  else
+    echo "    Fix: bash scripts/materialize.sh --dedup   (moves them to \$TMPDIR)"
+    echo "         or re-run this with --fix."
+    echo ""
+  fi
 fi
+
+# ── Report variant 1 (EVICTION) — can fail under --strict ───
+if [ -n "$DATALESS_FILES" ] ; then
+  COUNT=$(echo "$DATALESS_FILES" | wc -l | tr -d ' ')
+
+  echo ""
+  echo "⚠️  $COUNT files are 'dataless' (evicted by macOS Optimize Mac Storage)."
+  echo ""
+  echo "    First 5 affected:"
+  echo "$DATALESS_FILES" | head -5 | awk '{for (i=10;i<=NF;i++) printf "%s%s", $i, (i<NF?" ":"\n")}' | sed 's/^/      /'
+  echo ""
+  echo "    What happened: iCloud Drive's 'Optimize Mac Storage' (System"
+  echo "    Settings → Apple ID → iCloud → iCloud Drive) evicted files"
+  echo "    locally to free disk space. The file metadata still claims"
+  echo "    a non-zero size, but the bytes are gone (or in the cloud)."
+  echo "    'git status' reports 'short read while indexing'; vitest /"
+  echo "    npm run dev hit 'Unexpected end of JSON input' on stub"
+  echo "    package.json files."
+  echo ""
+  if [ "$FIX" -eq 1 ] ; then
+    echo "    --fix specified, invoking materialize.sh..."
+    exec bash "$(dirname "$0")/materialize.sh"
+  else
+    echo "    Fix options:"
+    echo "      1.  bash scripts/materialize.sh     (force re-download from iCloud)"
+    echo "      2.  System Settings → Apple ID → iCloud Drive → turn OFF"
+    echo "          'Optimize Mac Storage' (prevents recurrence)"
+    echo "      3.  For files iCloud can't recover, restore via:"
+    echo "             git checkout HEAD -- <path>"
+    echo ""
+    # Default is warn-and-continue so `npm run dev` isn't blocked by a
+    # transient eviction. Pass --strict for CI / pre-commit use.
+    if [ "$STRICT" -eq 1 ] ; then exit 1 ; fi
+  fi
+fi
+
+exit 0

--- a/scripts/materialize.sh
+++ b/scripts/materialize.sh
@@ -23,6 +23,28 @@
 
 set -euo pipefail
 
+# ── `--dedup`: clean iCloud SYNC-CONFLICT DUPLICATES (not eviction) ──
+# iCloud Drive sometimes drops a conflict copy named `<file> 2.ts` next to
+# the real file. They're UNTRACKED, but tsconfig's source globs pick them up
+# → spurious TS6307 typecheck failures (155 of them blocked the v0.11.1 cut).
+# Re-reading bytes (the recovery flow below) does NOT remove them — they must
+# be moved aside. `--dedup` does only that; the full run is unchanged.
+# Companion to scripts/check-materialization.sh (which detects + warns).
+if [ "${1:-}" = "--dedup" ] ; then
+  DEST="${TMPDIR:-/tmp}/duo-icloud-dupes"
+  N=0
+  while IFS= read -r f ; do
+    case "$f" in
+      *" "[0-9].*)
+        mkdir -p "$DEST/$(dirname "$f")"
+        mv "$f" "$DEST/$f" && N=$((N + 1))
+        ;;
+    esac
+  done < <(git ls-files --others --exclude-standard -- core renderer shared electron cli 2>/dev/null || true)
+  echo "materialize.sh --dedup: moved $N iCloud sync-conflict duplicate(s) to $DEST"
+  exit 0
+fi
+
 echo ""
 echo "──────────────────────────────────────────────────────────"
 echo " materialize.sh — recovering iCloud-evicted repo files"


### PR DESCRIPTION
## What & why

The macOS iCloud "Optimize Mac Storage" trap has a **second variant** beyond the documented eviction one. CLAUDE.md covers *eviction* (dataless files → `npm run materialize`). This adds detection for the other variant: iCloud drops **sync-conflict duplicates** named `<file> 2.ts` (space + digit + dot + ext) next to the real file. They're **untracked**, but `tsconfig.web.json` / `tsconfig.node.json` `core/**` + `renderer/**` globs pick them up and throw spurious `TS6307` typecheck failures on files nobody touched. **155 of them blocked the v0.11.1 cut (2026-06-18).** `npm run materialize` does **not** clean them — they're moved aside, not re-read.

## Changes

- **`scripts/check-materialization.sh`** — new check: untracked `<name> <digit>.<ext>` files under source dirs (`core renderer shared electron cli`) via `git ls-files --others --exclude-standard` + a bash `case` glob. Uses a `case` glob, **not** `grep -zE` (macOS BSD grep's `-z` ≠ GNU grep's). **Warn-only even under `--strict`** (matches the predev/pretest hook contract; eviction stays the only `--strict`-fatal variant); respects `--quiet`; `--fix` moves dups to `$TMPDIR/duo-icloud-dupes`.
- **`scripts/materialize.sh`** — new `--dedup` action that moves the duplicates aside (the full recovery flow is unchanged).
- **`CLAUDE.md`** — documents the second variant in the *iCloud Drive trap* section.

## Verification

- `bash -n` clean on both scripts.
- Dummy `core/foo 2.ts` → flagged (count 1, named); control `core/legit-v2.ts` (no space-digit) → **not** flagged.
- `bash scripts/materialize.sh --dedup` → moves the dummy to `$TMPDIR/duo-icloud-dupes`, reports `moved 1`.
- Clean state → no duplicate warning. All dummies cleaned up.

Tooling/hygiene only — no product behavior change. Branched off `main` (v0.11.2-dev).

> Heads-up surfaced while testing: this machine currently has **~3,699 actually-dataless (evicted) files** in the repo — the *eviction* variant is live right now. `npm run materialize` is the fix (separate from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)