### PR TITLE
ENH-236: keep focus + caret in the terminal after Send → agent

### DIFF
--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -30,7 +30,7 @@
 > playground send left OS focus in the page (its WebContentsView). Fix routes the
 > focus leg through the proven `focusPane('terminal')` helper. Renderer-only,
 > typecheck clean; **owner-verified live 2026-06-27** across all three send
-> surfaces (smoke-walk waived). PR open; flips to ✅ Shipped on merge.
+> surfaces (smoke-walk waived). PR #113 open; flips to ✅ Shipped on merge.
 
 ## Current state (2026-06-21)
 

--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -22,6 +22,15 @@
 > mark-reviewed, P1). Also **ENH-235** (`duo base new` scaffolder) + the standing
 > Vault/Home backlog, and an archive-debt cleanup (~10 older ✅ entries still
 > ✅-in-place in `tasks.md`, not swept during this cut).
+>
+> **In-flight (worktree `peaceful-robinson-084f22`, branch
+> `claude/peaceful-robinson-084f22`):** **ENH-236** — Send → agent keeps focus +
+> caret in the terminal after the inserted text. Root cause: the shared
+> `onSendToDuo` handler skipped `keyboard.reclaimFocus()`, so a browser-mode
+> playground send left OS focus in the page (its WebContentsView). Fix routes the
+> focus leg through the proven `focusPane('terminal')` helper. Renderer-only,
+> typecheck clean; **owner-verified live 2026-06-27** across all three send
+> surfaces (smoke-walk waived). PR open; flips to ✅ Shipped on merge.
 
 ## Current state (2026-06-21)
 

--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -5078,11 +5078,23 @@ export function App() {
               // into the active terminal's PTY. PRD G11: no Enter
               // appended — the user confirms by pressing Enter
               // themselves. Focus moves to the active terminal so the
-              // user can immediately type their verb without an extra
-              // click. We need both the React-side `focusedColumn`
-              // flip (drives the focus-ring CSS) AND OS-level focus on
-              // the xterm helper-textarea so PTY keystrokes route in —
-              // mirrors togglePaneFocus's terminal branch.
+              // user can immediately keep typing right after the inserted
+              // text, without an extra click.
+              //
+              // ENH-236 — reuse focusPane('terminal') (the ⌘⌥L /
+              // `duo focus-pane terminal` helper) for the focus leg. It
+              // does the React `focusedColumn` flip (focus-ring CSS) AND,
+              // crucially, calls keyboard.reclaimFocus() to pull OS focus
+              // back to the renderer webContents BEFORE focusing the xterm
+              // helper-textarea. The reclaim is REQUIRED when the pill
+              // fires from a browser-mode playground: its WebContentsView
+              // holds OS keyboard focus, so a bare textarea.focus() is a
+              // no-op at the OS level and the next keystrokes route into
+              // the page, not the terminal. The prior inline block flipped
+              // the column + focused the textarea but skipped the reclaim
+              // (despite a comment claiming it mirrored togglePaneFocus's
+              // terminal branch, which DOES reclaim) — so doc/canvas sends
+              // worked but playground sends left focus stranded in the page.
               //
               // ENH-176 — pill firing is now governed by two
               // independent localStorage flags (see useSendPillFlags).
@@ -5095,13 +5107,7 @@ export function App() {
                 activeTabId && ((claudeLive && sendPillFlags.agent) || (sendPillFlags.terminal && !claudeLive))
                   ? (payload) => {
                       void window.electron.pty.write(activeTabId, payload)
-                      setFocusedColumn('terminal')
-                      queueMicrotask(() => {
-                        const textarea = document.querySelector<HTMLTextAreaElement>(
-                          '.xterm-host:not([style*="display: none"]) .xterm-helper-textarea'
-                        )
-                        textarea?.focus()
-                      })
+                      focusPane('terminal')
                     }
                   : null
               }

--- a/tasks.md
+++ b/tasks.md
@@ -41,7 +41,7 @@ Let the user drop a reviewed/abandoned session off the Catch-up board. **Owner l
 
 ### ENH-236: Send → agent — keep focus + caret in the terminal after the inserted text
 
-**Status:** 🚧 Built + **owner-verified 2026-06-27** — PR open (flips to ✅ Shipped on merge). Owner validated all three send surfaces (doc · canvas · browser-mode playground) live; **smoke-walk waived by owner**. **Priority:** P2 (breaks the "select → send → keep typing" flow on playgrounds). **Effort:** S. **Ticket note:** allocated above committed max ENH-235; siblings (`vigorous-chandrasekhar-7d2fb6` et al.) sit ≤ ENH-235 — renumber on collision.
+**Status:** 🚧 Built + **owner-verified 2026-06-27** — PR #113 open (flips to ✅ Shipped on merge). Owner validated all three send surfaces (doc · canvas · browser-mode playground) live; **smoke-walk waived by owner**. **Priority:** P2 (breaks the "select → send → keep typing" flow on playgrounds). **Effort:** S. **Ticket note:** allocated above committed max ENH-235; siblings (`vigorous-chandrasekhar-7d2fb6` et al.) sit ≤ ENH-235 — renumber on collision.
 
 **Provenance.** Owner (2026-06-27): *"when a user selects text in a doc or playground, and then selects 'send to agent', after the text is populated in terminal the carat and focus MUST stay in the terminal after the inserted span so the user can just keep typing."*
 

--- a/tasks.md
+++ b/tasks.md
@@ -39,6 +39,22 @@ Let the user drop a reviewed/abandoned session off the Catch-up board. **Owner l
 
 **The change (proposed).** `duo base new --type <t> [--group <field>] [--cols a,b,c] [--filter '<expr>'] [--name "<view>"] [--out <path>] [--open]` → derives the corpus (`duo vault schema`), emits a `.base` (or ` ```base ` block) that's already lint-clean against the live types/fields/enums, and (with `--open`) hands straight to `duo rollup render`. New CLI verb → 4-surface sync (`cli/duo.ts`, `skill/SKILL.md` + `references/rollup.md`, `agents/duo.md`, `docs/CLI-COVERAGE.md`) + `build:cli` + `sync:claude`. Orthogonal to the Q1=A skill strengthening (helps every rollup path).
 
+### ENH-236: Send → agent — keep focus + caret in the terminal after the inserted text
+
+**Status:** 🚧 Built + **owner-verified 2026-06-27** — PR open (flips to ✅ Shipped on merge). Owner validated all three send surfaces (doc · canvas · browser-mode playground) live; **smoke-walk waived by owner**. **Priority:** P2 (breaks the "select → send → keep typing" flow on playgrounds). **Effort:** S. **Ticket note:** allocated above committed max ENH-235; siblings (`vigorous-chandrasekhar-7d2fb6` et al.) sit ≤ ENH-235 — renumber on collision.
+
+**Provenance.** Owner (2026-06-27): *"when a user selects text in a doc or playground, and then selects 'send to agent', after the text is populated in terminal the carat and focus MUST stay in the terminal after the inserted span so the user can just keep typing."*
+
+**Symptom.** Select text in a **browser-mode playground**, click the **Send → agent** pill; the formatted payload lands at the terminal prompt, but keyboard focus stays in the page — the next keystrokes route into the playground, not the terminal. (Doc/canvas sends already kept focus correctly.)
+
+**Root cause (confirmed by code read).** The shared `onSendToDuo` handler ([App.tsx](renderer/App.tsx) ~5094, used by the markdown editor, the canvas `PageTab`, AND the `BrowserRenderer` pill) did `setFocusedColumn('terminal')` + a `queueMicrotask` `textarea.focus()` but **skipped `keyboard.reclaimFocus()`** — despite a comment claiming it "mirrors togglePaneFocus's terminal branch" (which DOES reclaim). `PANE_FOCUS_RECLAIM` → `event.sender.focus()` ([main.ts](electron/main.ts):2182) pulls OS keyboard focus back to the renderer webContents. Without it, a doc/canvas send works (DOM + iframe already live in the renderer's webContents) but a **browser-mode playground** send doesn't: its `WebContentsView` keeps OS focus, so a bare DOM `textarea.focus()` is an OS-level no-op. Same focus-management domain as [BUG-211](#bug-211) (WCV ↔ keyboard focus), opposite direction.
+
+**Fix (shipped this entry).** Replace the inline focus block in `onSendToDuo` with the proven `focusPane('terminal')` helper (the `⌘⌥L` / `duo focus-pane terminal` path) — it flips the focus column, calls `reclaimFocus()`, THEN focuses the active xterm helper-textarea, uniformly for all three send surfaces. The PTY echo already lands the terminal cursor after the inserted text (no Enter appended — PRD G11), so the caret sits "after the inserted span" ready to keep typing. No CLI/IPC change (pure renderer focus-leg fix; the agent's `duo send` + `duo focus-pane terminal` already compose the same behavior).
+
+**Acceptance.** (1) Doc, (2) canvas page, and (3) **browser-mode playground**: select text → click Send → agent → immediately type → the typed characters append after the inserted text **in the terminal** (no extra click). Verify the playground case with a REAL keystroke (synthetic focus checks can't reproduce WCV OS-focus). No regression to the doc/canvas paths or to no-Enter behavior.
+
+---
+
 ### ENH-226: ⌘O Open bar — autofocus the URL/path entry field on open
 
 **Status:** 🆕 Filed 2026-06-21. **Priority:** P3 (small UX polish). **Effort:** S. **Ticket note:** allocated above this worktree's committed max (ENH-225); siblings sit ≤ ENH-206 — renumber if a concurrent agent collides.


### PR DESCRIPTION
## Summary

When you select text in a doc or playground and click **Send → agent**, the formatted payload lands at the terminal prompt — but, in a **browser-mode playground**, keyboard focus stayed in the page, so the next keystrokes routed into the playground instead of the terminal. This makes the caret + focus stay in the terminal right after the inserted text so you can just keep typing.

## Root cause

The shared `onSendToDuo` handler (`renderer/App.tsx`) — used by the markdown editor, the canvas page, **and** the browser-mode playground pill — flipped `focusedColumn` and focused the xterm helper-textarea, but **skipped `keyboard.reclaimFocus()`** (the OS-level focus-steal, `PANE_FOCUS_RECLAIM` → `event.sender.focus()`), despite a comment claiming it "mirrors togglePaneFocus's terminal branch" (which *does* reclaim).

- **Doc / canvas** live in the renderer's webContents → OS focus is already there, so `textarea.focus()` worked.
- **Browser-mode playground** renders in a separate `WebContentsView` that holds OS keyboard focus → a bare `textarea.focus()` is an OS-level no-op, so keystrokes stayed in the page.

## Fix

Route the focus leg through the proven `focusPane('terminal')` helper (the same one `⌘⌥L` and `duo focus-pane terminal` already use): `focusedColumn` flip → `reclaimFocus()` → focus the active xterm input. No Enter is appended (PRD G11), so the PTY echo leaves the caret right after the inserted text. One change point covers all three send surfaces.

```diff
-                      setFocusedColumn('terminal')
-                      queueMicrotask(() => {
-                        const textarea = document.querySelector<HTMLTextAreaElement>(
-                          '.xterm-host:not([style*="display: none"]) .xterm-helper-textarea'
-                        )
-                        textarea?.focus()
-                      })
+                      focusPane('terminal')
```

## Surface parity (renderer-surfaces rule)

**(a) Mirrored** — the fix is in the single shared `onSendToDuo` handler, so the markdown editor, canvas page, and browser-mode playground pills are all corrected by one change. No CLI surface change (pure renderer focus-leg; the agent's `duo send` + `duo focus-pane terminal` already compose the same behavior).

## Verification

- Renderer-only; `npm run typecheck` clean.
- **Owner-verified live (2026-06-27)** across all three send surfaces (doc · canvas · browser-mode playground): select → Send → agent → type → characters append in the terminal after the inserted text.
- **Smoke-walk waived by the owner.** (The browser-pane case can only be confirmed by a real keystroke — DOM probes can't observe `WebContentsView` OS-focus.)

Tracked as ENH-236 in `tasks.md`. Same focus-management domain as BUG-211 (WCV ↔ keyboard focus), opposite direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)