### PR TITLE
docs: note BUG-212 (#115) merged + flag stale RESUME

### DIFF
--- a/docs/dev/RESUME.md
+++ b/docs/dev/RESUME.md
@@ -1,4 +1,5 @@
 # Resume after compaction — current state (2026-06-21)
+# ⚠ STALE (pre-v0.13.0) — pending a from-scratch refresh. For latest `main` state see `docs/dev/active-sprint.md`. Most recent merge: BUG-212 ([[ default-vault fallback, #115, 2026-06-29).
 # ⚠ THIS WORKTREE (serene-lumiere-3cccdd) = ENH-224 FILE-OPEN FLOW — full state in `docs/prd/enh-224-file-open-flow.md`
 
 > **Post-compaction orientation (2026-06-21).** This worktree builds **ENH-224**

--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -1,5 +1,17 @@
 # Active sprint state — v0.13.0 shipped (shell cron jobs + Send→agent focus fix); next: triage
 
+## Post-v0.13.0 merges to `main` (unreleased — no cut yet)
+
+> **BUG-212** (#115, merged 2026-06-29) — `[[` autocomplete now falls back to the
+> **default vault** in files outside any vault (the suggester + `@` mention popover
+> + `⌘O` switcher share one index that previously resolved the vault *solely* by
+> walking up from the active file → empty popover everywhere outside a vault, which
+> made the persisted default *look* "lost on restart"). New
+> `findVaultRootWithDefault` (enclosing-vault-first / default-second, mirroring the
+> CLI's `resolveVaultOrDefault`); cmd+click wikilink-open uses the same resolver.
+> Live-validated via computer-use on a v0.13.2 local build. Will ship in the next
+> cut (currently v0.13.2 in-progress).
+
 ## v0.13.0 cut 2026-06-27 — Shell-command cron jobs + the Send→agent focus fix
 
 > **Shipped & cut (NOT yet pushed/tagged unless noted):** **ENH-237** (#112)


### PR DESCRIPTION
Orientation-doc honesty pass (CLAUDE.md rule 13) following the BUG-212 merge (#115): record the merge in `active-sprint.md` and add a stale flag + latest-merge pointer atop the 2026-06-21 ENH-224 `RESUME.md`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)