### PR TITLE
ENH-258: filter/group/bucket rollups by an entity (link-valued property)

### DIFF
--- a/cli/duo
+++ b/cli/duo
@@ -33,7 +33,7 @@ var import_crypto = require("crypto");
 var import_node_fs2 = __toESM(require("node:fs"));
 var import_node_path2 = __toESM(require("node:path"));
 
-// node_modules/js-yaml/dist/js-yaml.mjs
+// ../../../node_modules/js-yaml/dist/js-yaml.mjs
 function isNothing(subject) {
   return typeof subject === "undefined" || subject === null;
 }
@@ -3151,6 +3151,7 @@ function buildCorpus(root) {
   const aliases = {};
   const propsByType = /* @__PURE__ */ new Map();
   const enumsByType = /* @__PURE__ */ new Map();
+  const entityRefsByType = /* @__PURE__ */ new Map();
   const countsByType = /* @__PURE__ */ new Map();
   for (const note of notes) {
     const fm = note.frontmatter;
@@ -3164,8 +3165,15 @@ function buildCorpus(root) {
       if (!propsByType.has(t)) propsByType.set(t, /* @__PURE__ */ new Set());
       for (const [k, v] of Object.entries(fm)) {
         propsByType.get(t).add(k);
-        if (typeof v === "string" && !/^\[\[/.test(v)) {
-          const key = `${t}.${k}`;
+        const key = `${t}.${k}`;
+        for (const el of Array.isArray(v) ? v : [v]) {
+          if (typeof el !== "string") continue;
+          for (const ref of extractLinkRefs(el)) {
+            if (!entityRefsByType.has(key)) entityRefsByType.set(key, /* @__PURE__ */ new Map());
+            if (!entityRefsByType.get(key).has(ref.key)) entityRefsByType.get(key).set(ref.key, ref.display);
+          }
+        }
+        if (typeof v === "string" && extractLinkRefs(v).length === 0) {
           if (!enumsByType.has(key)) enumsByType.set(key, /* @__PURE__ */ new Set());
           enumsByType.get(key).add(v);
         }
@@ -3179,6 +3187,13 @@ function buildCorpus(root) {
     for (const k of [...m.keys()].sort()) out2[k] = [...m.get(k)].sort();
     return out2;
   };
+  const sortedRefs = (m) => {
+    const out2 = {};
+    for (const k of [...m.keys()].sort()) {
+      out2[k] = [...m.get(k).entries()].map(([slug, name]) => ({ name, slug })).sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return out2;
+  };
   const counts = {};
   for (const t of [...types].sort()) counts[t] = countsByType.get(t) ?? 0;
   return {
@@ -3189,6 +3204,7 @@ function buildCorpus(root) {
     propsByType: sortedRecord(propsByType),
     countsByType: counts,
     enumsByType: sortedRecord(enumsByType),
+    entityRefsByType: sortedRefs(entityRefsByType),
     templates
   };
 }
@@ -6546,7 +6562,7 @@ ${mergeRes.stdout}`.trim();
 }
 
 // cli/duo.ts
-var VERSION = true ? "0.13.4" : "0.0.0-dev";
+var VERSION = true ? "0.13.5" : "0.0.0-dev";
 var VERBS = [
   // ── Browser & tabs ──
   {

--- a/cli/duo
+++ b/cli/duo
@@ -3109,6 +3109,9 @@ function resolveVaultOrDefault(cwd, explicit, filePath = DEFAULT_VAULT_FILE) {
 // core/vault/corpus.ts
 var import_node_fs6 = __toESM(require("node:fs"));
 var import_node_path6 = __toESM(require("node:path"));
+function engineEntityRefs(value) {
+  return extractLinkRefs(value).filter((r) => r.syntax === "wikilink" || /\.md$/i.test(r.rawTarget));
+}
 function loadTemplates(root) {
   const dir = import_node_path6.default.join(root, "templates");
   let entries;
@@ -3166,14 +3169,17 @@ function buildCorpus(root) {
       for (const [k, v] of Object.entries(fm)) {
         propsByType.get(t).add(k);
         const key = `${t}.${k}`;
+        let scalarIsLink = false;
         for (const el of Array.isArray(v) ? v : [v]) {
           if (typeof el !== "string") continue;
-          for (const ref of extractLinkRefs(el)) {
+          const refs = engineEntityRefs(el);
+          if (el === v && refs.length > 0) scalarIsLink = true;
+          for (const ref of refs) {
             if (!entityRefsByType.has(key)) entityRefsByType.set(key, /* @__PURE__ */ new Map());
             if (!entityRefsByType.get(key).has(ref.key)) entityRefsByType.get(key).set(ref.key, ref.display);
           }
         }
-        if (typeof v === "string" && extractLinkRefs(v).length === 0) {
+        if (typeof v === "string" && !scalarIsLink) {
           if (!enumsByType.has(key)) enumsByType.set(key, /* @__PURE__ */ new Set());
           enumsByType.get(key).add(v);
         }

--- a/core/vault/builder.test.ts
+++ b/core/vault/builder.test.ts
@@ -15,6 +15,7 @@ import {
   setFrontmatterFields,
   entityPanel,
   rollupViewData,
+  modelViewData,
   type RollupBuilderModel,
 } from './builder'
 import { splitFrontmatter } from './parse'
@@ -193,5 +194,47 @@ describe('rollupViewData (D10 — structured rows, D5 — multi-level groups)', 
     const data = rollupViewData(v, 'rollups/broken.md')
     expect(data.error).toMatch(/YAML|views/)
     expect(data.rows).toEqual([])
+  })
+
+  // ENH-258 — a filter on an ENTITY-valued property matches by identity. The
+  // builder emits `contains` with the entity's display name; the engine folds
+  // it to the linked note's targetKey, so a rel-md link value matches. Before
+  // the fix the GUI fed the raw `[Growth](./…md)` string and matched 0 rows.
+  it('a `contains` filter on a link-valued prop matches rows by entity identity', () => {
+    write('themes/growth.md', '---\ntype: theme\n---\n# Growth\n')
+    write('initiatives/a.md', '---\ntype: initiative\ninitiative_theme: "[Growth](../themes/growth.md)"\n---\n# A\n')
+    write('initiatives/b.md', '---\ntype: initiative\ninitiative_theme: "[Growth](../themes/growth.md)"\n---\n# B\n')
+    write('initiatives/c.md', '---\ntype: initiative\n---\n# C (no theme)\n')
+    const model: RollupBuilderModel = {
+      title: 'Growth inits',
+      types: ['initiative'],
+      groupBy: [],
+      buckets: [],
+      filters: [{ property: 'initiative_theme', op: 'contains', value: 'Growth' }],
+      columns: [],
+    }
+    const data = modelViewData(v, model)
+    expect(data.error).toBeNull()
+    expect(data.warnings).toEqual([])
+    expect(data.rows.map((r) => r.title).sort()).toEqual(['a', 'b'])
+  })
+
+  // ENH-258 — a declared bucket keyed by an entity NAME absorbs the rows whose
+  // link-valued group prop points at that entity (identity match via memberEq).
+  it('a declared bucket keyed by an entity name captures its link-grouped rows', () => {
+    write('goals/reduce-churn.md', '---\ntype: goal\n---\n# Reduce Churn\n')
+    write('initiatives/x.md', '---\ntype: initiative\nparent: "[Reduce Churn](../goals/reduce-churn.md)"\n---\n# X\n')
+    const model: RollupBuilderModel = {
+      title: 'By goal',
+      types: ['initiative'],
+      groupBy: ['parent'],
+      buckets: [{ value: 'Reduce Churn' }],
+      filters: [],
+      columns: [],
+    }
+    const data = modelViewData(v, model)
+    expect(data.error).toBeNull()
+    // The declared bucket matched (non-null key) rather than rendering empty.
+    expect(data.buckets).toEqual([{ label: 'Reduce Churn', key: 'Reduce Churn' }])
   })
 })

--- a/core/vault/corpus.ts
+++ b/core/vault/corpus.ts
@@ -12,6 +12,7 @@ import path from 'node:path'
 import { load as yamlLoad } from 'js-yaml'
 import type { Corpus, TypeTemplate } from './types'
 import { readNotes, splitFrontmatter } from './parse'
+import { extractLinkRefs } from '../markdown/vaultLinks'
 
 /** Read `templates/<type>.md` files as the soft-schema registry (D5). Each
  *  declares its `type`, optional filing `folder`, expected `fields`, and an
@@ -63,6 +64,11 @@ export function buildCorpus(root: string): Corpus {
   const aliases: Record<string, string> = {}
   const propsByType = new Map<string, Set<string>>()
   const enumsByType = new Map<string, Set<string>>()
+  // ENH-258 — entity-reference values per link-valued property (`${type}.${prop}`
+  // → slug → display name, deduped by slug). A property lands here iff its
+  // values are entity links (wikilink or OKF rel-md); those are kept OUT of
+  // enumsByType, whose raw link strings are un-matchable filter operands.
+  const entityRefsByType = new Map<string, Map<string, string>>()
   const countsByType = new Map<string, number>()
 
   for (const note of notes) {
@@ -79,9 +85,24 @@ export function buildCorpus(root: string): Corpus {
       if (!propsByType.has(t)) propsByType.set(t, new Set())
       for (const [k, v] of Object.entries(fm)) {
         propsByType.get(t)!.add(k)
-        // Scalar, non-wikilink string → an enum candidate (status, team…).
-        if (typeof v === 'string' && !/^\[\[/.test(v)) {
-          const key = `${t}.${k}`
+        const key = `${t}.${k}`
+        // ENH-258 — entity refs first: any string value (scalar OR array
+        // element) that IS a link (wikilink or OKF rel-md) contributes its
+        // {slug → display} to entityRefsByType, and is NOT an enum candidate.
+        // extractLinkRefs is the ONE link parser (shared with the graph), so
+        // the slug (targetKey) matches the engine's identity fold exactly.
+        for (const el of Array.isArray(v) ? v : [v]) {
+          if (typeof el !== 'string') continue
+          for (const ref of extractLinkRefs(el)) {
+            if (!entityRefsByType.has(key)) entityRefsByType.set(key, new Map())
+            // First display wins for a given identity (stable label).
+            if (!entityRefsByType.get(key)!.has(ref.key)) entityRefsByType.get(key)!.set(ref.key, ref.display)
+          }
+        }
+        // Scalar, non-link string → an enum candidate (status, team…). The
+        // link guard now covers BOTH wikilinks and OKF rel-md (previously only
+        // `[[…` was excluded, so rel-md links leaked in as raw operands).
+        if (typeof v === 'string' && extractLinkRefs(v).length === 0) {
           if (!enumsByType.has(key)) enumsByType.set(key, new Set())
           enumsByType.get(key)!.add(v)
         }
@@ -98,6 +119,17 @@ export function buildCorpus(root: string): Corpus {
     return out
   }
 
+  // ENH-258 — {slug → name} maps → sorted {name, slug}[] (by display name).
+  const sortedRefs = (m: Map<string, Map<string, string>>): Record<string, { name: string; slug: string }[]> => {
+    const out: Record<string, { name: string; slug: string }[]> = {}
+    for (const k of [...m.keys()].sort()) {
+      out[k] = [...m.get(k)!.entries()]
+        .map(([slug, name]) => ({ name, slug }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+    }
+    return out
+  }
+
   // Template-only types count 0 (declared, unused) — R7 lists them anyway.
   const counts: Record<string, number> = {}
   for (const t of [...types].sort()) counts[t] = countsByType.get(t) ?? 0
@@ -110,6 +142,7 @@ export function buildCorpus(root: string): Corpus {
     propsByType: sortedRecord(propsByType),
     countsByType: counts,
     enumsByType: sortedRecord(enumsByType),
+    entityRefsByType: sortedRefs(entityRefsByType),
     templates,
   }
 }

--- a/core/vault/corpus.ts
+++ b/core/vault/corpus.ts
@@ -11,8 +11,22 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { load as yamlLoad } from 'js-yaml'
 import type { Corpus, TypeTemplate } from './types'
+import type { LinkRef } from '../markdown/vaultLinks'
 import { readNotes, splitFrontmatter } from './parse'
 import { extractLinkRefs } from '../markdown/vaultLinks'
+
+/** ENH-258 — the entity references the ENGINE folds to a `Link` (engine.ts
+ *  `parseLinkish`): a wikilink, OR a rel-md link whose target is a `.md` note.
+ *  `extractLinkRefs` is broader (it also matches a rel link to a NON-note
+ *  file, e.g. `[Cover](./cover.png)`), but the engine keeps such a value a
+ *  plain STRING — so it must NOT be offered as an entity operand (the GUI's
+ *  `contains` would never resolve). Narrowing here keeps the corpus's
+ *  classification in lock-step with the engine: `.md`/wikilink → entity ref
+ *  (identity-matched via `contains`); anything else → a scalar string that
+ *  `enumsByType` covers and `==` string-matches. */
+function engineEntityRefs(value: string): LinkRef[] {
+  return extractLinkRefs(value).filter((r) => r.syntax === 'wikilink' || /\.md$/i.test(r.rawTarget))
+}
 
 /** Read `templates/<type>.md` files as the soft-schema registry (D5). Each
  *  declares its `type`, optional filing `folder`, expected `fields`, and an
@@ -86,23 +100,28 @@ export function buildCorpus(root: string): Corpus {
       for (const [k, v] of Object.entries(fm)) {
         propsByType.get(t)!.add(k)
         const key = `${t}.${k}`
-        // ENH-258 — entity refs first: any string value (scalar OR array
-        // element) that IS a link (wikilink or OKF rel-md) contributes its
-        // {slug → display} to entityRefsByType, and is NOT an enum candidate.
-        // extractLinkRefs is the ONE link parser (shared with the graph), so
-        // the slug (targetKey) matches the engine's identity fold exactly.
+        // ENH-258 — an ENTITY-valued property (any string value, scalar OR
+        // array element, the engine folds to a Link) contributes its
+        // {slug → display} to entityRefsByType and is NOT a scalar enum.
+        // `engineEntityRefs` runs ONCE per value here; the scalar-enum guard
+        // below reuses `scalarIsLink` rather than re-scanning (an array value
+        // is never an enum candidate, matching the pre-ENH-258 behavior).
+        let scalarIsLink = false
         for (const el of Array.isArray(v) ? v : [v]) {
           if (typeof el !== 'string') continue
-          for (const ref of extractLinkRefs(el)) {
+          const refs = engineEntityRefs(el)
+          if (el === v && refs.length > 0) scalarIsLink = true
+          for (const ref of refs) {
             if (!entityRefsByType.has(key)) entityRefsByType.set(key, new Map())
             // First display wins for a given identity (stable label).
             if (!entityRefsByType.get(key)!.has(ref.key)) entityRefsByType.get(key)!.set(ref.key, ref.display)
           }
         }
-        // Scalar, non-link string → an enum candidate (status, team…). The
-        // link guard now covers BOTH wikilinks and OKF rel-md (previously only
-        // `[[…` was excluded, so rel-md links leaked in as raw operands).
-        if (typeof v === 'string' && extractLinkRefs(v).length === 0) {
+        // Scalar, non-entity string → an enum candidate (status, team… AND a
+        // rel link the engine keeps a plain string, e.g. a non-`.md` target,
+        // which `==` string-matches). A wikilink / `.md` rel link is an entity
+        // (above), never a raw-string enum operand — the ENH-258 fix.
+        if (typeof v === 'string' && !scalarIsLink) {
           if (!enumsByType.has(key)) enumsByType.set(key, new Set())
           enumsByType.get(key)!.add(v)
         }

--- a/core/vault/types.ts
+++ b/core/vault/types.ts
@@ -107,6 +107,13 @@ export interface Corpus {
   /** `${type}.${prop}` → observed scalar (non-link) values — the live
    *  enum domain used by lint's "did you mean" and the type picker. */
   enumsByType: Record<string, string[]>
+  /** ENH-258 — `${type}.${prop}` → the distinct ENTITY references observed in
+   *  a link-valued property, as {name (display), slug (targetKey identity)}.
+   *  A property is here iff its values are entity links (wikilink or OKF
+   *  rel-md); such props are deliberately ABSENT from enumsByType (their raw
+   *  link strings are un-matchable filter operands). Powers the Rollups
+   *  builder's entity value picker + identity-fold `contains` predicate. */
+  entityRefsByType: Record<string, { name: string; slug: string }[]>
   /** The type templates (the soft-schema registry, D5). */
   templates: TypeTemplate[]
 }

--- a/core/vault/vault.test.ts
+++ b/core/vault/vault.test.ts
@@ -209,6 +209,18 @@ describe('ENH-258 — entity-reference props (link-valued) split from scalar enu
     expect(c.entityRefsByType['initiative.status']).toBeUndefined()
   })
 
+  it('a rel link to a NON-note file is a plain string enum, not an entity ref', () => {
+    // The engine (parseLinkish) only folds `.md` rel links to a Link — a
+    // `.png` rel link stays a plain STRING. So it must NOT be offered as an
+    // entity operand (a `contains` on it would never resolve); it belongs in
+    // enumsByType as its raw string, which `==` string-matches.
+    write('_index.md', '---\nokf_version: "1.0"\ntype: index\n---\n')
+    write('initiatives/a.md', '---\ntype: initiative\ncover: "[Cover](./images/cover.png)"\n---\n# A\n')
+    const c = buildCorpus(tmp)
+    expect(c.entityRefsByType['initiative.cover']).toBeUndefined()
+    expect(c.enumsByType['initiative.cover']).toEqual(['[Cover](./images/cover.png)'])
+  })
+
   it('Obsidian: a wikilink prop is an entity ref (previously absent from enums entirely)', () => {
     fs.mkdirSync(path.join(tmp, '.obsidian'), { recursive: true })
     write('themes/Growth.md', '---\ntype: theme\n---\n# Growth\n')

--- a/core/vault/vault.test.ts
+++ b/core/vault/vault.test.ts
@@ -174,6 +174,63 @@ describe('parse helpers', () => {
 // ENH-216 OKF detection — throwaway tmpdir vaults (the frozen prototype is
 // Obsidian-mode and is NEVER mutated; OKF coverage lives here on its own
 // fixtures).
+describe('ENH-258 — entity-reference props (link-valued) split from scalar enums', () => {
+  let tmp: string
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'duo-vault-enh258-'))
+  })
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  const write = (rel: string, body: string) => {
+    const abs = path.join(tmp, rel)
+    fs.mkdirSync(path.dirname(abs), { recursive: true })
+    fs.writeFileSync(abs, body)
+  }
+
+  it('OKF: a rel-md link prop is an entity ref (not a scalar enum); a scalar stays an enum', () => {
+    write('_index.md', '---\nokf_version: "1.0"\ntype: index\n---\n')
+    write('goals/reduce-churn.md', '---\ntype: goal\n---\n# Reduce Churn\n')
+    write('themes/growth.md', '---\ntype: theme\n---\n# Growth\n')
+    write(
+      'initiatives/onboarding.md',
+      '---\ntype: initiative\nstatus: active\nparent: "[Reduce Churn](../goals/reduce-churn.md)"\ninitiative_theme: "[Growth](../themes/growth.md)"\n---\n# Onboarding\n',
+    )
+    const c = buildCorpus(tmp)
+    // The link props are entity refs, keyed by targetKey identity slug…
+    expect(c.entityRefsByType['initiative.parent']).toEqual([{ name: 'Reduce Churn', slug: 'reduce-churn' }])
+    expect(c.entityRefsByType['initiative.initiative_theme']).toEqual([{ name: 'Growth', slug: 'growth' }])
+    // …and are NOT polluting enumsByType with un-matchable raw-link strings.
+    expect(c.enumsByType['initiative.parent']).toBeUndefined()
+    expect(c.enumsByType['initiative.initiative_theme']).toBeUndefined()
+    // A genuine scalar prop is still a scalar enum, unchanged.
+    expect(c.enumsByType['initiative.status']).toEqual(['active'])
+    expect(c.entityRefsByType['initiative.status']).toBeUndefined()
+  })
+
+  it('Obsidian: a wikilink prop is an entity ref (previously absent from enums entirely)', () => {
+    fs.mkdirSync(path.join(tmp, '.obsidian'), { recursive: true })
+    write('themes/Growth.md', '---\ntype: theme\n---\n# Growth\n')
+    write('initiatives/Onboarding.md', '---\ntype: initiative\ninitiative_theme: "[[Growth]]"\n---\n# Onboarding\n')
+    const c = buildCorpus(tmp)
+    expect(c.entityRefsByType['initiative.initiative_theme']).toEqual([{ name: 'Growth', slug: 'growth' }])
+    expect(c.enumsByType['initiative.initiative_theme']).toBeUndefined()
+  })
+
+  it('array-valued link prop surfaces every entity, deduped by identity slug', () => {
+    fs.mkdirSync(path.join(tmp, '.obsidian'), { recursive: true })
+    write('a.md', '---\ntype: initiative\ntracks: ["[[Q3 Launch]]", "[[Growth]]"]\n---\n')
+    // A second note re-uses one track (alias-cased) — must fold to one slug.
+    write('b.md', '---\ntype: initiative\ntracks: ["[[q3-launch|Growth push]]"]\n---\n')
+    const c = buildCorpus(tmp)
+    const refs = c.entityRefsByType['initiative.tracks']
+    expect(refs.map((r) => r.slug).sort()).toEqual(['growth', 'q3-launch'])
+    // First display wins for a given identity (stable label).
+    expect(refs.find((r) => r.slug === 'q3-launch')!.name).toBe('Q3 Launch')
+  })
+})
+
 describe('OKF detection (ENH-216 D4)', () => {
   let tmp: string
   beforeEach(() => {

--- a/docs/dev/active-sprint.md
+++ b/docs/dev/active-sprint.md
@@ -1,5 +1,28 @@
 # Active sprint state — v0.13.2 shipped (init-on-choose vault + default-vault autocomplete + foreign-vault guard); next: triage
 
+## ENH-258 — Rollup builder: filter/group/bucket by an entity (link-valued prop) (🚧 built + data-path verified, branch `claude/rollup-arbitrary-entity-filter` — LIVE UI WALK PENDING)
+
+> **Owner-reported (photo):** can't filter a rollup on an entity-link property
+> (rolling up initiatives, filter by `initiative_theme`, group/bucket by
+> `parent`→goal) — it silently returns **zero rows**. **Root cause (verified
+> both formats):** `core/vault/corpus.ts` emitted entity-link values into
+> `enumsByType` in their raw serialized form (OKF `[Growth](./…md)`), so the
+> Rollups builder GUI offered un-matchable raw-link operands; the emitted
+> `initiative_theme == "[Growth](…)"` never matches the parsed `Link`
+> (identity `growth`). Engine + CLI (`~=`) were already correct; the defect was
+> corpus-schema + GUI. **Fix (shipped in this branch):** classify link-valued
+> scalars OUT of `enumsByType` into a new `entityRefsByType[type.prop] =
+> [{name, slug}]` (via the shared `extractLinkRefs`, both wikilink + rel-md);
+> surface it through `VaultSchemaDto`/IPC; the builder's filter-value +
+> bucket-value pickers now offer **entities** and emit the identity-fold
+> `contains`. Columns already rendered fine. **Verified:** typecheck clean · 351
+> vault tests green (incl. new corpus classification both-formats + end-to-end
+> `modelViewData` match tests) · `duo rollup show` on the GUI's exact read path
+> (`rollupViewData`) returns **rowCount=2** for `initiative_theme is Growth`
+> (was 0) and a declared entity bucket now matches. `cli/duo` rebuilt,
+> skill/vault.md + sync'd. **Owed:** live Rollups-tab walk (launch Duo) +
+> smoke-walk before any cut; tasks.md ENH-258 flips ✅ on merge.
+
 ## ENH-253 — Navigator repo-root "Pull latest changes" (🚧 built, branch `claude/file-navigator-git-pull-kt3dv7`, PR open — not yet a live-verified owner walk)
 
 > **Owner-requested directly** ("allow context click in file navigator on any

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2588,6 +2588,8 @@ function setupIPC(): void {
           enumsByType: corpus.enumsByType,
           // ENH-248 R7 — the Vault tab's Entities section counts.
           countsByType: corpus.countsByType,
+          // ENH-258 — entity options per link-valued property (filter/bucket).
+          entityRefsByType: corpus.entityRefsByType,
         },
       }
     } catch (e) {

--- a/renderer/components/Rollups/RollupsView.tsx
+++ b/renderer/components/Rollups/RollupsView.tsx
@@ -19,6 +19,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type {
   EntityPanelDto,
+  EntityRefDto,
   RollupFilterDto,
   RollupModelDto,
   RollupViewDataDto,
@@ -1046,6 +1047,18 @@ function BuilderPanel({
     return [...out].sort()
   }
 
+  // ENH-258 — a link-valued property's entity options (union across the
+  // rolled-up types, deduped by slug). Non-empty ⇒ the property is an entity
+  // reference: its filter/bucket value is PICKED from these entities and
+  // matched by identity (contains), never compared as a raw link string.
+  const entityOptions = (property: string): EntityRefDto[] => {
+    const bySlug = new Map<string, string>()
+    for (const t of model.types)
+      for (const e of schema?.entityRefsByType[`${t}.${property}`] ?? []) if (!bySlug.has(e.slug)) bySlug.set(e.slug, e.name)
+    return [...bySlug.entries()].map(([slug, name]) => ({ name, slug })).sort((a, b) => a.name.localeCompare(b.name))
+  }
+  const isLinkProp = (property: string): boolean => entityOptions(property).length > 0
+
   const commitTitle = () => {
     const t = title.trim()
     if (t && t !== model.title) onChange({ ...model, title: t })
@@ -1141,7 +1154,12 @@ function BuilderPanel({
               </span>
             ))}
             <AddBucket
-              options={enumOptions(model.groupBy[0]).filter((v) => !model.buckets.some((b) => b.value === v))}
+              // ENH-258 — for a link-valued group prop the bucket value is an
+              // ENTITY (matched by identity via memberEq), not a raw scalar.
+              options={(isLinkProp(model.groupBy[0])
+                ? entityOptions(model.groupBy[0]).map((e) => e.name)
+                : enumOptions(model.groupBy[0])
+              ).filter((v) => !model.buckets.some((b) => b.value === v))}
               onAdd={(b) => onChange({ ...model, buckets: [...model.buckets, b] })}
             />
           </div>
@@ -1153,7 +1171,9 @@ function BuilderPanel({
         {model.filters.map((f, i) => (
           <div key={`${f.property}-${i}`} className="duo-rollups-filter">
             <code>{f.property}</code>
-            <span>{OPS.find((o) => o.value === f.op)?.label}</span>
+            {/* ENH-258 — an identity `contains` on a link prop reads as "is",
+                not the multi-valued "has member" label. */}
+            <span>{f.op === 'contains' && isLinkProp(f.property) ? 'is' : OPS.find((o) => o.value === f.op)?.label}</span>
             {VALUE_OPS.has(f.op) ? <code>{f.value}</code> : null}
             <button
               type="button"
@@ -1165,7 +1185,13 @@ function BuilderPanel({
             </button>
           </div>
         ))}
-        <AddFilter props={props} enumOptions={enumOptions} onAdd={(f) => onChange({ ...model, filters: [...model.filters, f] })} />
+        <AddFilter
+          props={props}
+          enumOptions={enumOptions}
+          entityOptions={entityOptions}
+          isLinkProp={isLinkProp}
+          onAdd={(f) => onChange({ ...model, filters: [...model.filters, f] })}
+        />
       </div>
 
       <div className="duo-rollups-fieldlabel">Columns</div>
@@ -1287,17 +1313,40 @@ function AddBucket({
 function AddFilter({
   props,
   enumOptions,
+  entityOptions,
+  isLinkProp,
   onAdd,
 }: {
   props: string[]
   enumOptions: (property: string) => string[]
+  entityOptions: (property: string) => EntityRefDto[]
+  isLinkProp: (property: string) => boolean
   onAdd: (f: RollupFilterDto) => void
 }) {
   const [property, setProperty] = useState('')
   const [op, setOp] = useState<RollupFilterDto['op']>('eq')
   const [value, setValue] = useState('')
+  const link = property ? isLinkProp(property) : false
   const needsValue = VALUE_OPS.has(op)
-  const options = property ? enumOptions(property) : []
+  const options = property && !link ? enumOptions(property) : []
+  const entOptions = property && link ? entityOptions(property) : []
+  // ENH-258 — a link-valued property is matched by ENTITY IDENTITY, so its
+  // ops are "is <entity>" (identity `contains`) + set/notset. A raw-string
+  // `==` would never match the parsed Link, which is the bug this fixes.
+  const opsForProp = link
+    ? ([
+        { value: 'contains', label: 'is' },
+        { value: 'set', label: 'is set' },
+        { value: 'notset', label: 'is not set' },
+      ] as { value: RollupFilterDto['op']; label: string }[])
+    : OPS
+
+  const pickProperty = (p: string) => {
+    setProperty(p)
+    setValue('')
+    // Default a link prop to identity membership so its value actually matches.
+    setOp(p && isLinkProp(p) ? 'contains' : 'eq')
+  }
 
   const commit = () => {
     if (!property) return
@@ -1313,10 +1362,7 @@ function AddFilter({
       <select
         className="duo-rollups-add"
         value={property}
-        onChange={(e) => {
-          setProperty(e.target.value)
-          setValue('')
-        }}
+        onChange={(e) => pickProperty(e.target.value)}
         aria-label="Filter property"
       >
         <option value="">+ filter…</option>
@@ -1334,14 +1380,31 @@ function AddFilter({
             onChange={(e) => setOp(e.target.value as RollupFilterDto['op'])}
             aria-label="Filter operator"
           >
-            {OPS.map((o) => (
+            {opsForProp.map((o) => (
               <option key={o.value} value={o.value}>
                 {o.label}
               </option>
             ))}
           </select>
           {needsValue ? (
-            options.length > 0 ? (
+            link ? (
+              // ENH-258 — pick an ENTITY; the stored value is its display name,
+              // which the engine folds to the note's identity (memberEq), so a
+              // `[[Growth]]` / `[Growth](./growth.md)` value all match.
+              <select
+                className="duo-rollups-add"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                aria-label="Filter value"
+              >
+                <option value="">entity…</option>
+                {entOptions.map((e) => (
+                  <option key={e.slug} value={e.name}>
+                    {e.name}
+                  </option>
+                ))}
+              </select>
+            ) : options.length > 0 ? (
               <select
                 className="duo-rollups-add"
                 value={value}

--- a/shared/host-api.ts
+++ b/shared/host-api.ts
@@ -1333,12 +1333,25 @@ export interface RollupViewDataDto {
 
 /** Corpus schema slice the builder's dropdowns draw from (the corpus IS
  *  the schema — computed live per call, never cached). */
+/** ENH-258 — an entity reference observed in a link-valued property: the
+ *  human display name + the targetKey identity slug (the operand the engine's
+ *  identity fold matches). */
+export interface EntityRefDto {
+  name: string
+  slug: string
+}
+
 export interface VaultSchemaDto {
   types: string[]
   propsByType: Record<string, string[]>
   enumsByType: Record<string, string[]>
   /** ENH-248 R7 — type → live entity count (template-only types count 0). */
   countsByType: Record<string, number>
+  /** ENH-258 — `${type}.${prop}` → the entities observed in a link-valued
+   *  property. A property here is an entity reference (not a scalar enum);
+   *  the Rollups builder offers these as filter/bucket value options and
+   *  emits an identity-fold `contains` predicate. */
+  entityRefsByType: Record<string, EntityRefDto[]>
 }
 
 /** ENH-248 R2 — what the browser pane needs to overlay the Duo-native

--- a/skill/references/vault.md
+++ b/skill/references/vault.md
@@ -227,6 +227,21 @@ identity — alias variants of one note form ONE group; an array-valued
 groupBy matches a bucket on any element. `duo base render` JSON carries the
 same `warnings` key.
 
+**Filtering / grouping by an ENTITY (ENH-258).** When a property holds entity
+links (a `parent` → goal, an `initiative_theme` → theme; wikilink OR OKF
+rel-md), filter/group it **by the entity's identity, never its raw link
+string**. Use the membership form — `list(initiative_theme).contains("Growth")`
+or the builder twin `--filter 'initiative_theme~=Growth'` — passing the entity's
+**display name or slug** (both fold through targetKey; `"Growth"` and
+`"growth"` match, `"[Growth](../themes/growth.md)"` does NOT). A raw-link
+operand or a plain `initiative_theme == "[Growth](…)"` silently matches zero
+rows. `duo vault schema` exposes the pickable entities per link-valued property
+under **`entityRefsByType["<type>.<prop>"]`** (`[{name, slug}]`) — read that for
+the valid operands (the Rollups builder GUI populates its entity value/bucket
+pickers from it). Grouping by such a property already folds link identity
+(headers show the entity display name); declared buckets key by entity name too
+(`--bucket 'Reduce Churn'`).
+
 Renders are **stamped build artifacts** (D13): generated-at + source-hash +
 as-of date. Default writes to the vault's `output/` (or legacy `out/` for a
 vault that already has one — ENH-246); re-render to refresh — the

--- a/tasks.md
+++ b/tasks.md
@@ -2,6 +2,21 @@
 
 > **Scope.** Engineering ledger — open work + root-cause writeups for closed bugs. **Canonical version-by-version inventory lives in [CHANGELOG.md](CHANGELOG.md)** and the prose log in docs/RELEASES.md; this file is the running notebook with the "why did this break, what did we learn" detail those don't carry. \*\***Reading guide.** Status field on each entry: `🆕 Filed` / `🟡` / `⏳ Open` (active work) vs. `✅ Shipped vX.Y.Z` (closed; kept for historical reference). To find what's actively open at a glance: `grep -B1 "Status:\*\* (🆕\|🟡\|⏳)"`. \*\***Closed-work archive (ENH-191 / D1, 2026-05-31).** Closed entries (✅ shipped · ❌ won't-do · 🟢 done) now live in [tasks-archive.md](tasks-archive.md) — this file had grown to an 11k-line / 1.2 MB monolith (Duo's own editor worst-case). The cut-version skill moves newly-closed entries to the archive on each cut so this stays lean. \*\***Status legend.** OPEN (stay here): 🆕 filed · 🟡 awaiting-decision · ⏳ open · 🚧 in-progress · 🔴 blocker · ⬜ draft · ⚠️ / 🔵 see entry. CLOSED (archived): ✅ shipped · ❌ won't-do · 🟢 done.
 
+### ENH-258: Rollup builder — filter/group/bucket by an entity (link-valued property)
+**Status:** 🚧 In-progress (filed 2026-07-07, branch `claude/rollup-arbitrary-entity-filter`). **P1.**
+
+**The failure (owner-reported, photo'd).** In the Rollups builder you cannot filter a rollup on a property that holds an entity link — e.g. rolling up `initiative`s and filtering by `initiative_theme` (some link to a `[[Growth]]` theme) or grouping/bucketing by `parent` (→ a goal). It silently returns **zero rows** with no warning.
+
+**Root cause (verified empirically, both formats).** `core/vault/corpus.ts` emits entity-link scalar values into `enumsByType` in their **raw serialized form** — OKF `[Growth](../themes/growth.md)`, and (for wikilinks) nothing at all. The builder GUI populates its filter-value + bucket-value pickers from `enumsByType`, so it offers un-matchable raw-link strings; the emitted predicate `initiative_theme == "[Growth](../themes/growth.md)"` never matches, because the engine has parsed the frontmatter value into a `Link` whose identity is `growth`. The only forms that match are identity-folded: `list(prop).contains("Growth")` / `== "Growth"` (proven: 2/2 rows). **Group-by *rendering* already works** (folds link identity, ENH-255) — the shared defect is the *value operand picker*, which also feeds the declared-bucket UI. The engine + CLI (`--filter k~=v`) are already correct; the defect is corpus-schema + GUI-only.
+
+**Fix (owner-approved: full, applied across filter + group-by buckets + columns, both formats).** Make entity-reference properties first-class in the corpus:
+- `corpus.ts`: classify a link-valued frontmatter scalar (wikilink OR OKF rel-md, via the existing `extractLinkRefs`) OUT of `enumsByType` and into a new `entityRefsByType[type.prop] = [{name, slug}]` (dedupe by slug). Kills the pollution at the source, both formats.
+- `types.ts` / `shared/host-api.ts` `VaultSchemaDto` / `electron/main.ts` VAULT_SCHEMA IPC: surface `entityRefsByType`.
+- `RollupsView.tsx`: for a link-valued property, the filter-value + bucket-value controls become an **entity picker** (names) and the emitted filter is the identity-fold `contains`. Columns unchanged (render fine via `plainCell`). Scalar props unchanged.
+- Tests (corpus classification both formats; builder emits contains; a render proving `initiative_theme = Growth` returns rows); `npm run build:cli`; `check:skill-currency`; smoke-walk before cut.
+
+---
+
 ### ENH-232: Catch-up — rich re-entry for sessions whose worktree was removed
 **Status:** 🔵 Open (filed from ENH-231 walk #2, 2026-06-24). **P1.**
 


### PR DESCRIPTION
## The bug (owner-reported, photo'd)

The Rollups builder can't filter a rollup on a property that holds **entity links** — rolling up `initiative`s and filtering by `initiative_theme` (→ a theme), or grouping/bucketing by `parent` (→ a goal). It **silently returns zero rows**, no warning.

## Root cause (verified in both OKF and Obsidian)

`core/vault/corpus.ts` emitted entity-link frontmatter values into `enumsByType` in their **raw serialized form** (OKF `[Growth](../themes/growth.md)`; wikilinks were dropped entirely). The builder GUI populates its filter-value + bucket-value pickers from `enumsByType`, so it offered un-matchable raw-link strings and emitted `initiative_theme == "[Growth](…)"` — which never matches the value the engine parsed into a `Link` (identity `growth`). Only the identity-folded forms match: `list(initiative_theme).contains("Growth")` / `== "Growth"`.

The **engine and CLI were already correct** (`duo rollup … --filter 'initiative_theme~=Growth'` works with a bare name). The defect was corpus-schema + GUI-only.

## The fix — entity-reference properties are now first-class

- **`corpus.ts`** — a link-valued scalar (wikilink **and** OKF rel-md, via the shared `extractLinkRefs`) is classified **out of** `enumsByType` and into a new `entityRefsByType[type.prop] = [{name, slug}]`, deduped by identity slug. Kills the pollution at the source, both formats.
- **`types.ts` · `shared/host-api.ts` · `electron/main.ts`** — surface `entityRefsByType` through `VaultSchemaDto` + the `VAULT_SCHEMA` IPC.
- **`renderer/components/Rollups/RollupsView.tsx`** — for a link-valued property the filter-value and bucket-value pickers offer the **entities** and emit the identity-fold `contains`; the filter chip reads "is". Columns already rendered fine (`plainCell` → display text).

## Verification

- Reproduced the 0-row failure in both formats before the fix.
- Fix proven through **`rollupViewData`** — the exact function the GUI table renders from: `initiative_theme is Growth` → **rowCount = 2** (was 0); a declared `Reduce Churn` bucket now matches instead of rendering empty.
- **351/351 vault tests pass**, including new regression tests: corpus classification (OKF rel-md + Obsidian wikilink + array-valued dedupe) and end-to-end `modelViewData` entity-match + declared-bucket match.
- Typecheck clean · `cli/duo` rebuilt · 4-surface currency green · `skill/references/vault.md` documents the entity-filter path.

## Still owed (not in this PR)

**Live Rollups-tab walk + `/smoke-walk`** before any version cut — owner will verify on the fleet computer. `tasks.md` ENH-258 flips ✅ on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)