### PR TITLE
ENH-266c: seed .obsidian/app.json for OKF vaults (markdown-link mode)

### DIFF
--- a/cli/duo
+++ b/cli/duo
@@ -33,7 +33,7 @@ var import_crypto = require("crypto");
 var import_node_fs2 = __toESM(require("node:fs"));
 var import_node_path2 = __toESM(require("node:path"));
 
-// node_modules/js-yaml/dist/js-yaml.mjs
+// ../../../node_modules/js-yaml/dist/js-yaml.mjs
 function isNothing(subject) {
   return typeof subject === "undefined" || subject === null;
 }
@@ -2925,6 +2925,13 @@ function detectVaultMode(dir) {
 function isVaultRoot(dir) {
   return detectVaultMode(dir) !== null;
 }
+function isForeignVault(dir) {
+  try {
+    return import_node_fs4.default.statSync(import_node_path4.default.join(dir, "loop.manifest.json")).isFile();
+  } catch {
+    return false;
+  }
+}
 function findVaultRoot(startPath) {
   let dir = import_node_path4.default.resolve(startPath);
   try {
@@ -3050,11 +3057,25 @@ function readDefaultVault(filePath = DEFAULT_VAULT_FILE) {
   const p = readPrefs(filePath).defaultVault;
   return typeof p === "string" && isVaultRoot(p) ? p : null;
 }
+var OBSIDIAN_APP_JSON = { useMarkdownLinks: true, newLinkFormat: "relative" };
+function seedObsidianAppJson(vaultRoot) {
+  const target = import_node_path5.default.join(vaultRoot, ".obsidian", "app.json");
+  if (import_node_fs5.default.existsSync(target)) return false;
+  import_node_fs5.default.mkdirSync(import_node_path5.default.dirname(target), { recursive: true });
+  import_node_fs5.default.writeFileSync(target, JSON.stringify(OBSIDIAN_APP_JSON, null, 2) + "\n");
+  return true;
+}
+function maybeSeedObsidianAppJson(vaultRoot) {
+  if (detectVaultMode(vaultRoot) !== "okf") return false;
+  if (isForeignVault(vaultRoot)) return false;
+  return seedObsidianAppJson(vaultRoot);
+}
 function setDefaultVault(target, filePath = DEFAULT_VAULT_FILE) {
   const abs = import_node_path5.default.resolve(target);
   if (!isVaultRoot(abs)) {
     throw new Error(`not a vault (no okf_version _index.md/index.md or .obsidian/): ${abs}. Run \`duo vault init ${target}\` first.`);
   }
+  maybeSeedObsidianAppJson(abs);
   const prefs = readPrefs(filePath);
   prefs.defaultVault = abs;
   prefs.knownVaults = [.../* @__PURE__ */ new Set([...prefs.knownVaults ?? [], abs])];
@@ -3901,6 +3922,7 @@ function initVault(folder, opts = {}) {
     writeFile("templates/milestone.md", MILESTONE_TPL);
     writeFile("templates/meeting.md", MEETING_TPL);
     writeFile("templates/rollup.md", ROLLUP_TPL);
+    if (seedObsidianAppJson(root)) created.push(".obsidian/app.json");
   }
   const docs = import_node_path10.default.join(import_node_os2.default.homedir(), "Documents");
   if (root === docs || root.startsWith(docs + import_node_path10.default.sep)) {
@@ -6732,7 +6754,7 @@ ${mergeRes.stdout}`.trim();
 }
 
 // cli/duo.ts
-var VERSION = true ? "0.13.6" : "0.0.0-dev";
+var VERSION = true ? "0.13.7" : "0.0.0-dev";
 var VERBS = [
   // ── Browser & tabs ──
   {

--- a/core/vault/default-vault.test.ts
+++ b/core/vault/default-vault.test.ts
@@ -227,9 +227,10 @@ describe('PR#98 review — --no-default contract (C1) + mode-aware rejection (C2
 
   // C2 — proves the "not a vault (no .obsidian/)" path is COSMETIC: the guard
   // (isVaultRoot → detectVaultMode) accepts a real OKF vault, so it's never
-  // rejected; only the message string was stale.
-  it('setDefaultVault accepts an OKF vault (root index.md w/ okf_version, no .obsidian/)', () => {
-    expect(fs.existsSync(path.join(vaultA, '.obsidian'))).toBe(false) // it IS an OKF vault
+  // rejected; only the message string was stale. (ENH-266c: an OKF vault DOES
+  // carry a `.obsidian/` dir now — just the app.json compat seed, not a full
+  // Obsidian scaffold — so this no longer asserts its absence.)
+  it('setDefaultVault accepts an OKF vault (root index.md w/ okf_version)', () => {
     expect(detectVaultMode(vaultA)).toBe('okf')
     expect(() => setDefaultVault(vaultA, prefFile)).not.toThrow()
     expect(readDefaultVault(prefFile)).toBe(vaultA)

--- a/core/vault/default-vault.ts
+++ b/core/vault/default-vault.ts
@@ -93,16 +93,17 @@ export function readDefaultVault(filePath: string = DEFAULT_VAULT_FILE): string 
 }
 
 // ENH-266c — Obsidian-compat `.obsidian/app.json` seed. OKF mode writes
-// frontmatter entity references (owner:, initiative:, attendees:, …) and
 // prose links as standard markdown links (`[Display](./rel.md)`), never
-// wikilinks. Obsidian's FACTORY DEFAULT is the opposite (Use Wikilinks ON),
-// so a human who opens an OKF vault in real Obsidian and authors a NEW link
-// there gets a `[[wikilink]]` that neither Duo's reader nor an OKF-mode
-// vault's own convention expects. Two Obsidian settings flip that default to
-// match OKF's convention — confirmed live against a real installed Obsidian
-// 1.12.7 this cycle (Settings → Files and Links → Use Wikilinks OFF, New
-// link format → Path from current file), then reading the resulting
-// `.obsidian/app.json` back:
+// wikilinks (frontmatter entity refs — owner:, initiative:, attendees:, …
+// — are a separate, NOT-yet-shipped effort, sibling ENH-266a; until that
+// lands they still write `[[Title]]` wikilinks per FOLLOWUP-051). Obsidian's
+// FACTORY DEFAULT is wikilinks-everywhere (Use Wikilinks ON), so a human who
+// opens an OKF vault in real Obsidian and authors a NEW link there gets a
+// `[[wikilink]]` that doesn't match OKF's own prose convention. Two Obsidian
+// settings flip that default to match OKF's convention — confirmed live
+// against a real installed Obsidian 1.12.7 this cycle (Settings → Files and
+// Links → Use Wikilinks OFF, New link format → Path from current file), then
+// reading the resulting `.obsidian/app.json` back:
 const OBSIDIAN_APP_JSON = { useMarkdownLinks: true, newLinkFormat: 'relative' } as const
 
 /** Write `.obsidian/app.json` with the two ENH-266c settings, ABSENT-ONLY —

--- a/core/vault/default-vault.ts
+++ b/core/vault/default-vault.ts
@@ -23,7 +23,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
-import { isVaultRoot, findVaultRoot, resolveVault } from './detect'
+import { isVaultRoot, findVaultRoot, resolveVault, detectVaultMode, isForeignVault } from './detect'
 
 /** Default storage path. Overridable for tests. */
 export const DEFAULT_VAULT_FILE = path.join(os.homedir(), '.claude', 'duo', 'vault.json')
@@ -92,15 +92,69 @@ export function readDefaultVault(filePath: string = DEFAULT_VAULT_FILE): string 
   return typeof p === 'string' && isVaultRoot(p) ? p : null
 }
 
+// ENH-266c — Obsidian-compat `.obsidian/app.json` seed. OKF mode writes
+// frontmatter entity references (owner:, initiative:, attendees:, …) and
+// prose links as standard markdown links (`[Display](./rel.md)`), never
+// wikilinks. Obsidian's FACTORY DEFAULT is the opposite (Use Wikilinks ON),
+// so a human who opens an OKF vault in real Obsidian and authors a NEW link
+// there gets a `[[wikilink]]` that neither Duo's reader nor an OKF-mode
+// vault's own convention expects. Two Obsidian settings flip that default to
+// match OKF's convention — confirmed live against a real installed Obsidian
+// 1.12.7 this cycle (Settings → Files and Links → Use Wikilinks OFF, New
+// link format → Path from current file), then reading the resulting
+// `.obsidian/app.json` back:
+const OBSIDIAN_APP_JSON = { useMarkdownLinks: true, newLinkFormat: 'relative' } as const
+
+/** Write `.obsidian/app.json` with the two ENH-266c settings, ABSENT-ONLY —
+ *  never merges into or overwrites an existing app.json. A vault the owner
+ *  has already configured in Obsidian (any content, even `{}`) is left
+ *  completely untouched; this is what makes it safe to call as a silent
+ *  self-heal rather than an opt-in migration. Returns true iff it wrote the
+ *  file. Callers that need the OKF-mode / foreign-vault gate should use
+ *  {@link maybeSeedObsidianAppJson} instead — this one just writes. */
+export function seedObsidianAppJson(vaultRoot: string): boolean {
+  const target = path.join(vaultRoot, '.obsidian', 'app.json')
+  if (fs.existsSync(target)) return false
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, JSON.stringify(OBSIDIAN_APP_JSON, null, 2) + '\n')
+  return true
+}
+
+/** The eligibility-gated form of {@link seedObsidianAppJson}: only seeds
+ *  OKF-mode vaults (Obsidian-mode vaults keep whatever `.obsidian/app.json`
+ *  the legacy scaffold or the user already wrote — untouched by ENH-266c),
+ *  and skips a FOREIGN vault (one carrying a root `loop.manifest.json` —
+ *  a loopkit/brainkit-family bundle Duo did not create) using the SAME
+ *  `isForeignVault` guard the ENH-216 auto-relink-on-open hook respects —
+ *  Duo must never auto-mutate a vault it doesn't own. Shared by the
+ *  create-on-choose (`setDefaultVault`, below) and vault-open
+ *  (electron/main.ts boot + vault-switch, beside `maybeAutoRelinkVault`)
+ *  call sites so neither has to re-derive the guard. Returns true iff it
+ *  wrote the file. */
+export function maybeSeedObsidianAppJson(vaultRoot: string): boolean {
+  if (detectVaultMode(vaultRoot) !== 'okf') return false
+  if (isForeignVault(vaultRoot)) return false
+  return seedObsidianAppJson(vaultRoot)
+}
+
 /** Set the default vault. Validates the target is a real vault first (refuses a
  *  non-vault, so a typo can't strand the pref), and records it in
  *  `knownVaults` so the picker keeps offering it even after a later clear.
- *  Atomic write; preserves any existing known set. */
+ *  Atomic write; preserves any existing known set.
+ *
+ *  ENH-266c — also self-heals the Obsidian-compat app.json seed (absent-only,
+ *  OKF-mode + non-foreign only, see {@link maybeSeedObsidianAppJson}). This is
+ *  the site that covers the "already a vault, just set it as default" branch
+ *  of `duo vault default <path> --init` (ENH-242 create-on-choose) — the
+ *  branch that never calls `initVault` (and therefore never hits the
+ *  scaffold-time seed in `scaffold.ts`) because the folder was already a
+ *  vault. */
 export function setDefaultVault(target: string, filePath: string = DEFAULT_VAULT_FILE): string {
   const abs = path.resolve(target)
   if (!isVaultRoot(abs)) {
     throw new Error(`not a vault (no okf_version _index.md/index.md or .obsidian/): ${abs}. Run \`duo vault init ${target}\` first.`)
   }
+  maybeSeedObsidianAppJson(abs)
   const prefs = readPrefs(filePath)
   prefs.defaultVault = abs
   prefs.knownVaults = [...new Set([...(prefs.knownVaults ?? []), abs])]

--- a/core/vault/index.ts
+++ b/core/vault/index.ts
@@ -50,6 +50,8 @@ export {
   resolveVaultOrDefault,
   resolveVaultForUi,
   DEFAULT_VAULT_FILE,
+  seedObsidianAppJson,
+  maybeSeedObsidianAppJson,
 } from './default-vault'
 export { buildCorpus, loadTemplates, parseBaseYaml } from './corpus'
 export { backlinks, orphans, type Backlink } from './graph'

--- a/core/vault/obsidian-compat.test.ts
+++ b/core/vault/obsidian-compat.test.ts
@@ -1,8 +1,9 @@
 // ENH-266c — Obsidian-compat `.obsidian/app.json` seed. OKF mode writes
-// frontmatter entity refs + prose links as standard markdown links, never
-// wikilinks; these two Obsidian settings (confirmed live against a real
-// installed Obsidian 1.12.7) flip Obsidian's factory-default (Use Wikilinks
-// ON) so a human authoring a NEW link inside Obsidian matches OKF's own
+// prose links as standard markdown links, never wikilinks (frontmatter
+// entity refs are a separate, not-yet-shipped effort — sibling ENH-266a);
+// these two Obsidian settings (confirmed live against a real installed
+// Obsidian 1.12.7) flip Obsidian's factory-default (Use Wikilinks ON) so a
+// human authoring a NEW prose link inside Obsidian matches OKF's own
 // convention instead of producing an unresolved phantom-node wikilink.
 //
 // Covers the shared helper directly (seed-when-absent, respect-when-present,

--- a/core/vault/obsidian-compat.test.ts
+++ b/core/vault/obsidian-compat.test.ts
@@ -1,0 +1,147 @@
+// ENH-266c — Obsidian-compat `.obsidian/app.json` seed. OKF mode writes
+// frontmatter entity refs + prose links as standard markdown links, never
+// wikilinks; these two Obsidian settings (confirmed live against a real
+// installed Obsidian 1.12.7) flip Obsidian's factory-default (Use Wikilinks
+// ON) so a human authoring a NEW link inside Obsidian matches OKF's own
+// convention instead of producing an unresolved phantom-node wikilink.
+//
+// Covers the shared helper directly (seed-when-absent, respect-when-present,
+// foreign-bundle-skip) plus its three call sites: scaffold-time (initVault's
+// OKF branch), create-on-choose (setDefaultVault picking an ALREADY-existing
+// vault — the branch that never touches initVault), and the eligibility gate
+// electron/main.ts's vault-open flow (maybeAutoRelinkVault) reuses.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  seedObsidianAppJson,
+  maybeSeedObsidianAppJson,
+  setDefaultVault,
+  detectVaultMode,
+  isForeignVault,
+} from './index'
+import { initVault } from './scaffold'
+
+let root: string
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'duo-obsidian-compat-'))
+})
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+const APP_JSON_PATH = (vault: string) => path.join(vault, '.obsidian', 'app.json')
+
+describe('seedObsidianAppJson — the raw absent-only writer', () => {
+  it('seed-when-absent: writes exactly the two ENH-266c keys', () => {
+    const v = path.join(root, 'v')
+    fs.mkdirSync(v, { recursive: true })
+    expect(seedObsidianAppJson(v)).toBe(true)
+    expect(fs.existsSync(APP_JSON_PATH(v))).toBe(true)
+    const parsed = JSON.parse(fs.readFileSync(APP_JSON_PATH(v), 'utf8'))
+    expect(parsed).toEqual({ useMarkdownLinks: true, newLinkFormat: 'relative' })
+    expect(Object.keys(parsed).sort()).toEqual(['newLinkFormat', 'useMarkdownLinks'])
+  })
+
+  it('respect-when-present: an existing app.json (any content) is byte-unchanged', () => {
+    const v = path.join(root, 'v')
+    fs.mkdirSync(path.join(v, '.obsidian'), { recursive: true })
+    const ownerContent = JSON.stringify({ promptDelete: true, someOtherKey: 'kept' }, null, 2) + '\n'
+    fs.writeFileSync(APP_JSON_PATH(v), ownerContent)
+    expect(seedObsidianAppJson(v)).toBe(false)
+    expect(fs.readFileSync(APP_JSON_PATH(v), 'utf8')).toBe(ownerContent) // byte-identical
+  })
+
+  it('respect-when-present: even an EMPTY app.json ({}) is left untouched', () => {
+    const v = path.join(root, 'v')
+    fs.mkdirSync(path.join(v, '.obsidian'), { recursive: true })
+    fs.writeFileSync(APP_JSON_PATH(v), '{}')
+    expect(seedObsidianAppJson(v)).toBe(false)
+    expect(fs.readFileSync(APP_JSON_PATH(v), 'utf8')).toBe('{}')
+  })
+})
+
+describe('maybeSeedObsidianAppJson — the OKF-mode + non-foreign gate', () => {
+  it('seeds an OKF-mode vault', () => {
+    const v = initVault(path.join(root, 'v')).root
+    fs.rmSync(APP_JSON_PATH(v)) // scaffold-time seed already wrote it — clear to isolate this call
+    expect(detectVaultMode(v)).toBe('okf')
+    expect(maybeSeedObsidianAppJson(v)).toBe(true)
+    expect(fs.existsSync(APP_JSON_PATH(v))).toBe(true)
+  })
+
+  it('skips an Obsidian-mode vault (its own .obsidian/app.json is a different shape — never touched)', () => {
+    const v = initVault(path.join(root, 'v'), { format: 'obsidian' }).root
+    expect(detectVaultMode(v)).toBe('obsidian')
+    const before = fs.readFileSync(APP_JSON_PATH(v), 'utf8')
+    expect(maybeSeedObsidianAppJson(v)).toBe(false)
+    expect(fs.readFileSync(APP_JSON_PATH(v), 'utf8')).toBe(before) // legacy Obsidian scaffold content intact
+  })
+
+  it('foreign-bundle-skip: a vault carrying loop.manifest.json is NEVER seeded, even via the gate', () => {
+    const v = path.join(root, 'foreign')
+    fs.mkdirSync(v, { recursive: true })
+    fs.writeFileSync(path.join(v, '_index.md'), '---\nokf_version: "0.1"\ntype: index\n---\n')
+    fs.writeFileSync(path.join(v, 'loop.manifest.json'), JSON.stringify({ kit: 'brainkit' }))
+    expect(detectVaultMode(v)).toBe('okf')
+    expect(isForeignVault(v)).toBe(true)
+    expect(maybeSeedObsidianAppJson(v)).toBe(false)
+    expect(fs.existsSync(APP_JSON_PATH(v))).toBe(false)
+  })
+})
+
+describe('site 1 — scaffold-time seed (initVault OKF branch)', () => {
+  it('a freshly-scaffolded OKF vault carries .obsidian/app.json with the two keys', () => {
+    const v = initVault(path.join(root, 'v')).root
+    const parsed = JSON.parse(fs.readFileSync(APP_JSON_PATH(v), 'utf8'))
+    expect(parsed).toEqual({ useMarkdownLinks: true, newLinkFormat: 'relative' })
+  })
+
+  it('a freshly-scaffolded Obsidian-mode vault keeps its OWN legacy app.json (different keys, untouched)', () => {
+    const v = initVault(path.join(root, 'v'), { format: 'obsidian' }).root
+    const parsed = JSON.parse(fs.readFileSync(APP_JSON_PATH(v), 'utf8'))
+    expect(parsed).toEqual({ promptDelete: false, alwaysUpdateLinks: true })
+  })
+})
+
+describe('site 2 — create-on-choose via setDefaultVault (the "already a vault" branch)', () => {
+  it('picking an EXISTING OKF vault that pre-dates ENH-266c self-heals the seed', () => {
+    // Simulate a vault created before this PR shipped: a bare OKF marker,
+    // no .obsidian/ at all — never went through initVault's scaffold-time
+    // seed. This is exactly the branch `duo vault default <path> --init`
+    // hits when <path> is already a vault (it calls setDefaultVault directly,
+    // never initVault).
+    const v = path.join(root, 'pre-existing')
+    fs.mkdirSync(v, { recursive: true })
+    fs.writeFileSync(path.join(v, '_index.md'), '---\nokf_version: "0.1"\ntype: index\n---\n')
+    expect(fs.existsSync(APP_JSON_PATH(v))).toBe(false)
+    const prefFile = path.join(root, 'vault.json')
+    setDefaultVault(v, prefFile)
+    expect(fs.existsSync(APP_JSON_PATH(v))).toBe(true)
+    expect(JSON.parse(fs.readFileSync(APP_JSON_PATH(v), 'utf8'))).toEqual({
+      useMarkdownLinks: true,
+      newLinkFormat: 'relative',
+    })
+  })
+
+  it('setDefaultVault never seeds a foreign OKF bundle even when chosen as default', () => {
+    const v = path.join(root, 'foreign')
+    fs.mkdirSync(v, { recursive: true })
+    fs.writeFileSync(path.join(v, '_index.md'), '---\nokf_version: "0.1"\ntype: index\n---\n')
+    fs.writeFileSync(path.join(v, 'loop.manifest.json'), JSON.stringify({ kit: 'brainkit' }))
+    const prefFile = path.join(root, 'vault.json')
+    setDefaultVault(v, prefFile)
+    expect(fs.existsSync(APP_JSON_PATH(v))).toBe(false)
+  })
+
+  it('setDefaultVault respects an already-configured app.json (byte-unchanged)', () => {
+    const v = initVault(path.join(root, 'v')).root
+    const owner = JSON.stringify({ useMarkdownLinks: false, newLinkFormat: 'absolute', customFlag: true })
+    fs.writeFileSync(APP_JSON_PATH(v), owner)
+    const prefFile = path.join(root, 'vault.json')
+    setDefaultVault(v, prefFile)
+    expect(fs.readFileSync(APP_JSON_PATH(v), 'utf8')).toBe(owner)
+  })
+})

--- a/core/vault/okf.test.ts
+++ b/core/vault/okf.test.ts
@@ -213,9 +213,8 @@ describe('initVault — OKF scaffold + the D2 default flip', () => {
     expect(detectVaultMode(r.root)).toBe('okf')
   })
 
-  it('writes a root _index.md marker with okf_version + type:index + the listing fence, and NO .obsidian/', () => {
+  it('writes a root _index.md marker with okf_version + type:index + the listing fence, and NO README/bases', () => {
     const v = initVault(path.join(root, 'v')).root
-    expect(fs.existsSync(path.join(v, '.obsidian'))).toBe(false)
     expect(fs.existsSync(path.join(v, 'README.md'))).toBe(false)
     expect(fs.existsSync(path.join(v, 'bases'))).toBe(false)
     expect(fs.existsSync(path.join(v, 'index.md'))).toBe(false) // ENH-245: not the legacy name
@@ -223,6 +222,18 @@ describe('initVault — OKF scaffold + the D2 default flip', () => {
     expect(idx).toContain('okf_version:')
     expect(idx).toContain('type: index')
     expect(idx).toContain(LISTING_FENCE)
+  })
+
+  // ENH-266c — OKF mode now DOES carry a `.obsidian/` dir, but ONLY the
+  // app.json Obsidian-compat seed (see obsidian-compat.test.ts for the
+  // dedicated seed/respect/foreign-skip coverage).
+  it('ENH-266c: OKF init seeds .obsidian/app.json with the two Obsidian-compat keys', () => {
+    const v = initVault(path.join(root, 'v')).root
+    expect(fs.readdirSync(path.join(v, '.obsidian'))).toEqual(['app.json'])
+    expect(JSON.parse(fs.readFileSync(path.join(v, '.obsidian', 'app.json'), 'utf8'))).toEqual({
+      useMarkdownLinks: true,
+      newLinkFormat: 'relative',
+    })
   })
 
   it('templates are type-stamped (the 6-type set, incl. rollup) and the corpus surfaces index too (D10)', () => {

--- a/core/vault/scaffold.test.ts
+++ b/core/vault/scaffold.test.ts
@@ -98,9 +98,8 @@ describe('vault init (OKF — the new default, ENH-216 D2)', () => {
     expect(isVaultRoot(r.root)).toBe(true)
   })
 
-  it('scaffolds an OKF marker (root _index.md w/ okf_version + type:index), NO .obsidian/ / README / bases', () => {
+  it('scaffolds an OKF marker (root _index.md w/ okf_version + type:index), NO README / bases', () => {
     const v = initVault(path.join(root, 'v')).root
-    expect(fs.existsSync(path.join(v, '.obsidian'))).toBe(false)
     expect(fs.existsSync(path.join(v, 'README.md'))).toBe(false)
     expect(fs.existsSync(path.join(v, 'bases'))).toBe(false)
     expect(fs.existsSync(path.join(v, 'index.md'))).toBe(false) // ENH-245: not the legacy name
@@ -109,6 +108,16 @@ describe('vault init (OKF — the new default, ENH-216 D2)', () => {
     expect(idx).toContain('type: index')
     // the co-owned listing fence seed (U2 writes it; U3 fills the body)
     expect(idx).toContain('<!-- duo:listing -->')
+  })
+
+  // ENH-266c — OKF mode DOES get a `.obsidian/` dir now, but ONLY the
+  // app.json Obsidian-compat seed — never plugins/, workspace, or anything
+  // else Obsidian-internal (this is not a full Obsidian scaffold).
+  it('ENH-266c: seeds .obsidian/app.json (absent-only) so Obsidian authors OKF-convention links', () => {
+    const v = initVault(path.join(root, 'v')).root
+    expect(fs.readdirSync(path.join(v, '.obsidian'))).toEqual(['app.json'])
+    const appJson = JSON.parse(fs.readFileSync(path.join(v, '.obsidian', 'app.json'), 'utf8'))
+    expect(appJson).toEqual({ useMarkdownLinks: true, newLinkFormat: 'relative' })
   })
 
   it('templates are the SAME 6-type set as Obsidian (the initiative minus its embedded .base)', () => {

--- a/core/vault/scaffold.ts
+++ b/core/vault/scaffold.ts
@@ -371,11 +371,12 @@ export function initVault(
     // README); no bases/. (There IS a `.obsidian/` now — see below.)
 
     // ENH-266c — seed `.obsidian/app.json` (absent-only) so a human who later
-    // opens this OKF vault in real Obsidian authors NEW links (frontmatter
-    // entity refs + prose) in the SAME markdown-link convention OKF/Duo
-    // already write, instead of Obsidian's factory-default wikilinks. This
-    // is the ONLY `.obsidian/` content an OKF vault gets — no plugins/,
-    // no workspace, nothing else Obsidian-internal.
+    // opens this OKF vault in real Obsidian authors NEW prose links in the
+    // SAME markdown-link convention OKF/Duo already write, instead of
+    // Obsidian's factory-default wikilinks. (Frontmatter entity refs are a
+    // separate, not-yet-shipped effort — sibling ENH-266a.) This is the ONLY
+    // `.obsidian/` content an OKF vault gets — no plugins/, no workspace,
+    // nothing else Obsidian-internal.
     if (seedObsidianAppJson(root)) created.push('.obsidian/app.json')
   }
 

--- a/core/vault/scaffold.ts
+++ b/core/vault/scaffold.ts
@@ -13,6 +13,7 @@ import { loadTemplates } from './corpus'
 import { ensureNoteId } from './move'
 import { OKF_INDEX_FILENAMES, OKF_INDEX_FILENAME_DEFAULT } from './okf-filenames'
 import { OUTPUT_DIR_DEFAULT } from './output-dir'
+import { seedObsidianAppJson } from './default-vault'
 import type { TypeTemplate, VaultMode } from './types'
 
 const TB = '`'.repeat(3) // ``` — the markdown code fence
@@ -367,7 +368,15 @@ export function initVault(
     writeFile('templates/meeting.md', MEETING_TPL)
     writeFile('templates/rollup.md', ROLLUP_TPL)
     // No README (D10: the root listing is the index file, not a frontmatter-less
-    // README); no .obsidian/, no bases/.
+    // README); no bases/. (There IS a `.obsidian/` now — see below.)
+
+    // ENH-266c — seed `.obsidian/app.json` (absent-only) so a human who later
+    // opens this OKF vault in real Obsidian authors NEW links (frontmatter
+    // entity refs + prose) in the SAME markdown-link convention OKF/Duo
+    // already write, instead of Obsidian's factory-default wikilinks. This
+    // is the ONLY `.obsidian/` content an OKF vault gets — no plugins/,
+    // no workspace, nothing else Obsidian-internal.
+    if (seedObsidianAppJson(root)) created.push('.obsidian/app.json')
   }
 
   // iCloud-eviction trap (PRD risk): warn if the vault lives under

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4398,6 +4398,14 @@ function maybeAutoRelinkVault(root: string | null, opts: { write?: boolean } = {
     }
     return
   }
+  // ENH-266c — retroactive Obsidian-compat seed for an OKF vault created
+  // before this PR shipped. Absent-only + synchronous (a single fs.existsSync
+  // check), so it rides the SAME mode/foreign gate just passed above rather
+  // than deferring off the critical path like the relink walk below. Fires on
+  // both boot (write=true) and a live vault-switch (write=false, dry-run for
+  // relink) — the app.json seed itself has no write/dry-run distinction, it's
+  // always safe to self-heal.
+  vaultCore.maybeSeedObsidianAppJson(root)
   // Mark BEFORE scheduling so a second trigger in the same window is dropped;
   // the entry self-clears after the dedupe window so a later genuine re-open
   // (e.g. a note moved, then the vault re-picked) relinks again.


### PR DESCRIPTION
## Summary
- OKF mode writes prose links as standard markdown links (`[Display](./rel.md)`), never wikilinks — but Obsidian's factory default (Use Wikilinks ON) means a human who opens an OKF vault in real Obsidian and authors a NEW link there gets a `[[wikilink]]` that doesn't match OKF's own convention. This PR seeds `.obsidian/app.json` with the two settings that fix that, so Obsidian authors in the same convention OKF/Duo already write.
- The exact setting values (`{useMarkdownLinks: true, newLinkFormat: "relative"}`) were determined empirically this session: a real installed Obsidian 1.12.7 was used to flip Settings → Files and Links → Use Wikilinks OFF + New link format → "Path from current file", then the resulting `.obsidian/app.json` was read back to capture the exact keys/values Obsidian itself writes — this wasn't guessed from Obsidian's docs.
- Seeding is absent-only (never touches an existing `.obsidian/app.json`, even `{}`) and gated to OKF-mode, non-foreign vaults (reusing the ENH-216 `isForeignVault` guard), covering all three real write paths: scaffold-time (`initVault`'s OKF branch), create-on-choose (`setDefaultVault`, for a pre-existing bare OKF vault), and vault-open/boot self-heal (`electron/main.ts`, beside `maybeAutoRelinkVault`).
- This is PR-2 of a coordinated 4-PR ENH-266 rollout (see Test plan for the empirical finding that motivated the whole umbrella).

## Test plan
- [x] `npm run typecheck` clean on both configs (node + web)
- [x] `npm run test:run` — 141 files / 2244 tests, all passing (11 new tests: seed-when-absent, respect-when-present including a byte-identical empty-file case, foreign-vault-skip, and all three call sites individually)
- [x] `npm run build:cli` — rebuilt `cli/duo` is byte-identical to the committed binary (no drift)
- [x] `npm run check:skill-currency` — 81 verbs, 0 failures (no CLI-doc sync needed; this shipped as a side effect of existing verbs, not a new one)
- [x] Live-verified against the rebuilt CLI binary: `vault init --format=okf` writes exactly `{useMarkdownLinks:true, newLinkFormat:"relative"}` to `.obsidian/app.json`, and `vault default <path>` self-heals the same file on a pre-existing bare OKF vault
- [x] Traced every `initVault(...)` call site (`cli/duo.ts` x2, `electron/main.ts` `VAULT_CREATE`, `scaffold.ts` itself) and every `.obsidian` reference across `core/` and `renderer/` — confirmed all real write/self-heal sites are covered and the "for free" claims (VAULT_CREATE dialog, `vault default --init` both branches) check out against the actual call graph
- [x] Confirmed no regression in `detectVaultMode`'s D4 tie-break (`okf_version` wins over `.obsidian/` presence) — an OKF vault that now carries `.obsidian/app.json` still classifies as `okf`, both via the core detector and the renderer's IPC-delegated detector; the one renderer function that does a literal `.obsidian/`-presence-only walk (`wikilinkResolver.ts`'s legacy `findVaultRoot`) is confirmed dead code, not on the live click-nav path
- [x] Confirmed `SEARCH_SKIP_DIRS`/`SKIP_DIRS` already skip `.obsidian`, so the new file doesn't leak into corpus/search
- [x] Independent review pass (a second agent) caught three code/test comments overclaiming that OKF mode already writes frontmatter entity refs (`owner:`, `initiative:`, `attendees:`, …) as markdown links "never wikilinks" — that's false today per the still-locked FOLLOWUP-051; frontmatter entity refs remain `[[Title]]` wikilinks in OKF mode until the sibling ENH-266a effort ships. Fixed in `e59b6a1` — comments/docs only, no behavior change, full gate suite re-verified green after
- [x] `tasks.md`/`docs`/`skill`/`agents` correctly left untouched — out of this PR's scope; the ENH-266 umbrella ledger entry is tracked separately

This is part of a coordinated 4-PR rollout — duo PR-1, PR-2 (this PR), PR-3, plus a companion loop-library PR — tracked under ENH-266 in the duo repo's `tasks.md`. Authored by an AI agent workflow; human-reviewed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)