### PR TITLE
ENH-267: titlebar default-vault chip — show the set default vault in the app header

### DIFF
--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -579,18 +579,20 @@ export function App() {
   const [dirtyPaths, setDirtyPaths] = useState<Set<string>>(() => new Set())
   const [activeWorking, setActiveWorking] = useState<ActiveWorking>({ kind: 'browser' })
 
-  // ENH-228 — the Vault tab is present-when-default (D4). Track whether a
-  // default vault is set; the tab is synthesized into fileTabs (after Home)
-  // whenever this is true, and removed otherwise. Fetched once at mount and
+  // ENH-228 — the Vault tab is present-when-default (D4). Track the default
+  // vault's root path (null when unset); the tab is synthesized into fileTabs
+  // (after Home) whenever one is set, and removed otherwise. The titlebar
+  // vault chip renders off the same state. Fetched once at mount and
   // re-read whenever any path broadcasts `duo-vault-default-changed` (the
   // header switcher, Settings → Default Vault, `duo vault default`).
-  const [hasDefaultVault, setHasDefaultVault] = useState(false)
+  const [defaultVaultRoot, setDefaultVaultRoot] = useState<string | null>(null)
+  const hasDefaultVault = defaultVaultRoot !== null
   useEffect(() => {
     let alive = true
     const refresh = async () => {
       try {
         const r = await window.electron.vault.getDefault()
-        if (alive) setHasDefaultVault(!!r?.defaultVault)
+        if (alive) setDefaultVaultRoot(r?.defaultVault ?? null)
       } catch {
         /* leave prior state — the tab persists across a transient IPC failure */
       }
@@ -4824,6 +4826,34 @@ export function App() {
               <span className="text-zinc-500 shrink-0" aria-hidden="true">⎇</span>
               <span className="truncate font-mono text-zinc-500">{navWorktree.branch || 'detached'}</span>
             </span>
+          )}
+          {/* Default-vault chip — glanceable "captures land here" confirmation.
+              Driven by the same live defaultVaultRoot state that gates the
+              Vault tab (mount fetch + duo-vault-default-changed re-reads), so
+              it appears/re-points/disappears in lockstep across every writer
+              (Settings, menu radio, `duo vault default`, another window).
+              Click activates the Vault tab — same dispatch as `duo goto vault`
+              (ENH-257); the tab is guaranteed present while the chip renders. */}
+          {defaultVaultRoot && (
+            <button
+              type="button"
+              onClick={() => {
+                setActiveWorking({ kind: 'file', id: VAULT_TAB_ID })
+                setFocusedColumn('working')
+              }}
+              className="titlebar-nodrag ml-1 inline-flex items-center gap-1 shrink min-w-0 max-w-[180px] text-[11px] text-zinc-600 rounded-full px-2 py-0.5 border border-border hover:bg-accent/10 hover:border-accent/40 transition-colors"
+              title={`Default vault: ${defaultVaultRoot} — click to open the Vault tab`}
+              aria-label={`Default vault: ${defaultVaultRoot}`}
+            >
+              {/* Open-book glyph — same mark the Vault tab uses (ENH-228). */}
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true" className="shrink-0">
+                <path d="M5 2.4C4.2 1.9 2.9 1.7 1.5 1.9V7.7c1.4-.2 2.7 0 3.5.5.8-.5 2.1-.7 3.5-.5V1.9C7.1 1.7 5.8 1.9 5 2.4Z" stroke="currentColor" strokeWidth="0.9" strokeLinejoin="round" />
+                <path d="M5 2.4V8.2" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" />
+              </svg>
+              <span className="truncate">
+                {defaultVaultRoot.replace(/\/+$/, '').split('/').pop() || defaultVaultRoot}
+              </span>
+            </button>
           )}
         </div>
         {workspacePillMenuEnabled && (

--- a/tasks.md
+++ b/tasks.md
@@ -2,6 +2,18 @@
 
 > **Scope.** Engineering ledger — open work + root-cause writeups for closed bugs. **Canonical version-by-version inventory lives in [CHANGELOG.md](CHANGELOG.md)** and the prose log in docs/RELEASES.md; this file is the running notebook with the "why did this break, what did we learn" detail those don't carry. \*\***Reading guide.** Status field on each entry: `🆕 Filed` / `🟡` / `⏳ Open` (active work) vs. `✅ Shipped vX.Y.Z` (closed; kept for historical reference). To find what's actively open at a glance: `grep -B1 "Status:\*\* (🆕\|🟡\|⏳)"`. \*\***Closed-work archive (ENH-191 / D1, 2026-05-31).** Closed entries (✅ shipped · ❌ won't-do · 🟢 done) now live in [tasks-archive.md](tasks-archive.md) — this file had grown to an 11k-line / 1.2 MB monolith (Duo's own editor worst-case). The cut-version skill moves newly-closed entries to the archive on each cut so this stays lean. \*\***Status legend.** OPEN (stay here): 🆕 filed · 🟡 awaiting-decision · ⏳ open · 🚧 in-progress · 🔴 blocker · ⬜ draft · ⚠️ / 🔵 see entry. CLOSED (archived): ✅ shipped · ❌ won't-do · 🟢 done.
 
+### ENH-267: Titlebar default-vault chip — show the set default vault in the app header
+
+**Status:** ⏳ Open 2026-07-16 — implemented on `claude/default-vault-scope-jdq6fh`, PR in review. **Priority:** Low (glanceable-state QoL). **Ticket note:** allocated after grepping tasks.md (max ENH-266) and checking open PRs for claims.
+
+**Problem.** The default vault (the global `~/.claude/duo/vault.json` pref every capture/search/rollup falls back to) is invisible unless you open Settings or the Vault tab — nothing in the chrome answers "where will ⇧⌘N land right now?". This matters because the setting is machine-global (D11): a `duo vault default` from ANY terminal or another window silently re-points every window (see ENH-257's verification, where exactly this cross-session mutation caused a confusing mid-walk red herring).
+
+**Fix.** A titlebar chip next to the workspace badge / worktree chip: open-book glyph (same mark as the Vault tab) + the vault's basename, full path on hover, click activates the Vault tab (same `setActiveWorking({kind:'file', id: VAULT_TAB_ID})` dispatch as `duo goto vault`). Renders only while a default vault is set. Driven by the SAME state that gates the Vault tab — the existing `vault.getDefault` mount fetch + the BUG-214 `duo-vault-default-changed` broadcast — so it appears/re-points/disappears live across every writer (Settings, menu radio, CLI, another window) with no new IPC. `App.tsx`'s `hasDefaultVault` boolean upgraded to hold the root path (`defaultVaultRoot`), boolean derived.
+
+**CLI parity:** read-only display of state the CLI already owns (`duo vault default` reads it; `duo goto vault` is the click's twin) — no new verb needed.
+
+---
+
 ### BUG-265: Quitting one Duo instance unlinks another instance's live socket/port files
 
 **Status:** 🆕 Filed 2026-07-08 (live repro during the ENH-264 verification walk). **Priority:** P2. **Ticket note:** allocated after ENH-264 in this worktree; renumber on collision.


### PR DESCRIPTION
## Summary

The default vault is machine-global (`~/.claude/duo/vault.json`, D11) and can be re-pointed by ANY writer — Settings, the menu radio, `duo vault default` from any terminal, or another window — but nothing in the chrome shows what it currently is. This adds a titlebar chip so "where will ⇧⌘N land right now?" is glanceable.

- **New chip** in the titlebar's left group (next to the workspace badge / worktree chip): the Vault tab's open-book glyph + the vault's **basename**, full path in the hover tooltip.
- **Click** activates the Vault tab — the exact `setActiveWorking({kind:'file', id: VAULT_TAB_ID})` dispatch `duo goto vault` (ENH-257) already uses; the tab is guaranteed present whenever the chip renders (both gate on the same state).
- **Live across all writers, no new IPC:** driven by the same state that gates the Vault tab — the existing `vault.getDefault` mount fetch plus the BUG-214 `duo-vault-default-changed` broadcast — so it appears / re-points / disappears in lockstep with CLI writes, Settings, and other windows.
- `App.tsx`'s `hasDefaultVault` boolean upgraded to carry the root path (`defaultVaultRoot`); the boolean is now derived, so the ENH-228 Vault-tab reconciliation is untouched.

**CLI parity:** read-only display of state the CLI already owns (`duo vault default` reads it; `duo goto vault` is the click's twin) — no new verb.

Ledger: ENH-267 filed in `tasks.md`.

## Verification

- `npm run typecheck` clean (both configs).
- Targeted vitest green: `vaultTab`, `VaultSearchPalette`, `wikilinkResolver` (33/33).
- ⚠️ **Not visually verified** — this session runs in a remote Linux container with no macOS Electron target, so I could not run the app or screenshot the chip (CLAUDE.md §7). Before merge, a quick look at the titlebar with a default vault set / cleared (`duo vault default <path>` → chip appears; clear → chip gone; click → Vault tab activates) is owed. Theme note: the chip reuses existing titlebar palette classes (`text-zinc-600`, `border-border`, `hover:bg-accent/10` — same as the workspace badge), but per the theme-legibility rule it's worth an eyeball in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZ5Eoa9Ze3XHPoBjgQMN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkZ5Eoa9Ze3XHPoBjgQMN9)_