### PR TITLE
BUG-267: kill the project-rail focus flicker loop — adjudicate activations, not focus changes

### DIFF
--- a/docs/prd/enh-182-project-centric-ux.md
+++ b/docs/prd/enh-182-project-centric-ux.md
@@ -257,3 +257,39 @@ code areas 1–10 (see § 9) and the § 4 design assets.
 
 **10 · Context-menu pattern (for the tile right-click menu, D12)**
 - `renderer/components/FileTree.tsx` — `popupMenu()` (`:630–670`) calls `window.electron.menu.popup({ items, x, y })` (`:663`) → `handleMenuChoice()` (`:669`); template via `buildTreeMenuTemplate()` (`:853`, items like `pin`/`unpin`, multi-select aware). Also `WorkingTabStrip.tsx:149` + `Breadcrumb.tsx:24`. **The tile menu (Pin/Unpin + "Close N terminals and M tabs") follows this `MenuTemplateItem[]` → IPC popup → `chosenId` shape — do not hand-roll a menu.**
+
+---
+
+## Requirements changed — BUG-267 (2026-07-17): D11 adjudicates activations, not focus changes
+
+**Defect.** D11's effect re-ran its membership check on every `focusedProject`
+change, not just on file/browser activations. Clicking a tile of project P
+while the active working surface belonged to project Q made D11 (focus → Q)
+and the keep-visible effect (active surface → member of P) correct the same
+discrepancy in opposite directions — a non-converging P↔Q oscillation that
+re-rendered on every commit (the "rail-click flicker loop"; app unusable
+until an "All" click landed, since both effects gate on `null`). The repro
+selector "a project with working tabs but no terminals" is simply a project
+the user is not working in, guaranteeing a foreign active surface at click
+time. The browser side (Phase 3c-browser vs the FOLLOWUP-030 redirect
+machine) had the same fight through async `switchTab` IPC.
+
+**Locked amendment.** D11 (file and browser alike) switches focus only on a
+**genuine activation change** — the active file-tab id / browser-tab id
+differs from the previous adjudication — and never during the focus-entry
+settling window (`pendingBrowserRedirect !== null`) or on a programmatic
+keep-visible/redirect move (those pre-seed the adjudication refs). Decision
+logic is the pure `adjudicateActiveSurfaceFocusSwitch`
+(`shared/project-lifecycle.ts`, unit-pinned). Behavioral deltas, all
+deliberate:
+
+- Tile clicks / CLI `duo project focus` never bounce: entering focus with a
+  foreign active surface keeps the chosen focus while the keep-visible
+  effect converges (≤2 passes).
+- BUG-193-family "focus theft" via a *pinned* foreign tab on focus entry is
+  gone — the pinned tab stays visible and active, focus stays put.
+- A late membership-probe settle on an unchanged active surface no longer
+  yanks focus.
+- `duo edit` / `duo open` / user tab-clicks onto a foreign-project surface
+  still auto-switch focus (those are activation changes — the original D11
+  contract).

--- a/renderer/App.tsx
+++ b/renderer/App.tsx
@@ -57,6 +57,7 @@ import type { TabSession, DirEntry, TerminalTabKind, NewTabResult, PinEntry, Ses
 import { reorderVisible } from '@shared/reorderTabs'
 import { pruneByTab } from './state/perTabPrune'
 import {
+  adjudicateActiveSurfaceFocusSwitch,
   effectiveProjectTerminals,
   mergeLiveCwdInfo,
   planProjectClose,
@@ -1314,6 +1315,13 @@ export function App() {
       setFocusedProject(root)
     })
   }, [])
+  // ENH-182 FOLLOWUP-030 — declared HERE (used by the BUG-267 adjudicators
+  // below) but drained by the browser-redirect apply effect further down.
+  // Set to the new focus on every focus change; non-null means "focus-entry
+  // convergence in progress" — the settling window during which the
+  // keep-visible/redirect effects may programmatically move the active
+  // surface.
+  const [pendingBrowserRedirect, setPendingBrowserRedirect] = useState<string | null>(null)
   // ENH-182 Phase 3c (D11) — auto-switch focus when activeWorking
   // moves to a file whose deepest project ≠ the currently-focused
   // project. Hooking off `activeWorking` (rather than `tabMembership`
@@ -1327,14 +1335,30 @@ export function App() {
   // file activations; terminal-tab switches are intentionally not a
   // trigger (a focused user clicking a hidden terminal is a UI
   // impossibility — the strip already hides it).
+  //
+  // BUG-267 — adjudicate only a GENUINE activation change. This effect
+  // used to re-run its membership check on every focus change; combined
+  // with the keep-visible effect (E9, below) moving the active file
+  // into the new focus, the pair formed a non-converging 2-cycle
+  // (focus P ↔ Q, both non-null) — the rail-click flicker loop. The
+  // ref tracks the last-seen active file id; an unchanged surface (or
+  // one moved programmatically inside the focus-entry settling window,
+  // `pendingBrowserRedirect !== null`) never switches focus. See
+  // `adjudicateActiveSurfaceFocusSwitch` for the full gate order.
+  const lastAdjudicatedFileRef = useRef<string | null>(null)
   useEffect(() => {
-    if (focusedProject === null) return
-    if (activeWorking.kind !== 'file') return
-    const project = tabMembership[activeWorking.id]
-    if (project && project !== focusedProject) {
-      setFocusedProject(project)
-    }
-  }, [activeWorking, tabMembership, focusedProject])
+    const surfaceKey = activeWorking.kind === 'file' ? activeWorking.id : null
+    const prevSurfaceKey = lastAdjudicatedFileRef.current
+    lastAdjudicatedFileRef.current = surfaceKey
+    const target = adjudicateActiveSurfaceFocusSwitch({
+      focusTransitionPending: pendingBrowserRedirect !== null,
+      prevSurfaceKey,
+      surfaceKey,
+      focusedProject,
+      membership: surfaceKey !== null ? tabMembership[surfaceKey] : null
+    })
+    if (target !== null) setFocusedProject(target)
+  }, [activeWorking, tabMembership, focusedProject, pendingBrowserRedirect])
   // BUG-194 — release focus when the focused project vanishes. With
   // BUG-191's live-cwd tracking, `cd`-ing the focused project's last
   // terminal OUT of it drops the project from the rail; if focus stayed
@@ -1640,16 +1664,28 @@ export function App() {
   // any path under no qualifying root) do NOT trigger a switch —
   // those are reference material; the FOLLOWUP-030 effect below
   // handles their visibility separately.
+  // BUG-267 — same activation-change adjudication as the file-side D11
+  // effect above. Without the ref/pending gates this effect and the
+  // FOLLOWUP-030 redirect machine below fight through async switchTab
+  // IPC (redirect moves the active tab to a member of the new focus;
+  // this effect sees the stale foreign tab and yanks focus back) — the
+  // browser-side face of the rail-click flicker loop.
+  const lastAdjudicatedBrowserTabRef = useRef<number | null>(null)
   useEffect(() => {
-    if (focusedProject === null) return
-    if (activeWorking.kind !== 'browser') return
     const active = browserTabs.find((bt) => bt.isActive && !bt.inAux)
-    if (!active) return
-    const project = browserTabMembership.get(active.id)
-    if (project && project !== focusedProject) {
-      setFocusedProject(project)
-    }
-  }, [activeWorking, browserTabs, browserTabMembership, focusedProject])
+    const surfaceKey =
+      activeWorking.kind === 'browser' && active ? active.id : null
+    const prevSurfaceKey = lastAdjudicatedBrowserTabRef.current
+    lastAdjudicatedBrowserTabRef.current = surfaceKey
+    const target = adjudicateActiveSurfaceFocusSwitch({
+      focusTransitionPending: pendingBrowserRedirect !== null,
+      prevSurfaceKey,
+      surfaceKey,
+      focusedProject,
+      membership: surfaceKey !== null ? browserTabMembership.get(surfaceKey) : null
+    })
+    if (target !== null) setFocusedProject(target)
+  }, [activeWorking, browserTabs, browserTabMembership, focusedProject, pendingBrowserRedirect])
   // ENH-182 FOLLOWUP-030 — browser-pane active-tab redirect on focus
   // entry / focus change. The browser pane is one shared
   // WebContentsView; without this, hiding a non-member browser tab's
@@ -1690,7 +1726,8 @@ export function App() {
   // propagated from the addTab IPC, then never re-fires for that focus
   // session (ref-guard skips). A pure no-guard effect fires every
   // state change but bounces user-clicked tabs.
-  const [pendingBrowserRedirect, setPendingBrowserRedirect] = useState<string | null>(null)
+  // (BUG-267 — the `pendingBrowserRedirect` useState itself is declared
+  // earlier, above the D11 adjudicator that reads it.)
   useEffect(() => {
     setPendingBrowserRedirect(focusedProject)
   }, [focusedProject])
@@ -1739,8 +1776,17 @@ export function App() {
       (bt) => !bt.inAux && browserTabMembership.get(bt.id) === focusedProject
     )
     if (firstMember) {
+      // BUG-267 — pre-seed the adjudicator ref: this is OUR move, not a
+      // user activation; the resulting active-tab change must not
+      // re-adjudicate focus (that re-opens the flicker loop after the
+      // pending window clears in this same batch).
+      lastAdjudicatedBrowserTabRef.current = firstMember.id
       void window.electron.browser.switchTab(firstMember.id)
     } else if (visibleFileTabs.length > 0) {
+      // BUG-267 — same pre-seed, file side. visibleFileTabs[0] may be a
+      // pinned foreign-project reference tab; landing on it must not
+      // steal focus.
+      lastAdjudicatedFileRef.current = visibleFileTabs[0].id
       setActiveWorking({ kind: 'file', id: visibleFileTabs[0].id })
     }
     setPendingBrowserRedirect(null)
@@ -1825,9 +1871,19 @@ export function App() {
       activeWorking.kind === 'file' &&
       !visibleFileTabs.some((t) => t.id === activeWorking.id)
     ) {
+      // BUG-267 — these are programmatic keep-visible moves, not user
+      // activations: pre-seed the adjudicator refs so the resulting
+      // surface change never re-adjudicates focus. Without this, moving
+      // the active file into the new focus while D11 re-examined the
+      // old one formed the rail-click flicker loop (see tasks.md
+      // BUG-267); and the browser fallback landing on a foreign
+      // file:// tab would bounce focus through the redirect machine.
       if (visibleFileTabs.length > 0) {
+        lastAdjudicatedFileRef.current = visibleFileTabs[0].id
         setActiveWorking({ kind: 'file', id: visibleFileTabs[0].id })
       } else {
+        const activeBt = browserTabs.find((bt) => bt.isActive && !bt.inAux)
+        lastAdjudicatedBrowserTabRef.current = activeBt?.id ?? null
         setActiveWorking({ kind: 'browser' })
       }
     }

--- a/shared/project-lifecycle.test.ts
+++ b/shared/project-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  adjudicateActiveSurfaceFocusSwitch,
   effectiveProjectTerminals,
   mergeLiveCwdInfo,
   newTerminalMembershipsSince,
@@ -241,5 +242,92 @@ describe('planProjectClose (BUG-192 jitter-loop fix)', () => {
     expect(plan.memberTermIds).toEqual([])
     expect(plan.memberFileIds).toEqual([])
     expect(plan.needsReplacementShell).toBe(false)
+  })
+})
+
+// ── BUG-267 · adjudicateActiveSurfaceFocusSwitch ─────────────────────
+describe('adjudicateActiveSurfaceFocusSwitch (BUG-267 rail-click flicker loop)', () => {
+  const base = {
+    focusTransitionPending: false,
+    prevSurfaceKey: 'f-old' as string | number | null,
+    surfaceKey: 'f-new' as string | number | null,
+    focusedProject: '/proj/p' as string | null,
+    membership: '/proj/q' as string | null | undefined
+  }
+
+  it('switches focus when a genuinely-new surface belongs to another project (the D11 contract)', () => {
+    expect(adjudicateActiveSurfaceFocusSwitch(base)).toBe('/proj/q')
+  })
+
+  it('NEVER switches on an unchanged surface — a focus change alone must not re-adjudicate (the loop-breaker)', () => {
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({ ...base, prevSurfaceKey: 'f-new' })
+    ).toBeNull()
+  })
+
+  it('never switches while the focus-entry convergence window is open (programmatic keep-visible moves)', () => {
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({ ...base, focusTransitionPending: true })
+    ).toBeNull()
+  })
+
+  it('no-ops in All mode', () => {
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({ ...base, focusedProject: null })
+    ).toBeNull()
+  })
+
+  it('no-ops when there is no adjudicable surface', () => {
+    expect(adjudicateActiveSurfaceFocusSwitch({ ...base, surfaceKey: null })).toBeNull()
+  })
+
+  it('stays put for a member of the focused project, and for null/undefined membership', () => {
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({ ...base, membership: '/proj/p' })
+    ).toBeNull()
+    expect(adjudicateActiveSurfaceFocusSwitch({ ...base, membership: null })).toBeNull()
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({ ...base, membership: undefined })
+    ).toBeNull()
+  })
+
+  it('accepts numeric surface keys (browser-tab ids) with the same gates', () => {
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({
+        ...base,
+        prevSurfaceKey: 7,
+        surfaceKey: 7
+      })
+    ).toBeNull()
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({ ...base, prevSurfaceKey: 7, surfaceKey: 9 })
+    ).toBe('/proj/q')
+  })
+
+  it('REGRESSION: the tile-click 2-cycle never fires a switch', () => {
+    // Entry state: focused P via a tile click, active file f-q (member of
+    // Q) unchanged from the previous run. Pass 1 — D11 observes the
+    // unchanged surface: must stay quiet while E9 converges.
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({
+        focusTransitionPending: false,
+        prevSurfaceKey: 'f-q',
+        surfaceKey: 'f-q',
+        focusedProject: '/proj/p',
+        membership: '/proj/q'
+      })
+    ).toBeNull()
+    // Pass 2 — E9 moved the active file to P's member f-p (an activation
+    // change, but a member): still no switch. The pair quiesces in ≤2
+    // passes instead of flipping focus P↔Q forever.
+    expect(
+      adjudicateActiveSurfaceFocusSwitch({
+        focusTransitionPending: false,
+        prevSurfaceKey: 'f-q',
+        surfaceKey: 'f-p',
+        focusedProject: '/proj/p',
+        membership: '/proj/p'
+      })
+    ).toBeNull()
   })
 })

--- a/shared/project-lifecycle.ts
+++ b/shared/project-lifecycle.ts
@@ -164,6 +164,61 @@ export function shouldReleaseFocusForNewTerminals(
   return newTerminalMemberships.some((membership) => membership !== focusedProject)
 }
 
+/**
+ * BUG-267 — the single decision point for the two "follow the active
+ * surface" effects (ENH-182 Phase 3c file + Phase 3c-browser): should
+ * activating this surface switch focus to its project?
+ *
+ * The flicker loop this kills: D11 used to re-adjudicate the
+ * PRE-EXISTING active surface whenever `focusedProject` changed, while
+ * the keep-visible effect (E9) simultaneously moved the active surface
+ * into the new focus — two effects correcting the same discrepancy in
+ * opposite directions, a perfect 2-cycle (focus P ↔ Q) that re-fired on
+ * every commit and made the app unusable until an "All" click landed.
+ *
+ * Invariants, in gate order:
+ *   • No surface (`surfaceKey === null`) → never switch.
+ *   • Unchanged surface (`surfaceKey === prevSurfaceKey`) → never
+ *     switch. A focus change or a late membership-probe settle is NOT a
+ *     user activation; only a genuine activation change adjudicates.
+ *     This is the loop-breaker: on tile-click entry the active surface
+ *     is unchanged, so D11 stays quiet while E9 converges.
+ *   • `focusTransitionPending` → never switch. E9's own convergence
+ *     moves (switching the active file / dropping to the browser
+ *     surface) DO change the surface, and may legitimately land on a
+ *     visible-but-foreign tab (pinned reference, non-member browser
+ *     tab). Those programmatic moves happen inside the focus-entry
+ *     settling window (the pendingBrowserRedirect machine's lifetime);
+ *     adjudicating them re-opens the loop through the redirect IPC.
+ *   • All mode (`focusedProject === null`) → nothing to switch from.
+ *   • No / same-project membership → stay put.
+ *   • Otherwise → switch to the surface's project (the D11 contract:
+ *     `duo edit` / `duo open` / a user tab-click onto a foreign-project
+ *     surface follows that project).
+ */
+export function adjudicateActiveSurfaceFocusSwitch(input: {
+  /** True while the focus-entry convergence window is open (a focus
+   *  change whose redirect/keep-visible moves haven't settled). */
+  focusTransitionPending: boolean
+  /** The surface key observed on the previous effect run (file-tab id
+   *  or browser-tab id), or null when none was adjudicable. */
+  prevSurfaceKey: string | number | null
+  /** The currently-active adjudicable surface key, or null. */
+  surfaceKey: string | number | null
+  focusedProject: string | null
+  /** The active surface's project membership (root, or null/undefined
+   *  for "no project" / "not yet probed"). */
+  membership: string | null | undefined
+}): string | null {
+  const { focusTransitionPending, prevSurfaceKey, surfaceKey, focusedProject, membership } = input
+  if (surfaceKey === null) return null
+  if (surfaceKey === prevSurfaceKey) return null
+  if (focusTransitionPending) return null
+  if (focusedProject === null) return null
+  if (!membership || membership === focusedProject) return null
+  return membership
+}
+
 /** BUG-192 — the pure plan for closing every member of a project. The
  *  React handler applies this with a single, un-nested setState burst. */
 export interface ProjectClosePlan {

--- a/tasks.md
+++ b/tasks.md
@@ -2,6 +2,25 @@
 
 > **Scope.** Engineering ledger — open work + root-cause writeups for closed bugs. **Canonical version-by-version inventory lives in [CHANGELOG.md](CHANGELOG.md)** and the prose log in docs/RELEASES.md; this file is the running notebook with the "why did this break, what did we learn" detail those don't carry. \*\***Reading guide.** Status field on each entry: `🆕 Filed` / `🟡` / `⏳ Open` (active work) vs. `✅ Shipped vX.Y.Z` (closed; kept for historical reference). To find what's actively open at a glance: `grep -B1 "Status:\*\* (🆕\|🟡\|⏳)"`. \*\***Closed-work archive (ENH-191 / D1, 2026-05-31).** Closed entries (✅ shipped · ❌ won't-do · 🟢 done) now live in [tasks-archive.md](tasks-archive.md) — this file had grown to an 11k-line / 1.2 MB monolith (Duo's own editor worst-case). The cut-version skill moves newly-closed entries to the archive on each cut so this stays lean. \*\***Status legend.** OPEN (stay here): 🆕 filed · 🟡 awaiting-decision · ⏳ open · 🚧 in-progress · 🔴 blocker · ⬜ draft · ⚠️ / 🔵 see entry. CLOSED (archived): ✅ shipped · ❌ won't-do · 🟢 done.
 
+### BUG-267: Project-rail focus flicker loop — clicking a tile of a project with working tabs but no terminals oscillates focus until an "All" click lands
+
+**Status:** 🚧 In progress 2026-07-17 (branch `claude/project-focus-flicker-bug-28b83c`). **Priority:** P0 (app-unusable render loop; recurring owner report — prior sessions failed to fix). **Ticket note:** allocated after ENH-266 across all worktrees; renumber on collision.
+
+**Symptom (owner, recurring).** Click a project tile whose project has open markdown/browser tabs but NO member terminals → the whole UI enters a rapid flickering re-render loop, unusable until repeated clicks on the "All" tile happen to land mid-flicker.
+
+**Root cause — a two-effect tug-of-war, entered from a plain tile click.** Two App.tsx effects each "correct" the same discrepancy in opposite directions, forming a perfect 2-cycle that re-fires on every commit:
+
+- **D11 auto-switch** (`App.tsx` § ENH-182 Phase 3c): re-runs on *focus change* (deps include `focusedProject`), sees the still-active working file belongs to another project Q, and switches focus → Q. Its intent was "follow a file *activation*", but it re-adjudicates the pre-existing active file after every focus change.
+- **Keep-visible** (E9, `App.tsx` § auto-spawn effect): sees the active file is hidden under the new focus P and switches the active file → P's first visible member.
+
+State after one pass: (focus=Q, active file ∈ P) — the mirror of the entry state (focus=P, active file ∈ Q). Both effects re-fire; the pair flips forever. Both are gated on `focusedProject === null`, which is why only an "All" click escapes — and why BUG-192's static audit (which proved all P↔null loops convergent and focused on the close path) missed it: this is a **P↔Q loop, both non-null**. The "no terminals" repro condition is a selector, not a mechanism: a project open only as reference tabs is one the user is NOT working in, so the active surface is virtually guaranteed to belong to another project at click time. The browser side has the same fight (Phase 3c-browser vs the FOLLOWUP-030 redirect machine), laundered through async `browser.switchTab` IPC.
+
+**Fix.** Ref-guard both follow-the-active-surface effects so they adjudicate only a *genuine activation change* (active file-tab id / active browser-tab id differs from the last run), never the pre-existing active surface after a focus change or a late membership settle. Pure decision helper `adjudicateActiveSurfaceFocusSwitch` in `shared/project-lifecycle.ts` + unit tests pinning the no-bounce-on-focus-entry invariant (per the recurring-regression-needs-durable-test rule). Converges in ≤2 passes: tile click → D11 skips (unchanged surface) → E9 moves the active surface into P → D11 re-runs on that change → member → quiesce. Deliberate behavior changes: (a) BUG-193-style "focus theft" via a *pinned* foreign active file on focus entry is gone (D11 no longer re-adjudicates it); (b) a late membership-probe settle on an unchanged active file no longer yanks focus. `duo edit` / `duo open` / user tab-clicks still switch focus (those change the active surface).
+
+**Related.** BUG-192 (sibling loop, close-path, root cause never pinned — this may be the non-convergent region it force-quit into), BUG-193 (D11 focus theft, same adjudication family), ENH-204 (release-to-All on new foreign terminal — untouched), FOLLOWUP-030 (browser redirect machine — untouched, now converges).
+
+---
+
 ### BUG-265: Quitting one Duo instance unlinks another instance's live socket/port files
 
 **Status:** 🆕 Filed 2026-07-08 (live repro during the ENH-264 verification walk). **Priority:** P2. **Ticket note:** allocated after ENH-264 in this worktree; renumber on collision.

--- a/tasks.md
+++ b/tasks.md
@@ -4,7 +4,7 @@
 
 ### BUG-267: Project-rail focus flicker loop — clicking a tile of a project with working tabs but no terminals oscillates focus until an "All" click lands
 
-**Status:** 🚧 In progress 2026-07-17 (branch `claude/project-focus-flicker-bug-28b83c`). **Priority:** P0 (app-unusable render loop; recurring owner report — prior sessions failed to fix). **Ticket note:** allocated after ENH-266 across all worktrees; renumber on collision.
+**Status:** 🚧 In progress 2026-07-17 (branch `claude/project-focus-flicker-bug-28b83c`) — fix implemented + **live-verified in dev** (owner-approved app cycle): the exact repro (focus a marker project holding only a working tab, active file in another project) held focus rock-stable across 12 polls of `duo project list` with the keep-visible/auto-spawn convergence firing once; the D11 contract (`duo edit` a foreign-project file while focused → focus follows) also re-verified stable. **Priority:** P0 (app-unusable render loop; recurring owner report — prior sessions failed to fix). **Ticket note:** allocated after ENH-266 across all worktrees; renumber on collision. **Discovered in passing (separate):** terminals in a `/tmp`-rooted project split into a duplicate `/private/tmp/...` tile (live-cwd canonicalization; BUG-162 covered browser tabs only) — spun off as its own task chip; fixture-only impact today.
 
 **Symptom (owner, recurring).** Click a project tile whose project has open markdown/browser tabs but NO member terminals → the whole UI enters a rapid flickering re-render loop, unusable until repeated clicks on the "All" tile happen to land mid-flicker.
 


### PR DESCRIPTION
## What

Fixes the recurring **rail-click flicker loop**: clicking a project tile whose project has open markdown/browser tabs but no terminals sent the UI into a rapid non-converging re-render loop, unusable until an "All" click landed mid-flicker.

## Root cause

Two `App.tsx` effects corrected the same discrepancy in opposite directions, forming a perfect 2-cycle that re-fired on every commit:

- **D11 auto-switch** re-ran its membership check on every `focusedProject` change (not just on file activations), saw the still-active foreign file, and yanked focus back to its project.
- **Keep-visible (E9)** simultaneously moved the active file into the newly-focused project.

State after one pass is the mirror of the entry state, so the pair flips forever — a **P↔Q loop, both non-null**, which is why only an "All" click (both effects gate on `null`) could escape, and why BUG-192's static audit (close-path, P↔null loops) missed it. The "no terminals" repro condition is a selector, not a mechanism: a project open only as reference tabs guarantees a foreign active surface at click time. The browser side (Phase 3c-browser vs the FOLLOWUP-030 redirect machine) had the same fight through async `switchTab` IPC.

## Fix

New pure `adjudicateActiveSurfaceFocusSwitch` (`shared/project-lifecycle.ts`) gates both follow-the-active-surface effects: switch focus **only on a genuine activation change** (active file-tab / browser-tab id differs from the last adjudication), never during the focus-entry settling window (`pendingBrowserRedirect !== null`), and never on programmatic keep-visible/redirect moves (which pre-seed the adjudication refs). Converges in ≤2 passes. Deliberate behavior deltas (PRD-amended): pinned-foreign-tab "focus theft" on focus entry is gone; a late membership-probe settle no longer yanks focus; `duo edit`/`duo open`/user tab-clicks onto foreign surfaces still auto-switch (the original D11 contract).

## Verification

- 9 new unit tests pin the no-bounce-on-focus-entry invariant + the D11 contract; suite **2377/2377**, both typechecks clean.
- **Live-verified in dev** (owner-approved app cycle): exact repro — marker project holding only a working tab, active file in another project, `duo project focus` → focus rock-stable across 12 polls, keep-visible/auto-spawn converged once, no console loop errors; then `duo edit` of a foreign-project file while focused correctly switched focus and stayed stable.
- Ledger entry (tasks.md BUG-267) + dated ENH-182 PRD amendment included.
- Discovered in passing (separate chip filed): terminals in a /tmp-rooted project split into a duplicate /private/tmp tile (live-cwd canonicalization; BUG-162 covered browser tabs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)